### PR TITLE
Dockerize armbian build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,10 @@ build-all: build-target-exists docker-build-go
 	@echo "Building armbian.."
 	$(MAKE) -C armbian
 
+clean:
+	$(MAKE) -C armbian clean
+	rm -rf $(REPO_ROOT)/build
+
 dockerinit: check-docker
 	docker build --tag digitalbitbox/bitbox-base .
 

--- a/armbian/build.sh
+++ b/armbian/build.sh
@@ -7,23 +7,9 @@
 #
 set -eu
 
-# Settings
-#
-# VirtualBox Number of CPU cores
-VIRTUALBOX_CPU="4"
-# VirtualBox Memory in MB
-VIRTUALBOX_MEMORY="8192"
-
 function usage() {
 	echo "Build customized Armbian base image for BitBox Base"
 	echo "Usage: ${0} [update]"
-}
-
-function cleanup() {
-	if [[ "${ACTION}" != "clean" ]]; then
-		echo "Cleaning up by halting any running vagrant VMs.."
-		vagrant halt
-	fi
 }
 
 ACTION=${1:-"build"}
@@ -33,11 +19,9 @@ if ! [[ "${ACTION}" =~ ^(build|update|clean)$ ]]; then
 	exit 1
 fi
 
-trap cleanup EXIT
-
 case ${ACTION} in
 	build|update)
-		if ! which git >/dev/null 2>&1 || ! which vagrant >/dev/null 2>&1; then
+		if ! which git >/dev/null 2>&1 || ! which docker >/dev/null 2>&1; then
 			echo
 			echo "Build environment not set up, please check documentation at"
 			echo "https://digitalbitbox.github.io/bitbox-base"
@@ -49,12 +33,9 @@ case ${ACTION} in
 
 		if [ ! -d "armbian-build" ]; then 
 			git clone https://github.com/armbian/build armbian-build
-			sed -i "s/#vb.memory = \"8192\"/vb.memory = \"${VIRTUALBOX_MEMORY}\"/g" armbian-build/Vagrantfile
-			sed -i "s/#vb.cpus = \"4\"/vb.cpus = \"${VIRTUALBOX_CPU}\"/g" armbian-build/Vagrantfile
 		fi
 		cd armbian-build
 
