### PR TITLE
Add Travis CI with Dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+dist: trusty
+
+sudo: true
+
+services:
+  - docker
+
+os:
+  - linux
+
+addons:
+  apt:
+    packages:
+      - make
+
+script:
+    - ./scripts/travis-ci.sh
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    clang \
+    gcc \
+    libc6-dev \
+    make \
+    curl \
+    ca-certificates \
+    git
+
+RUN mkdir -p /opt/go_dist &&\
+    curl -O https://dl.google.com/go/go1.12.5.linux-amd64.tar.gz &&\
+    echo "aea86e3c73495f205929cfebba0d63f1382c8ac59be081b6351681415f4063cf go1.12.5.linux-amd64.tar.gz" | sha256sum -c &&\
+    tar -xz go1.11.linux-amd64.tar.gz -C /opt/go_dist
+
+ENV GOPATH /opt/go
+ENV GOROOT /opt/go_dist/go
+ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH
+
+ADD middleware/Makefile /tmp/
+ADD middleware/scripts/go-get.sh /tmp/scripts/
+RUN make -C  /tmp/ envinit
+

--- a/middleware/.golangci.yml
+++ b/middleware/.golangci.yml
@@ -1,0 +1,108 @@
+# This file contains all available configuration options
+# with their default values.
+
+# options for analysis running
+run:
+  # default concurrency is a available CPU number
+  concurrency: 4
+
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  deadline: 10m
+
+  # exit code when at least one issue was found, default is 1
+  issues-exit-code: 1
+
+  # include test files or not, default is true
+  tests: true
+
+# output configuration options
+output:
+  # colored-line-number|line-number|json|tab|checkstyle, default is "colored-line-number"
+  format: colored-line-number
+
+  # print lines of code with issue, default is true
+  print-issued-lines: true
+
+  # print linter name in the end of issue text, default is true
+  print-linter-name: true
+
+
+# all available settings of specific linters
+linters-settings:
+  gocritic:
+    enabled-checks:
+      - assignOp
+      - builtinShadow
+      - caseOrder
+      - captLocal
+      - dupArg
+      - dupBranchBody
+      - dupCase
+      - elseif
+      - flagDeref
+      - ifElseChain
+      - nilValReturn
+      - rangeExprCopy
+      - rangeValCopy
+      - regexpMust
+      - sloppyLen
+      - switchTrue
+      - typeSwitchVar
+      - typeUnparen
+      - underef
+      - unlambda
+      - unslice
+      - defaultCaseOrder
+  gocyclo:
+    min-complexity: 25
+  maligned:
+    # print struct with more effective memory layout or not, false by default
+    suggest-new: true
+  dupl:
+    # tokens count to trigger issue, 150 by default
+    threshold: 150
+  goconst:
+    # minimal length of string constant, 3 by default
+    min-len: 3
+    # minimal occurrences count to trigger, 3 by default
+    min-occurrences: 3
+  misspell:
+    # Correct spellings using locale preferences for US or UK.
+    # Default is to use a neutral variety of English.
+    # Setting locale to US will correct the British spelling of 'colour' to 'color'.
+    locale: US
+  lll:
+    # max line length, lines longer will be reported. Default is 120.
+    # '\t' is counted as 1 character by default, and can be changed with the tab-width option
+    line-length: 120
+    # allow long comments.
+    exclude: '//'
+    # tab width in spaces. Default to 1.
+    tab-width: 4
+
+
+linters:
+  enable-all: true
+  disable:
+    - maligned
+    - prealloc
+    - lll
+    - gochecknoinits
+    #- gochecknoglobals
+  disable-all: false
+
+issues:
+  # List of regexps of issue texts to exclude, empty list by default.
+  # But independently from this option we use default exclude patterns,
+  # it can be disabled by `exclude-use-default: false`. To list all
+  # excluded by default patterns execute `golangci-lint run --help`
+  exclude:
+    # TLS `InsecureSkipVerify` set true. (gas)
+    - G402
+    # Potential hardcoded credentials (gas)
+    - G101
+    # gas: Duplicated errcheck checks
+    - G104
+  # Use linters in their original configuration. golangci-linter changes the default config, for
+  # example skipping the docstring comment checks of golint.
+exclude-use-default: false

--- a/middleware/Makefile
+++ b/middleware/Makefile
@@ -9,7 +9,7 @@ ci:
 envinit:
 	# TODO(hkjn): Make this rule more robust, or remove it if there's no clear
 	# need for it.
-	./scripts/go-get.sh v1.15.0 github.com/golangci/golangci-lint/cmd/golangci-lint
+	./scripts/go-get.sh v1.16.0 github.com/golangci/golangci-lint/cmd/golangci-lint
 	go get -u github.com/golang/dep/cmd/dep
 native: check-env
 	go build -o $(REPO_ROOT)/build/base-middleware ./src/

--- a/middleware/scripts/ci.sh
+++ b/middleware/scripts/ci.sh
@@ -14,5 +14,4 @@
 # limitations under the License.
 
 # This script has to be called from the project root directory.
-cd src
 golangci-lint run

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -1,0 +1,7 @@
+docker build --tag=digitalbitbox/bitbox-base .
+docker run -v ${TRAVIS_BUILD_DIR}:/opt/go/src/github.com/digitalbitbox/bitbox-base/ \
+        -i digitalbitbox/bitbox-base \
+        bash -c "make -C \$GOPATH/src/github.com/digitalbitbox/bitbox-base/middleware ci" \
+        bash -c "make -C \$GOPATH/src/github.com/digitalbitbox/bitbox-base/middleware native" \
+        bash -c "make -C \$GOPATH/src/github.com/digitalbitbox/bitbox-base/tools/bbbfancontrol"
+


### PR DESCRIPTION
Travis CI now runs builds of the middleware and the bbbfancontrol. The travis job runs in its own docker container and runs golangci-lint according the specs defined in middleware/.golangci.yml .

I split the actual docker run into a separate file. When I ran the same lines directly from the script part of the travis.yml , the travis build would fail with the error: "docker: invalid reference format". Tips on how to fix this are welcome. 

The travis build will initially fail until the middleware sticks to the golangci style.