### PR TITLE
armbian: Fix broken build by removing 'git pull'

### DIFF
--- a/armbian/build.sh
+++ b/armbian/build.sh
@@ -51,11 +51,8 @@ case ${ACTION} in
 			git clone https://github.com/armbian/build armbian-build
 			sed -i "s/#vb.memory = \"8192\"/vb.memory = \"${VIRTUALBOX_MEMORY}\"/g" armbian-build/Vagrantfile
 			sed -i "s/#vb.cpus = \"4\"/vb.cpus = \"${VIRTUALBOX_CPU}\"/g" armbian-build/Vagrantfile
-			cd armbian-build
-		else 
-			cd armbian-build
-			git pull --no-rebase
 		fi
+		cd armbian-build
 
 		vagrant up
 		mkdir -p output/


### PR DESCRIPTION
In 24ae9acd, we added the `LIB_TAG=sunxi-4.20` build tag, which
checks out a specific git tag of the github.com/armbian/build repo.
This means that `git pull` won't work. From a clean checkout:

```
$ cd armbian && make
bash /home/user/src/hkjn.me/bitbox-base/armbian/build.sh build
You are not currently on a branch.
Please specify which branch you want to merge with.
See git-pull(1) for details.

    git pull <remote> <branch>

Cleaning up by halting any running vagrant VMs..
==> default: VM not created. Moving on...
make: *** [Makefile:4: default] Error 1
$ echo $?
2
```