-		vagrant up
 		mkdir -p output/
 		mkdir -p userpatches/overlay
 		cp -aR ../base/* userpatches/overlay/					# copy scripts and configuration items to overlay
@@ -62,23 +43,15 @@ case ${ACTION} in
 		cp -a  ../base/build/customize-image.sh userpatches/	# copy customize script to standard Armbian build hook
 
 		BOARD=${BOARD:-rockpro64}
-		BUILD_ARGS="BOARD=${BOARD} KERNEL_ONLY=no KERNEL_CONFIGURE=no RELEASE=stretch BRANCH=default BUILD_DESKTOP=no WIREGUARD=no LIB_TAG=sunxi-4.20"
-		if [ "${ACTION}" == "build" ]; then
-			vagrant ssh -c "cd armbian/ && sudo time ./compile.sh ${BUILD_ARGS}"
-		else
+		BUILD_ARGS="docker BOARD=${BOARD} KERNEL_ONLY=no KERNEL_CONFIGURE=no RELEASE=stretch BRANCH=default BUILD_DESKTOP=no WIREGUARD=no LIB_TAG=sunxi-4.20"
+		if ! [ "${ACTION}" == "build" ]; then
 			BUILD_ARGS="${BUILD_ARGS} CLEAN_LEVEL=oldcache PROGRESS_LOG_TO_FILE=yes"
-			vagrant ssh -c "cd armbian/ && sudo time ./compile.sh ${BUILD_ARGS}"
 		fi
+		time ./compile.sh ${BUILD_ARGS}
+
 		;;
 
 	clean)
-		set +e
-		if [ -d "armbian-build" ]; then
-			cd armbian-build
-			vagrant halt 
-			vagrant destroy -f
-			cd ..
-			rm -rf armbian-build
-		fi
+		rm -rf armbian-build
 		;;
 esac

--- a/docs/os/armbian-build.md
+++ b/docs/os/armbian-build.md
@@ -9,22 +9,25 @@ nav_order: 310
 The goal of building the Armbian operating system from source is to create a highly configurable base image, with granular control over kernel features, that can be written on an eMMC or SD card and boots directly into an operational state.
 
 The process to build the Armbian image for the RockPro64 board is mostly automated and follows [Armbian best practices](https://docs.armbian.com/Developer-Guide_Build-Preparation).
-It utilizes a VirtualBox machine with Ubuntu 18.04 LTS as a build environment, configured and run automatically using Vagrant.
+
+It makes use of the Docker containers to perform the build process:
+
+* https://docs.armbian.com/Developer-Guide_Building-with-Docker/
+
 The following build instructions have been tested both on Debian-based Linux systems and within Windows PowerShell.
 
 ### Requirements
 
 * Regular computer with x86/x64 architecture, 4GB+ memory, 4+ cores
 * minimum of 25 GB free space on a fast drive, preferrably SSD
-* any operating system that can run Virtualbox and Vagrant is supported
+* any operating system that can run Docker containers is supported
 
 ### Prepare build environment
 
 To set up and run the build environment in the virtual machine, the following software needs to be installed:
 
 * Git ([download](https://git-scm.com/))
-* Virtualbox ([download](https://www.virtualbox.org/)), version > 5.1.12
-* Vagrant ([download](https://www.vagrantup.com/)), version >= 2.2
+* Docker ([download](https://www.docker.com/get-started)), version >= 18.06.3-ce
 
 All sources and build scripts are contained in this repository, which needs to be cloned locally.
 The following commands are executed in the command line, either the Linux terminal or Windows PowerShell.  
@@ -38,8 +41,6 @@ In the following instructions, Windows users just replace `make` with `sh .\buil
   git clone https://github.com/digitalbitbox/bitbox-base.git
   cd bitbox-base/armbian
   ```
-
-* The virtual machine will be configured running on 4 cpu cores and 8GB memory. You can adjust these settings in the `build.sh` script.
 
 ### Configure build options
 
@@ -84,10 +85,6 @@ Now the operating system image can be built. The whole BitBox Base configuration
 
 ### Not enough disk space
 
-The build needs 25G+.
-On Linux, the VirtualBox data directory is `~/VirtualBox VMs` by default, so the host user running the build will need sufficient storage space in their home directory.
+The build needs several gigabytes of disk space.
 
-### Filesystem doesn't support permissions
-
-If using a filesystem like exFAT, UNIX file permissions are not supported and the build will not succeed.
-Move the repo and the virtualbox data directory to a filesystem that does support file permissions to proceed.
+On Linux, the Docker data directory is `/var/lib/docker` by default, so this directory needs to be on a filesystem with sufficient space.

--- a/middleware/Makefile
+++ b/middleware/Makefile
@@ -21,9 +21,9 @@ fetch-deps:
 	@echo "Fetching dependencies.."
 	go get -v ./...
 
-native: check-go-env fetch-deps
+native: check-go-env fetch-deps ci
 	go install $(REPO_ROOT)/middleware/cmd/middleware
 
-aarch64: check-go-env fetch-deps
+aarch64: check-go-env fetch-deps ci
 	GOARCH=arm64 go install $(REPO_ROOT)/middleware/cmd/middleware
 	cp ${GOPATH}/bin/linux_arm64/middleware $(REPO_ROOT)/build/base-middleware

--- a/scripts/travis-ci.sh
+++ b/scripts/travis-ci.sh
@@ -5,11 +5,8 @@
 set -euo pipefail
 
 TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR:-"$(pwd)"}
-
-docker build --tag=digitalbitbox/bitbox-base .
-docker run -v ${TRAVIS_BUILD_DIR}:/opt/go/src/github.com/digitalbitbox/bitbox-base/ \
-        -i digitalbitbox/bitbox-base \
-        bash -c "make -C \$GOPATH/src/github.com/digitalbitbox/bitbox-base/middleware ci" \
-        bash -c "make -C \$GOPATH/src/github.com/digitalbitbox/bitbox-base/middleware native" \
-        bash -c "make -C \$GOPATH/src/github.com/digitalbitbox/bitbox-base/tools/bbbfancontrol"
-
+# TODO(hkjn): We could 'make build-all' here if we can resolve
+# remaining issues with building Armbian images in a dockerized
+# workflow on Travis:
+# https://github.com/digitalbitbox/bitbox-base/issues/39#issuecomment-501343881
+make docker-build-go


### PR DESCRIPTION
Note that we do not switch over Travis CI to use the dockerized build yet, since some issues remain:

* https://github.com/digitalbitbox/bitbox-base/issues/39#issuecomment-501343881

After this change, the default `make` command in the root of the repo (`make build-all`) uses Docker to build the Armbian image as well. (We already were building the Go services using Docker since ac5a3040.)