### PR TITLE
set middleware config with config file

### DIFF
--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -433,17 +433,24 @@ cd base-middleware
 make native
 cp base-middleware /usr/local/sbin/
 
+mkdir -p /etc/base-middleware/
+cat << EOF > /etc/base-middleware/base-middleware.conf
+BITCOIN_RPCUSER=__cookie__
+BITCOIN_RPCPORT=18332
+LIGHTNING_RPCPATH=/mnt/ssd/bitcoin/.lightning-testnet/lightning-rpc
+EOF
+
 cat << 'EOF' > /etc/systemd/system/base-middleware.service
 [Unit]
 Description=BitBox Base Middleware
-Requires=bitcoind.service
-Requires=lightningd.service
-Requires=electrs.service
+Wants=bitcoind.service lightningd.service electrs.service
 After=lightningd.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/sbin/base-middleware -rpcuser=__cookie__ -rpcpassword=${RPCPASSWORD} -rpcport=18332 -lightning-rpc-path=/mnt/ssd/bitcoin/.lightning-testnet/lightning-rpc
+EnvironmentFile=/etc/base-middleware/base-middleware.conf
+EnvironmentFile=/mnt/ssd/bitcoin/.bitcoin/.cookie.env
+ExecStart=/usr/local/sbin/base-middleware -rpcuser=${BITCOIN_RPCUSER} -rpcpassword=${RPCPASSWORD} -rpcport=${BITCOIN_RPCPORT} -lightning-rpc-path=${LIGHTNING_RPCPATH}
 Restart=always
 RestartSec=10
 

--- a/armbian/base/scripts/set-bitcoin-network.sh
+++ b/armbian/base/scripts/set-bitcoin-network.sh
@@ -32,6 +32,8 @@ if [ "$NETWORK" == "mainnet" ]; then
     sed -i '/LIGHTNING-DIR=/Ic\lightning-dir=/mnt/ssd/bitcoin/.lightning' /etc/lightningd/lightningd.conf
     sed -i '/NETWORK=/Ic\NETWORK=mainnet' /etc/electrs/electrs.conf
     sed -i '/RPCPORT=/Ic\RPCPORT=8332' /etc/electrs/electrs.conf
+    sed -i '/BITCOIN_RPCPORT=/Ic\BITCOIN_RPCPORT=8332' /etc/base-middleware/base-middleware.conf
+    sed -i '/LIGHTNING_RPCPATH=/Ic\LIGHTNING_RPCPATH=/mnt/ssd/bitcoin/.lightning/lightning-rpc' /etc/base-middleware/base-middleware.conf
     sed -i '/<PORT>18333/Ic\<port>8333</port>' /etc/avahi/services/bitcoind.service
 else
     sed -i '/CONFIGURED FOR/Ic\echo "Configured for Bitcoin TESTNET"; echo' /etc/update-motd.d/20-shift
@@ -44,6 +46,8 @@ else
     sed -i '/BITCOIN-RPCPORT=/Ic\bitcoin-rpcport=18332' /etc/lightningd/lightningd.conf
     sed -i '/NETWORK=/Ic\NETWORK=testnet' /etc/electrs/electrs.conf
     sed -i '/RPCPORT=/Ic\RPCPORT=18332' /etc/electrs/electrs.conf
+    sed -i '/BITCOIN_RPCPORT=/Ic\BITCOIN_RPCPORT=18332' /etc/base-middleware/base-middleware.conf
+    sed -i '/LIGHTNING_RPCPATH=/Ic\LIGHTNING_RPCPATH=/mnt/ssd/bitcoin/.lightning-testnet/lightning-rpc' /etc/base-middleware/base-middleware.conf
     sed -i '/<PORT>8333/Ic\<port>18333</port>' /etc/avahi/services/bitcoind.service
 fi
 source /root/.bashrc-custom


### PR DESCRIPTION
* configure middleware with configuration file (using environment variables)
* use `Wants=` instead of `Requires` in systemd to start the service in any case
* adjust `base-middleware.conf` when switching Bitcoin networks