### PR TITLE
Minor improvements / fixes

### DIFF
--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -464,6 +464,7 @@ NETWORK=testnet
 RPCCONNECT=127.0.0.1
 RPCPORT=18332
 DB_DIR=/mnt/ssd/electrs/db
+DAEMON_DIR=/mnt/ssd/bitcoin/.bitcoin
 VERBOSITY=vvvv
 RUST_BACKTRACE=1
 EOF
@@ -477,7 +478,7 @@ After=bitcoind.service
 EnvironmentFile=/etc/electrs/electrs.conf
 EnvironmentFile=/mnt/ssd/bitcoin/.bitcoin/.cookie.env
 ExecStartPre=/bin/systemctl is-active bitcoind.service
-ExecStart=/bin/bash -c "electrs --network ${NETWORK} -${VERBOSITY} --index-batch-size=10 --jsonrpc-import --db-dir ${DB_DIR} --daemon-rpc-addr ${RPCCONNECT}:${RPCPORT} --cookie __cookie__:${RPCPASSWORD}"
+ExecStart=/usr/bin/electrs --network ${NETWORK} -${VERBOSITY} --db-dir ${DB_DIR} --daemon-dir ${DAEMON_DIR} --cookie "__cookie__:${RPCPASSWORD}"
 RuntimeDirectory=electrs
 User=electrs
 Group=bitcoin

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -180,10 +180,10 @@ apt install -y  autoconf automake build-essential git libtool libgmp-dev \
 # build electrs
 # apt install -y  clang cmake
 
-# networking
-apt install -y  openssl tor net-tools fio fail2ban \
-                avahi-daemon avahi-discover libnss-mdns \
-                avahi-utils
+# system
+apt install -y  openssl tor net-tools fio libnss-mdns \
+                avahi-daemon avahi-discover avahi-utils \
+                fail2ban acl
 
 
 # STARTUP CHECKS ---------------------------------------------------------------

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -183,7 +183,7 @@ apt install -y  autoconf automake build-essential git libtool libgmp-dev \
 # system
 apt install -y  openssl tor net-tools fio libnss-mdns \
                 avahi-daemon avahi-discover avahi-utils \
-                fail2ban acl
+                fail2ban acl ifmetric
 
 
 # STARTUP CHECKS ---------------------------------------------------------------
@@ -861,8 +861,8 @@ EOF
 
 # include Wifi credentials, if specified
 if [[ -n "${BASE_WIFI_SSID}" ]]; then
-  sed -i '/WPA-SSID/Ic\  wpa-ssid ${BASE_WIFI_SSID}' /opt/shift/config/wifi/wlan0.conf
-  sed -i '/WPA-PSK/Ic\  wpa-psk ${BASE_WIFI_PW}' /opt/shift/config/wifi/wlan0.conf
+  sed -i "/WPA-SSID/Ic\  wpa-ssid ${BASE_WIFI_SSID}" /opt/shift/config/wifi/wlan0.conf
+  sed -i "/WPA-PSK/Ic\  wpa-psk ${BASE_WIFI_PW}" /opt/shift/config/wifi/wlan0.conf
   cp /opt/shift/config/wifi/wlan0.conf /etc/network/interfaces.d/
   echo "WIFI=1" > ${SYSCONFIG_PATH}/WIFI
 fi

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -37,6 +37,9 @@ if [[ ${#} -eq 0 ]] || [[ "${1}" == "-h" ]] || [[ "${1}" == "--help" ]]; then
 elif [[ "${1}" == "-v" ]] || [[ "${1}" == "--version" ]]; then
   echo "bbb-config version 0.1"
   exit 0
+elif [[ ${#} -eq 1 ]]; then
+  usage
+  exit 0
 fi
 
 if [[ ${UID} -ne 0 ]]; then
@@ -119,7 +122,7 @@ case "${COMMAND}" in
         ;;
 
     set)
-        if [[ -z ${3} ]]; then
+        if [[ ${#} -lt 3 ]]; then
             echo "Missing argument: command 'set' needs two arguments."
             exit 1
         fi

--- a/armbian/base/scripts/startup-checks.sh
+++ b/armbian/base/scripts/startup-checks.sh
@@ -8,6 +8,9 @@ if [ ! -f /etc/ssl/private/nginx-selfsigned.key ]; then
   openssl req -x509 -nodes -newkey rsa:2048 -keyout /etc/ssl/private/nginx-selfsigned.key -out /etc/ssl/certs/nginx-selfsigned.crt -subj "/CN=localhost"
 fi
 
+# make sure wired interface eth0 is used if present (set metric to 10, wifi will have > 1000)
+ifmetric eth0 10
+
 timedatectl set-ntp true
 echo "180" > /sys/class/hwmon/hwmon0/pwm1
 

--- a/armbian/base/scripts/startup-checks.sh
+++ b/armbian/base/scripts/startup-checks.sh
@@ -51,11 +51,14 @@ if ! mountpoint /mnt/ssd -q; then
 fi
 
 # create missing directories & always set correct owner
+# access control lists (setfacl) are used to control permissions of newly created files 
 chown bitcoin:system /mnt/ssd 
 mkdir -p /mnt/ssd/bitcoin/
 chown -R bitcoin:bitcoin /mnt/ssd/bitcoin/
+setfacl -d -m o::- /mnt/ssd/bitcoin/.bitcoin/
 mkdir -p /mnt/ssd/electrs/
 chown -R electrs:bitcoin /mnt/ssd/electrs/
+setfacl -d -m o::- /mnt/ssd/bitcoin/.bitcoin/
 mkdir -p /mnt/ssd/prometheus
 chown -R prometheus:system /mnt/ssd/prometheus/
 mkdir -p /mnt/ssd/system/journal/


### PR DESCRIPTION
* install `acl` (access control lists) to secure `/mnt/ssd/bitcoin/.bitcoin/.cookie` file to be created using `sysperms=1` and no world permissions (secured from users like "hdmi" outside group "bitcoin")
* electr: load blockchain data directly from the bitcoind directory (not via json-rpc)
* fix unbound variables in `bbb-config.sh`