### PR TITLE
Make the websocket in the middleware just send json

### DIFF
--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -21,14 +21,14 @@ type SampleInfo struct {
 type Middleware struct {
 	info        SampleInfo
 	environment system.Environment
-	events      chan *SampleInfo
+	events      chan interface{}
 }
 
 // NewMiddleware returns a new instance of the middleware
 func NewMiddleware(bitcoinRPCUser, bitcoinRPCPassword, bitcoinRPCPort, lightningRPCPath, electrsRPCPort, network string) *Middleware {
 	middleware := &Middleware{
 		environment: system.NewEnvironment(bitcoinRPCUser, bitcoinRPCPassword, bitcoinRPCPort, lightningRPCPath, electrsRPCPort, network),
-		events:      make(chan *SampleInfo),
+		events:      make(chan interface{}),
 		info: SampleInfo{
 			Blocks:         0,
 			Difficulty:     0.0,
@@ -96,7 +96,7 @@ func (middleware *Middleware) rpcLoop() {
 }
 
 // Start gives a trigger for the handler to start the rpc event loop
-func (middleware *Middleware) Start() <-chan *SampleInfo {
+func (middleware *Middleware) Start() <-chan interface{} {
 	go middleware.rpcLoop()
 	return middleware.events
 }


### PR DESCRIPTION
The middleware package now communicates purely through a generic event interface with the handler. I thus removed a TODO that was created for this task. The event is then sent through a websocket connection to connected clients.