### PR TITLE
Fix BOARD argument in build.sh

### DIFF
--- a/armbian/build.sh
+++ b/armbian/build.sh
@@ -62,7 +62,7 @@ case ${ACTION} in
 		cp -a  ../base/build/customize-image.sh userpatches/	# copy customize script to standard Armbian build hook
 
 		BOARD=${BOARD:-rockpro64}
-		BUILD_ARGS="${BOARD} KERNEL_ONLY=no KERNEL_CONFIGURE=no RELEASE=stretch BRANCH=default BUILD_DESKTOP=no WIREGUARD=no LIB_TAG=sunxi-4.20"
+		BUILD_ARGS="BOARD=${BOARD} KERNEL_ONLY=no KERNEL_CONFIGURE=no RELEASE=stretch BRANCH=default BUILD_DESKTOP=no WIREGUARD=no LIB_TAG=sunxi-4.20"
 		if [ "${ACTION}" == "build" ]; then
 			vagrant ssh -c "cd armbian/ && sudo time ./compile.sh ${BUILD_ARGS}"
 		else


### PR DESCRIPTION
Minor change to fix missing `BOARD` argument in `build.sh`

Without it, the board variable is ignored, resulting in a interactive prompt to choose the board:

![Screenshot from 2019-06-06 21-46-37](https://user-images.githubusercontent.com/19550140/59062398-0026c400-88a6-11e9-90bd-8087e43cad37.png)

![Screenshot from 2019-06-06 21-50-54](https://user-images.githubusercontent.com/19550140/59062404-0321b480-88a6-11e9-97dc-6a6db3173118.png)

After the fix, the BOARD is recognized

![Screenshot from 2019-06-06 21-52-22](https://user-images.githubusercontent.com/19550140/59062418-0ddc4980-88a6-11e9-884d-66bcfdd84ef1.png)

