### PR TITLE
autosetup-ssd.sh & build option

### DIFF
--- a/armbian/base/build/build.conf
+++ b/armbian/base/build/build.conf
@@ -12,3 +12,7 @@
 
 # Bitcoin network: <testnet|mainnet>
 #BASE_BITCOIN_NETWORK="testnet"
+
+# Auto-initialize SSD: <true|false> 
+# WARNING: existing data on external drive is deleted!
+#BASE_AUTOSETUP_SSD="false"

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -34,6 +34,7 @@ source /tmp/overlay/build/build-local.conf || true
 
 BASE_HOSTNAME=${BASE_HOSTNAME:-"bitbox-base"}
 BASE_BITCOIN_NETWORK=${BASE_BITCOIN_NETWORK:-"testnet"}
+BASE_AUTOSETUP_SSD=${BASE_AUTOSETUP_SSD:-"false"}
 
 if [[ ${UID} -ne 0 ]]; then
   echo "${0}: needs to be run as superuser." >&2
@@ -44,9 +45,6 @@ fi
 rm -f /root/.not_logged_in_yet
 ROOTPW=$(< /dev/urandom tr -dc A-Z-a-z-0-9 | head -c32)
 echo root:${ROOTPW} | chpasswd
-echo "================================================================================"
-echo "==> Password for user 'root' randomly set to: ${ROOTPW}"
-echo "================================================================================"
 export HOME=/root
 
 set -ex
@@ -765,6 +763,10 @@ if [ "$BASE_BITCOIN_NETWORK" == "mainnet" ]; then
   /opt/shift/scripts/set-bitcoin-network.sh mainnet
 fi
 
+if [ "$BASE_AUTOSETUP_SSD" == "true" ]; then
+  touch /opt/shift/config/.autosetup_ssd
+fi
+
 set +x
 echo
 echo "================================================================================"
@@ -773,5 +775,6 @@ echo "==========================================================================
 echo "    USER / PASSWORD: root / ${ROOTPW}"
 echo "    HOSTNAME:        ${BASE_HOSTNAME}"
 echo "    BITCOIN NETWORK: ${BASE_BITCOIN_NETWORK}"
+echo "    AUTOSETUP SSD:   ${BASE_AUTOSETUP_SSD}"
 echo "================================================================================"
 echo

--- a/armbian/base/scripts/autosetup-ssd.sh
+++ b/armbian/base/scripts/autosetup-ssd.sh
@@ -163,10 +163,10 @@ case ${ACTION} in
 
             case $DEVICE in
                 /dev/nvme*)
-                    echo "${DEVICE}p1"
+                    mkfs.ext4 -F "${DEVICE}p1"
                     ;;
                 /dev/sd*)
-                    echo "${DEVICE}1"
+                    mkfs.ext4 -F "${DEVICE}1"
                 ;;
             esac
             

