### PR TITLE
Freeze Armbian & additional build options

### DIFF
--- a/armbian/base/build/build.conf
+++ b/armbian/base/build/build.conf
@@ -15,3 +15,7 @@
 
 # Manual root password (very unsafe, for DEVELOPMENT ONLY!)
 #BASE_ROOTPW="development"
+
+# Wifi settings (optional)
+#BASE_WIFI_SSID=""
+#BASE_WIFI_PASS=""

--- a/armbian/base/build/build.conf
+++ b/armbian/base/build/build.conf
@@ -12,3 +12,6 @@
 
 # Bitcoin network: <testnet|mainnet>
 #BASE_BITCOIN_NETWORK="testnet"
+
+# Manual root password (very unsafe, for DEVELOPMENT ONLY!)
+#BASE_ROOTPW="development"

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -40,12 +40,14 @@ if [[ ${UID} -ne 0 ]]; then
   exit 1
 fi
 
-# Disable Armbian script on first boot, configure root
+# Disable Armbian script on first boot
 rm -f /root/.not_logged_in_yet
-ROOTPW=$(< /dev/urandom tr -dc A-Z-a-z-0-9 | head -c32)
-echo root:${ROOTPW} | chpasswd
+
+# Set root password (either from configuration or random)
+BASE_ROOTPW=${BASE_ROOTPW:-$(< /dev/urandom tr -dc A-Z-a-z-0-9 | head -c32)}
+echo root:${BASE_ROOTPW} | chpasswd
 echo "================================================================================"
-echo "==> Password for user 'root' randomly set to: ${ROOTPW}"
+echo "==> Password for user 'root' set to: ${BASE_ROOTPW}"
 echo "================================================================================"
 export HOME=/root
 
@@ -780,7 +782,7 @@ echo
 echo "================================================================================"
 echo "==> Armbian build process finished. Login using SSH Keys or root password."
 echo "================================================================================"
-echo "    USER / PASSWORD: root / ${ROOTPW}"
+echo "    USER / PASSWORD: root / ${BASE_ROOTPW}"
 echo "    HOSTNAME:        ${BASE_HOSTNAME}"
 echo "    BITCOIN NETWORK: ${BASE_BITCOIN_NETWORK}"
 echo "================================================================================"

--- a/armbian/build.sh
+++ b/armbian/build.sh
@@ -63,9 +63,9 @@ case ${ACTION} in
 		cp -a  ../base/build/customize-image.sh userpatches/	# copy customize script to standard Armbian build hook
 
 		if [ "${ACTION}" == "build" ]; then
-			vagrant ssh -c 'cd armbian/ && sudo time ./compile.sh BOARD=rockpro64 KERNEL_ONLY=no KERNEL_CONFIGURE=no RELEASE=stretch BRANCH=default BUILD_DESKTOP=no WIREGUARD=no PROGRESS_LOG_TO_FILE=yes'
+			vagrant ssh -c 'cd armbian/ && sudo time ./compile.sh BOARD=rockpro64 KERNEL_ONLY=no KERNEL_CONFIGURE=no RELEASE=stretch BRANCH=default BUILD_DESKTOP=no WIREGUARD=no PROGRESS_LOG_TO_FILE=yes LIB_TAG=sunxi-4.20'
 		else
-			vagrant ssh -c 'cd armbian/ && sudo time ./compile.sh BOARD=rockpro64 KERNEL_ONLY=no KERNEL_CONFIGURE=no RELEASE=stretch BRANCH=default BUILD_DESKTOP=no WIREGUARD=no CLEAN_LEVEL="oldcache" PROGRESS_LOG_TO_FILE=yes'
+			vagrant ssh -c 'cd armbian/ && sudo time ./compile.sh BOARD=rockpro64 KERNEL_ONLY=no KERNEL_CONFIGURE=no RELEASE=stretch BRANCH=default BUILD_DESKTOP=no WIREGUARD=no CLEAN_LEVEL="oldcache" PROGRESS_LOG_TO_FILE=yes LIB_TAG=sunxi-4.20'
 		fi
 
 		sha256sum output/images/Armbian_*.img


### PR DESCRIPTION
Various minor fixes and features adds
* freeze Armbian at latest stable release (sunxi-4.20)
* build option to manually set root password (development only)
* build option to configure default wifi network (needs additional hardware module)
* display build options (dedicated script function)