### PR TITLE
Improved stability & faster build

### DIFF
--- a/armbian/base/build/build.conf
+++ b/armbian/base/build/build.conf
@@ -39,3 +39,9 @@
 
 # Enable web dashboard output
 #BASE_DASHBOARD_WEB_ENABLED="false"
+
+# Build c-lightning from source (true), or use prebuilt binary (false)
+# the prebuilt binary speeds up the image build process and is meant for development only
+# https://github.com/digitalbitbox/bitbox-base-deps
+
+#BASE_BUILD_LIGHTNINGD="true"

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -384,6 +384,7 @@ if [ "${BASE_BUILD_LIGHTNINGD}" == "true" ]; then
   make install
 
 else
+  apt install -y libsodium-dev
   cd /usr/local/src/
   # temporary storage of 'lightningd' until official arm64 binaries work with stable Armbian release
   curl --retry 5 -SLO https://github.com/digitalbitbox/bitbox-base-deps/releases/download/${BIN_DEPS_TAG}/lightningd_${LIGHTNING_VERSION}-1_arm64.deb

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -163,7 +163,7 @@ apt update
 apt upgrade -y
 
 # development
-apt install -y  git tmux qrencode #bwm-ng
+apt install -y  git tmux qrencode
 
 # system
 apt install -y  openssl net-tools fio libnss-mdns \
@@ -370,13 +370,15 @@ EOF
 BIN_DEPS_TAG="v0.0.1-alpha"
 LIGHTNING_VERSION="0.7.0"
 
+apt install -y libsodium-dev
+
 ## either compile c-lightning from source (default), or use prebuilt binary
 if [ "${BASE_BUILD_LIGHTNINGD}" == "true" ]; then
   apt install -y  autoconf automake build-essential git libtool libgmp-dev \
-                  libsqlite3-dev python python3 net-tools zlib1g-dev libsodium-dev
+                  libsqlite3-dev python python3 net-tools zlib1g-dev
 
   cd /usr/local/src/
-  git clone https://github.com/ElementsProject/lightning.git || true
+  git clone https://github.com/ElementsProject/lightning.git
   cd lightning
   git checkout v${LIGHTNING_VERSION}
   ./configure
@@ -384,7 +386,6 @@ if [ "${BASE_BUILD_LIGHTNINGD}" == "true" ]; then
   make install
 
 else
-  apt install -y libsodium-dev
   cd /usr/local/src/
   # temporary storage of 'lightningd' until official arm64 binaries work with stable Armbian release
   curl --retry 5 -SLO https://github.com/digitalbitbox/bitbox-base-deps/releases/download/${BIN_DEPS_TAG}/lightningd_${LIGHTNING_VERSION}-1_arm64.deb
@@ -393,6 +394,8 @@ else
     exit 1
   fi
   dpkg -i lightningd_${LIGHTNING_VERSION}-1_arm64.deb
+
+  # symlink is needed, as the direct compilation (default) installs into /usr/local/bin, while this package uses '/usr/bin'
   ln -s /usr/bin/lightningd /usr/local/bin/lightningd
   
 fi

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -256,8 +256,8 @@ EOF
 ln -sf /mnt/ssd/system/journal/ /var/log/journal
 
 # make bbb scripts executable with sudo
-sudo ln /opt/shift/scripts/bbb-config.sh    /usr/local/sbin/bbb-config.sh
-sudo ln /opt/shift/scripts/bbb-systemctl.sh /usr/local/sbin/bbb-systemctl.sh
+sudo ln -s /opt/shift/scripts/bbb-config.sh    /usr/local/sbin/bbb-config.sh
+sudo ln -s /opt/shift/scripts/bbb-systemctl.sh /usr/local/sbin/bbb-systemctl.sh
 
 
 # TOR --------------------------------------------------------------------------

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -63,10 +63,10 @@ fi
 chown bitcoin:system /mnt/ssd 
 
 # bitcoin data storage
-mkdir -p /mnt/ssd/bitcoin/.bitcoin/
+mkdir -p /mnt/ssd/bitcoin/.bitcoin/testnet3
 chown -R bitcoin:bitcoin /mnt/ssd/bitcoin/
-setfacl -d -m g::rx /mnt/ssd/bitcoin/.bitcoin/
-setfacl -d -m o::- /mnt/ssd/bitcoin/.bitcoin/
+setfacl -dR -m g::rx /mnt/ssd/bitcoin/.bitcoin/
+setfacl -dR -m o::- /mnt/ssd/bitcoin/.bitcoin/
 
 # electrs data storage
 mkdir -p /mnt/ssd/electrs/

--- a/armbian/build.sh
+++ b/armbian/build.sh
@@ -70,8 +70,6 @@ case ${ACTION} in
 		else
 			vagrant ssh -c "cd armbian/ && sudo time ./compile.sh BOARD=${BOARD} KERNEL_ONLY=no KERNEL_CONFIGURE=no RELEASE=stretch BRANCH=default BUILD_DESKTOP=no WIREGUARD=no CLEAN_LEVEL=oldcache PROGRESS_LOG_TO_FILE=yes LIB_TAG=sunxi-4.20"
 		fi
-
-		sha256sum output/images/Armbian_*.img
 		;;
 
 	clean)


### PR DESCRIPTION
Various minor configuration fixes:
* better, recursive ACL for directory `/mnt/ssd/bitcoin/.bitcoin`
* fix setting hardlinks for bbb-* scripts (now: symlinks)
* remove sha256sum display at end of build script, can take long time with multiple images
* use new [bitbox-base-deps](https://github.com/digitalbitbox/bitbox-base-deps) repository for prebuilt binaries
* by default, c-lightning is compiled during build, but can optionally be installed as package