### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Declare files that will always have CRLF line endings on checkout.
+*.sh text eol=lf
+*.py text eol=lf
+*.service text eol=lf
+Makefile text eol=lf


### PR DESCRIPTION
This makes sure Windows does not mess up add during checkout, this would make the scripts fail.