### PR TITLE
Makefile: Use the dockerized build for Go tools by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,25 +1,31 @@
-.DEFAULT_GOAL=default
+.DEFAULT_GOAL=build-all
 HAS_DOCKER := $(shell which docker 2>/dev/null)
 REPO_ROOT=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+
+build-target-exists:
+	@mkdir -p $(REPO_ROOT)/build
 
 check-docker:
 ifndef HAS_DOCKER
 	$(error "This command requires Docker.")
 endif
 
-default:
+build-go: build-target-exists
 	@mkdir -p $(REPO_ROOT)/build
 	@echo "Building tools.."
 	$(MAKE) -C tools
 	@echo "Building middleware.."
 	$(MAKE) -C middleware
+
+build-all: build-target-exists docker-build-go
 	@echo "Building armbian.."
 	$(MAKE) -C armbian
 
 dockerinit: check-docker
 	docker build --tag digitalbitbox/bitbox-base .
 
-docker-build: dockerinit
+docker-build-go: dockerinit
+	@echo "Building tools and middleware inside Docker container.."
 	docker run \
 	       --rm \
 	       --tty \

--- a/middleware/Makefile
+++ b/middleware/Makefile
@@ -17,9 +17,13 @@ envinit:
 	@echo "Initializing Go environment.."
 	$(REPO_ROOT)/middleware/scripts/envinit.sh
 
-native: check-go-env
+fetch-deps:
+	@echo "Fetching dependencies.."
+	go get -v ./...
+
+native: check-go-env fetch-deps
 	go install $(REPO_ROOT)/middleware/cmd/middleware
 
-aarch64: check-go-env
+aarch64: check-go-env fetch-deps
 	GOARCH=arm64 go install $(REPO_ROOT)/middleware/cmd/middleware
 	cp ${GOPATH}/bin/linux_arm64/middleware $(REPO_ROOT)/build/base-middleware


### PR DESCRIPTION
### Makefile: Use the dockerized build for Go tools by default

Before this change, there was some issue with dependencies
with the default `make` target for the Go tools.

Specifically, in `middleware/main.go` we import other packages:

```
github.com/digitalbitbox/bitbox-base/middleware/src
github.com/digitalbitbox/bitbox-base/middleware/src/handlers
```

The user who has checked out their own fork of the `bitbox-base`
repo might or might not have these packages under the expected path:

```
$GOPATH/src/github.com/digitalbitbox/bitbox-base/middleware/src/{,handlers}
```

A further improvement would be to either `go get` the dependencies we
need, or fail with a better error message, if we can detect this situation
reliably.

Since we have a dockerized build for the Go tools, let's use
that for the default `make` target. I've added a separate
`make build-go` that does the build on the host system (not
using Docker) as well.

### middleware: Also fetch dependencies with 'go get' before build 