--- a/armbian/base/scripts/autosetup-ssd.sh
+++ b/armbian/base/scripts/autosetup-ssd.sh
@@ -104,9 +104,9 @@ function format() {
             ;;
     esac
 
-    partprobe ${PARTITION}
+    partprobe ${DEVICE}
     sleep 10
-    mkfs.ext4 ${PARTITION}
+    mkfs.ext4 -F ${PARTITION}
 
     printf "\nDevice ${DEVICE} prepared, partition ${PARTITION} formatted:\n\n"
     lsblk

--- a/armbian/base/scripts/autosetup-ssd.sh
+++ b/armbian/base/scripts/autosetup-ssd.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+set -eu
+
+# BitBox Base: auto-setup of SSD
+#
+
+function usage() {
+    printf "\n
+BitBox Base: Auto-Setup SSD
+
+This script checks for potential storage targets and automates the setup process.
+Use with caution, data on targets will be deleted.
+
+Usage: $0 <status|apply> [device] [--force]
+
+Examples:
+* $0 status                 Get list of potential target devices in system
+* $0 apply /dev/sda         Set up specified device interactively
+* $0 apply auto             Detect device and set up interactively
+* $0 apply auto --force     WARNING! Execute only in well defined environments!
+
+"
+}
+
+function status() {
+    echo
+    printf "%-16s %-7s %16s    %-30s\n" "DEVICE" "FSTYPE" "SIZE" "OK for storage?"
+    printf "%-16s %-7s %16s   %-30s\n" "---------------" "------" "-----------------" "------------------------------"
+
+    targets_total=0
+    blockdev_target_path=""
+    while read blockdev; do
+        name=$( echo "$blockdev" | cut -f 1 -d " " )
+        type=$( echo "$blockdev" | cut -f 2 -d " " )
+        size=$( echo "$blockdev" | cut -f 4 -d " " )
+        blockdev_target=""
+
+        # check for existing filesystem
+        if [[ ${#type} -gt 0 ]]; then
+            blockdev_target="NO: has file system"
+        
+        # check if at least 200GB
+        elif [[ ${size} -lt 200000000000 ]]; then
+            blockdev_target="NO: too small (min 200GB)"
+        
+        else
+            # check for sub-partitions
+            partition_count=0
+            while read partition; do
+                name_part=$( echo "$partition" | cut -f 1 -d " " )
+                if [[ "$name_part" =~ "$name" ]] && [[ "$name_part" != "$name" ]]; then
+                    partition_count=$((partition_count+1))
+                    blockdev_target="NO: has $partition_count partition(s)"
+                fi
+            done <<< "$(lsblk -o NAME,FSTYPE,PARTTYPE,SIZE,TYPE,MAJ:MIN -abrnp -e 1,7,31,179,252)"
+
+            if [[ ${#blockdev_target} -eq 0 ]]; then
+                targets_total=$((targets_total + 1))
+                blockdev_target="OK"
+                blockdev_target_path="$name"
+            fi
+        fi
+
+        printf "%-16s %-7s %16s    %-20s\n" "$name" "$type" "$size" "$blockdev_target"
+
+    done <<< "$(lsblk -o NAME,FSTYPE,PARTTYPE,SIZE,TYPE,MAJ:MIN -abrnp -e 1,7,31,179,252 -d)"
+    printf "%-16s %-7s %16s   %-20s\n" "---------------" "------" "-----------------" "------------------------------"
+    printf "TOTAL %s potential target blockdevices found\n" "$targets_total"
+}
+
+
+ACTION=${1:-"help"}
+DEVICE=${2:-""}
+FORCE=${3:-""}
+
+if ! [[ ${ACTION} =~ ^(status|apply)$ ]]; then
+    usage
+    exit 1
+fi
+
+if [[ ${UID} -ne 0 ]]; then
+    echo "${0}: needs to be run as superuser." >&2
+    exit 1
+fi
+
+case ${ACTION} in
+    status)
+        status
+        ;;
+
+    apply)
+        if [ "$#" -lt 2 ]; then
+            usage
+            printf "Please specify a DEVICE, e.g. /dev/sda\n\n"
+            exit 1
+        fi
+        
+        status
+        doit=0
+
+        # sanity checks ------------------------------
+        # auto-detect successful?
+        if [[ "$DEVICE" == "auto" ]]; then
+            if [[ $targets_total -gt 0 ]]; then
+                if [[ $targets_total -eq 1 ]]; then 
+                    DEVICE="$blockdev_target_path"
+                    printf "Target selected due to AUTO option: $DEVICE\n"
+                else
+                    printf "More than one suitable blockdevice found.\nPlease specify device manually.\n\n"
+                    exit 1
+                fi
+            else
+                printf "No suitable blockdevice found.\n\n"
+                exit 1
+            fi                
+        fi
+        
+        # check for 2 dashes & min length
+        device_dashes=$(echo "$DEVICE" | awk -F"/" '{print NF-1}')
+        if [[ device_dashes -lt 2 ]] || [[ ${#DEVICE} -lt 8 ]]; then
+            printf "This is not a valid blockdevice: $DEVICE\n\n"
+            exit 1
+        fi
+
+        # force specified? otherwise ask
+        if [[ "$FORCE" == "--force" ]]; then
+            doit=1
+        else
+            # is device recommended for storage? works only with one recommended drive.
+            if [[ "$DEVICE" != "$blockdev_target_path" ]]; then
+                printf "\nDevice $DEVICE is not recommended for storage. Continue?\nType: YES or abort with Ctrl-C\n> "
+                read type_yes
+
+                if [[ "$type_yes" != "YES" ]]; then
+                    echo "Aborted."
+                    exit 1
+                fi
+            fi
+
+            printf "\nAre you sure you want to COMPLETELY WIPE device $DEVICE?\nContinue?\nType: YES or abort with Ctrl-C\n> "
+            read type_yes
+
+            if [[ "$type_yes" == "YES" ]]; then
+                doit=1
+            else
+                echo "Aborted."
+                exit 1
+            fi
+        fi
+
+        if [[ doit -eq 1 ]]; then
+            ### DANGER ZONE ###
+            #parted --script $DEVICE mklabel gpt
+            (
+                echo o # Create a new empty DOS partition table
+                echo n # Add a new partition
+                echo p # Primary partition
+                echo 1 # Partition number
+                echo   # First sector (Accept default: 1)
+                echo   # Last sector (Accept default: varies)
+                echo w # Write changes
+            ) | fdisk $DEVICE
+            mkfs.ext4 -F ${DEVICE}1
+            echo 
+            echo "Device $DEVICE prepared:"
+            echo 
+            lsblk /dev/sda
+            echo
+        fi
+        ;;
+
+esac

--- a/armbian/base/scripts/autosetup-ssd.sh
+++ b/armbian/base/scripts/autosetup-ssd.sh
@@ -160,11 +160,20 @@ case ${ACTION} in
                 echo   # Last sector (Accept default: varies)
                 echo w # Write changes
             ) | fdisk $DEVICE
-            mkfs.ext4 -F ${DEVICE}1
+
+            case $DEVICE in
+                /dev/nvme*)
+                    echo "${DEVICE}p1"
+                    ;;
+                /dev/sd*)
+                    echo "${DEVICE}1"
+                ;;
+            esac
+            
             echo 
             echo "Device $DEVICE prepared:"
             echo 
-            lsblk /dev/sda
+            lsblk 
             echo
         fi
         ;;

--- a/armbian/base/scripts/autosetup-ssd.sh
+++ b/armbian/base/scripts/autosetup-ssd.sh
@@ -5,34 +5,37 @@ set -eu
 #
 
 function usage() {
-    printf "\n
+    printf "
 BitBox Base: Auto-Setup SSD
 
 This script checks for potential storage targets and automates the setup process.
 Use with caution, data on targets will be deleted.
 
-Usage: $0 <status|apply> [device] [--force]
+Usage: $0 <status|format> [device] [--assume-yes]
 
 Examples:
-* $0 status                 Get list of potential target devices in system
-* $0 apply /dev/sda         Set up specified device interactively
-* $0 apply auto             Detect device and set up interactively
-* $0 apply auto --force     WARNING! Execute only in well defined environments!
+* $0 status                     Get list of potential target devices in system
+* $0 format /dev/sda            Set up specified device interactively
+* $0 format auto                Detect device and set up interactively
+* $0 format auto --assume-yes   WARNING! Execute only in well defined environments!
 
 "
 }
 
-function status() {
+function list_targets() {
     echo
     printf "%-16s %-7s %16s    %-30s\n" "DEVICE" "FSTYPE" "SIZE" "OK for storage?"
     printf "%-16s %-7s %16s   %-30s\n" "---------------" "------" "-----------------" "------------------------------"
 
+    device_found=0
     targets_total=0
     blockdev_target_path=""
+
+    # loop over all top-level block devices
     while read blockdev; do
-        name=$( echo "$blockdev" | cut -f 1 -d " " )
-        type=$( echo "$blockdev" | cut -f 2 -d " " )
-        size=$( echo "$blockdev" | cut -f 4 -d " " )
+        name=$( echo "${blockdev}" | cut -f 1 -d " " )
+        type=$( echo "${blockdev}" | cut -f 2 -d " " )
+        size=$( echo "${blockdev}" | cut -f 4 -d " " )
         blockdev_target=""
 
         # check for existing filesystem
@@ -42,38 +45,76 @@ function status() {
         # check if at least 200GB
         elif [[ ${size} -lt 200000000000 ]]; then
             blockdev_target="NO: too small (min 200GB)"
-        
+
         else
-            # check for sub-partitions
+            # check top-level device for partitions
             partition_count=0
             while read partition; do
-                name_part=$( echo "$partition" | cut -f 1 -d " " )
-                if [[ "$name_part" =~ "$name" ]] && [[ "$name_part" != "$name" ]]; then
+                name_part=$( echo "${partition}" | cut -f 1 -d " " )
+                if [[ "${name_part}" =~ "${name}" ]] && [[ "${name_part}" != "${name}" ]]; then
                     partition_count=$((partition_count+1))
-                    blockdev_target="NO: has $partition_count partition(s)"
+                    blockdev_target="NO: has ${partition_count} partition(s)"
                 fi
             done <<< "$(lsblk -o NAME,FSTYPE,PARTTYPE,SIZE,TYPE,MAJ:MIN -abrnp -e 1,7,31,179,252)"
 
             if [[ ${#blockdev_target} -eq 0 ]]; then
                 targets_total=$((targets_total + 1))
                 blockdev_target="OK"
-                blockdev_target_path="$name"
+                blockdev_target_path="${name}"
             fi
+
+            # check if specified device is found
+            if [[ "${name}" == "${DEVICE}" ]]; then 
+                device_found=1
+            fi
+
         fi
 
-        printf "%-16s %-7s %16s    %-20s\n" "$name" "$type" "$size" "$blockdev_target"
+        printf "%-16s %-7s %16s    %-20s\n" "${name}" "${type}" "${size}" "${blockdev_target}"
 
+    # `lsblk` returns only top-level devices (-d) and excludes device-types by major number
+    # (see http://www.lanana.org/docs/device-list/devices-2.6+.txt)
     done <<< "$(lsblk -o NAME,FSTYPE,PARTTYPE,SIZE,TYPE,MAJ:MIN -abrnp -e 1,7,31,179,252 -d)"
+    
     printf "%-16s %-7s %16s   %-20s\n" "---------------" "------" "-----------------" "------------------------------"
-    printf "TOTAL %s potential target blockdevices found\n" "$targets_total"
+    printf "TOTAL %s potential target blockdevices found\n\n" "${targets_total}"
 }
 
 
-ACTION=${1:-"help"}
-DEVICE=${2:-""}
-FORCE=${3:-""}
+function format() {
+    ### DANGER ZONE ###
+    (
+        echo o # Create a new empty DOS partition table
+        echo n # Add a new partition
+        echo p # Primary partition
+        echo 1 # Partition number
+        echo   # First sector (Accept default: 1)
+        echo   # Last sector (Accept default: varies)
+        echo w # Write changes
+    ) | fdisk ${DEVICE}
 
-if ! [[ ${ACTION} =~ ^(status|apply)$ ]]; then
+    case ${DEVICE} in
+        # internal drive (e.g. PCIe)
+        /dev/nvme*)
+            mkfs.ext4 -F "${DEVICE}p1"
+            ;;
+        # external drive (e.g. USB)
+        /dev/sd*)
+            mkfs.ext4 -F "${DEVICE}1"
+            ;;
+    esac
+    
+    printf "\nDevice ${DEVICE} prepared:\n\n"
+    lsblk 
+    echo
+}
+
+
+ACTION=${1:-""}
+DEVICE=${2:-""}
+ASSUMEYES=${3:-""}
+
+if ! [[ "${ACTION}" =~ ^(status|format)$ ]]; then
     usage
     exit 1
 fi
@@ -85,26 +126,33 @@ fi
 
 case ${ACTION} in
     status)
-        status
+        list_targets
         ;;
 
-    apply)
-        if [ "$#" -lt 2 ]; then
+    format)
+        if [ "${#}" -lt 2 ]; then
             usage
             printf "Please specify a DEVICE, e.g. /dev/sda\n\n"
             exit 1
         fi
         
-        status
-        doit=0
+        format_target=0        
+
+        # print and check for potential targets)
+        list_targets
+
+        if [[ "${device_found}" -eq 0 ]] && [[ "${DEVICE}" != "auto" ]]; then
+            printf "Specified DEVICE '${DEVICE}' not found as potential target.\n\n"
+            exit 1
+        fi
 
         # sanity checks ------------------------------
         # auto-detect successful?
-        if [[ "$DEVICE" == "auto" ]]; then
-            if [[ $targets_total -gt 0 ]]; then
-                if [[ $targets_total -eq 1 ]]; then 
-                    DEVICE="$blockdev_target_path"
-                    printf "Target selected due to AUTO option: $DEVICE\n"
+        if [[ "${DEVICE}" == "auto" ]]; then
+            if [[ ${targets_total} -gt 0 ]]; then
+                if [[ ${targets_total} -eq 1 ]]; then 
+                    DEVICE="${blockdev_target_path}"
+                    printf "Target selected due to AUTO option: ${DEVICE}\n"
                 else
                     printf "More than one suitable blockdevice found.\nPlease specify device manually.\n\n"
                     exit 1
@@ -115,66 +163,42 @@ case ${ACTION} in
             fi                
         fi
         
-        # check for 2 dashes & min length
-        device_dashes=$(echo "$DEVICE" | awk -F"/" '{print NF-1}')
+        # check for 2 slashes & min length
+        device_dashes=$(echo "${DEVICE}" | awk -F"/" '{print NF-1}')
         if [[ device_dashes -lt 2 ]] || [[ ${#DEVICE} -lt 8 ]]; then
-            printf "This is not a valid blockdevice: $DEVICE\n\n"
+            printf "This is not a valid blockdevice: ${DEVICE}\n\n"
             exit 1
         fi
 
-        # force specified? otherwise ask
-        if [[ "$FORCE" == "--force" ]]; then
-            doit=1
+        # assume-yes specified? otherwise ask
+        if [[ "${ASSUMEYES}" == "--assume-yes" ]]; then
+            format_target=1
         else
             # is device recommended for storage? works only with one recommended drive.
-            if [[ "$DEVICE" != "$blockdev_target_path" ]]; then
-                printf "\nDevice $DEVICE is not recommended for storage. Continue?\nType: YES or abort with Ctrl-C\n> "
-                read type_yes
+            if [[ "${DEVICE}" != "${blockdev_target_path}" ]]; then
+                printf "\nDevice ${DEVICE} is not recommended for storage. Continue?\nType: YES or abort with Ctrl-C\n> "
+                read ask_confirmation
 
-                if [[ "$type_yes" != "YES" ]]; then
+                if [[ "${ask_confirmation}" != "YES" ]]; then
                     echo "Aborted."
                     exit 1
                 fi
             fi
 
-            printf "\nAre you sure you want to COMPLETELY WIPE device $DEVICE?\nContinue?\nType: YES or abort with Ctrl-C\n> "
-            read type_yes
+            printf "\nAre you sure you want to COMPLETELY WIPE device ${DEVICE}?\nContinue?\nType: YES or abort with Ctrl-C\n> "
+            read ask_confirmation
 
-            if [[ "$type_yes" == "YES" ]]; then
-                doit=1
+            if [[ "${ask_confirmation}" == "YES" ]]; then
+                format_target=1
             else
                 echo "Aborted."
                 exit 1
             fi
         fi
 
-        if [[ doit -eq 1 ]]; then
-            ### DANGER ZONE ###
-            #parted --script $DEVICE mklabel gpt
-            (
-                echo o # Create a new empty DOS partition table
-                echo n # Add a new partition
-                echo p # Primary partition
-                echo 1 # Partition number
-                echo   # First sector (Accept default: 1)
-                echo   # Last sector (Accept default: varies)
-                echo w # Write changes
-            ) | fdisk $DEVICE
-
-            case $DEVICE in
-                /dev/nvme*)
-                    mkfs.ext4 -F "${DEVICE}p1"
-                    ;;
-                /dev/sd*)
-                    mkfs.ext4 -F "${DEVICE}1"
-                ;;
-            esac
-            
-            echo 
-            echo "Device $DEVICE prepared:"
-            echo 
-            lsblk 
-            echo
+        # partition and format target
+        if [[ ${format_target} -eq 1 ]]; then
+            format
         fi
         ;;
 

--- a/armbian/base/scripts/autosetup-ssd.sh
+++ b/armbian/base/scripts/autosetup-ssd.sh
@@ -105,6 +105,7 @@ function format() {
     esac
 
     partprobe ${PARTITION}
+    sleep 10
     mkfs.ext4 ${PARTITION}
 
     printf "\nDevice ${DEVICE} prepared, partition ${PARTITION} formatted:\n\n"

--- a/armbian/base/scripts/startup-checks.sh
+++ b/armbian/base/scripts/startup-checks.sh
@@ -14,7 +14,7 @@ if ! grep -q '/mnt/ssd' /etc/fstab ; then
 
   # image configured for autosetup of SSD?
   if ! mountpoint /mnt/ssd -q && [ -f /opt/shift/config/.autosetup_ssd ]; then
-    /opt/shift/scripts/autosetup-ssd.sh apply auto --force
+    /opt/shift/scripts/autosetup-ssd.sh format auto --assume-yes
     if [ $? -eq 0 ]; then
       rm /opt/shift/config/.autosetup_ssd
     fi

--- a/armbian/base/scripts/startup-checks.sh
+++ b/armbian/base/scripts/startup-checks.sh
@@ -11,6 +11,15 @@ echo "255" > /sys/class/hwmon/hwmon0/pwm1
 
 # check if SSD mount is configured in /etc/fstab
 if ! grep -q '/mnt/ssd' /etc/fstab ; then
+
+  # image configured for autosetup of SSD?
+  if ! mountpoint /mnt/ssd -q && [ -f /opt/shift/config/.autosetup_ssd ]; then
+    /opt/shift/scripts/autosetup-ssd.sh apply auto --force
+    if [ $? -eq 0 ]; then
+      rm /opt/shift/config/.autosetup_ssd
+    fi
+  fi
+
   if lsblk | grep -q 'nvme0n1p1'; then
     echo "/dev/nvme0n1p1 /mnt/ssd ext4 rw,nosuid,dev,noexec,noatime,nodiratime,auto,nouser,async,nofail 0 2" >> /etc/fstab
   elif lsblk | grep -q 'sda1'; then


### PR DESCRIPTION
The bash script `storage-setup.sh` detects possible targets and can set them automatically (interactive or without prompt):

```
BitBox Base: Auto-Setup SSD

This script checks for potential storage targets and automates the setup process.
Use with caution, data on targets will be deleted.

Usage: ./storage-setup.sh <status|apply> [device] [--force]

Examples:
* ./storage-setup.sh status                 Get list of potential target devices in system
* ./storage-setup.sh apply /dev/sda         Set up specified device interactively
* ./storage-setup.sh apply auto             Detect device and set up interactively
* ./storage-setup.sh apply auto --force     WARNING! Execute only in well defined environments!
```

When building the image, the following can be specified:
* in `armbian/base/build/build.conf`: `BASE_AUTOSETUP_SSD="true"`
* during build, the file `/opt/shift/config/.autosetup_ssd` is created
* among other checks, if this file is present on system boot, the script `/opt/shift/scripts/storage-setup.sh` is executed
* on success, the file `.autosetup_ssd` is deleted

This feature is still somewhat experimental and not enabled by default. If it works reliably, the image boots successfully into a brand-new factory ssd with all services up-and-running on first boot. 