### PR TITLE
avahi-daemon: publish-workstation=yes

### DIFF
--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -700,6 +700,8 @@ Cache=yes
 EOF
 
 # mDNS services
+sed -i '/PUBLISH-WORKSTATION/Ic\publish-workstation=yes' /etc/avahi/avahi-daemon.conf
+
 cat << EOF > /etc/avahi/services/bitcoind.service
 <?xml version="1.0" standalone='no'?>
 <!DOCTYPE service-group SYSTEM "avahi-service.dtd">


### PR DESCRIPTION
Configure the `avahi-daemon` to publish the hostname within the local network and make the device reachable, e.g. under `bitbox-base.local`