### PR TITLE
Fix Regression in system.go

### DIFF
--- a/middleware/src/system/system.go
+++ b/middleware/src/system/system.go
@@ -32,7 +32,7 @@ func (environment *Environment) GetBitcoinRPCUser() string {
 
 // GetBitcoinRPCPassword is a getter for the bitcoinRPCPassword
 func (environment *Environment) GetBitcoinRPCPassword() string {
-	return environment.bitcoinRPCUser
+	return environment.bitcoinRPCPassword
 }
 
 // GetBitcoinRPCPort is a getter for the bitcoinRPCPort


### PR DESCRIPTION
The rpcpassword getter mistakenly returned the rpcuser. This is an embarassing regression. It would be nice, if the dockerfile would include regtest setups of c-lightning and bitcoind to check if the middleware is still capable of communicating / routing traffic with them.