### PR TITLE
Add environment package to track external configs

### DIFF
--- a/middleware/cmd/middleware/main.go
+++ b/middleware/cmd/middleware/main.go
@@ -14,8 +14,10 @@ import (
 func main() {
 	bitcoinRPCUser := flag.String("rpcuser", "rpcuser", "Bitcoin rpc user name")
 	bitcoinRPCPassword := flag.String("rpcpassword", "rpcpassword", "Bitcoin rpc password")
-	bitcoinRPCPort := flag.String("rpcport", "8332", "Bitcoin rpc port, localhost is assumed as an address")
+	bitcoinRPCPort := flag.String("rpcport", "18332", "Bitcoin rpc port, localhost is assumed as an address")
 	lightningRPCPath := flag.String("lightning-rpc-path", "/home/bitcoin/.lightning/lightning-rpc", "Path to the lightning rpc unix socket")
+	electrsRPCPort := flag.String("electrsport", "51002", "Electrs rpc port")
+	network := flag.String("network", "testnet", "Indicate wether running bitcoin on testnet or mainnet")
 	flag.Parse()
 
 	logBeforeExit := func() {
@@ -27,7 +29,7 @@ func main() {
 		}
 	}
 	defer logBeforeExit()
-	middleware := middleware.NewMiddleware(*bitcoinRPCUser, *bitcoinRPCPassword, *bitcoinRPCPort, *lightningRPCPath)
+	middleware := middleware.NewMiddleware(*bitcoinRPCUser, *bitcoinRPCPassword, *bitcoinRPCPort, *lightningRPCPath, *electrsRPCPort, *network)
 	log.Println("--------------- Started middleware --------------")
 
 	handlers := handlers.NewHandlers(middleware)

--- a/middleware/src/system/system.go
+++ b/middleware/src/system/system.go
@@ -1,0 +1,54 @@
+//package system provides functionality to get data such as open ports and services running on the system the middleware is deployed on
+package system
+
+// Environment provides some information on the system we are running on.
+type Environment struct {
+	network                                            string
+	electrsRPCPort                                     string
+	bitcoinRPCUser, bitcoinRPCPassword, bitcoinRPCPort string
+	lightningRPCPath                                   string
+}
+
+// NewEnvironment returns a new Environment instance.
+func NewEnvironment(bitcoinRPCUser, bitcoinRPCPassword, bitcoinRPCPort, lightningRPCPath, electrsRPCPort, network string) Environment {
+	// TODO(TheCharlatan) Instead of just accepting a long list of arguments, use a map here and check if the arguments can be read from a system config.
+	environment := Environment{
+		bitcoinRPCUser:     bitcoinRPCUser,
+		bitcoinRPCPassword: bitcoinRPCPassword,
+		bitcoinRPCPort:     bitcoinRPCPort,
+		lightningRPCPath:   lightningRPCPath,
+		electrsRPCPort:     electrsRPCPort,
+		network:            network,
+	}
+	return environment
+}
+
+// GetBitcoinRPCUser is a getter for bitcoinRPCUser
+func (environment *Environment) GetBitcoinRPCUser() string {
+	return environment.bitcoinRPCUser
+}
+
+// GetBitcoinRPCPassword is a getter for the bitcoinRPCPassword
+func (environment *Environment) GetBitcoinRPCPassword() string {
+	return environment.bitcoinRPCUser
+}
+
+// GetBitcoinRPCPort is a getter for the bitcoinRPCPort
+func (environment *Environment) GetBitcoinRPCPort() string {
+	return environment.bitcoinRPCPort
+}
+
+// GetLightningRPCPath is a getter for the lightningRPCPath
+func (environment *Environment) GetLightningRPCPath() string {
+	return environment.lightningRPCPath
+}
+
+// GetElectrsRPCPort is a getter for the electrsRPCPort
+func (environment *Environment) GetElectrsRPCPort() string {
+	return environment.electrsRPCPort
+}
+
+// GetNetwork is a getter for the network type (testnet/mainnet)
+func (environment *Environment) GetNetwork() string {
+	return environment.network
+}


### PR DESCRIPTION
All command line arguments are now passed to a separate data structure
inside its own package that only exposes the data with getter functions.

This commits also adds the network and electrs port command line
arguments.