### PR TITLE
Add .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+armbian/armbian-build/


### PR DESCRIPTION
This allows Docker to avoid copying several GB of data from
`armbian/armbian-build/` which never will be used as build inputs
to the build context, thus speeding up builds.