### PR TITLE
armbian/base: Return accidentally commented-out line

### DIFF
--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -502,7 +502,7 @@ cp /tmp/overlay/bbbfancontrol.service /etc/systemd/system/
 
 ## base-middleware
 ## see https://github.com/digitalbitbox/bitbox-base/blob/master/middleware/README.md
-# cp /tmp/overlay/base-middleware /usr/local/sbin/
+cp /tmp/overlay/base-middleware /usr/local/sbin/
 
 mkdir -p /etc/base-middleware/
 cat << EOF > /etc/base-middleware/base-middleware.conf


### PR DESCRIPTION
Looks like this line was accidentally commented out in
https://github.com/digitalbitbox/bitbox-base/pull/48#discussion-diff-292464056R505