### PR TITLE
must-mount-ssd

### DIFF
--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -93,8 +93,10 @@ adduser --system --group --disabled-login --no-create-home              promethe
 adduser --system --group --disabled-login --no-create-home              node_exporter
 
 # remove bitcoin user home on rootfs (must be on SSD)
+# also revoke direct write access for service users to local directory
 if ! mountpoint /mnt/ssd -q; then 
   rm -rf /mnt/ssd/bitcoin/
+  chmod 700 /mnt/ssd
 fi
 
 apt remove -y ntp network-manager


### PR DESCRIPTION
Prevent the services to fill up the internal eMMC / sdcard when SSD is not mounted