### PR TITLE
WIP: Add 'make docker-jekyll' rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ armbian/base/build/build-local.conf
 tools/bbbfancontrol/bbbfancontrol
 *.sw?
 build/
+_site/
+.jekyll-metadata

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+DOCKER := $(shell which docker 2> /dev/null)
+
 default:
 	mkdir -p build
 	echo "Building tools.."
@@ -6,6 +8,14 @@ default:
 	$(MAKE) -C middleware
 	echo "Building armbian.."
 	$(MAKE) -C armbian
+
+docker-jekyll:
+ifndef DOCKER
+	$(error "This rule requires Docker to run jekyll.")
+endif
+	@echo "Starting docker-jekyll server at localhost:4000.."
+	docker run --rm -it -p 4000:4000 -v $(shell pwd):/srv/jekyll \
+	       jekyll/jekyll:pages jekyll serve --watch --incremental
 
 ci:
 	./scripts/travis-ci.sh


### PR DESCRIPTION
This allows us to render a local version of the
https://base.shiftcrypto.ch/ site.

_Edit:_ There's some unfortunate interactions between Jekyll-in-Docker and VirtualBox-via-Vagrant, see comments.