### PR TITLE
docs: Add top-level Go applications page

### DIFF
--- a/docs/go-apps.md
+++ b/docs/go-apps.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Go applications
+nav_order: 450
+has_children: true
+permalink: /go
+---
+## BitBox Base: Go applications

--- a/docs/go/build.md
+++ b/docs/go/build.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Building Go binaries
+nav_order: 100
+parent: Go applications
+---
+## BitBox Base: Building Go binaries
+
+The BitBox Base runs custom software written in Go that has to be compiled and become part of [the Armbian image](/os/armbian-build.html).
+This page describes the process used to build those images.
+
+The top-level [`Makefile`](https://github.com/digitalbitbox/bitbox-base/blob/master/Makefile#L27) for the repository has two targets:
+
+- `make docker-build-go`: Build the Go applications inside a Docker container
+- `make build-go`: Build the Go applications on the host
+
+The default `make` target invokes the `make docker-build-go` target to produce Go binaries compiled for the target CPU architecture in the `build/` directory, and then builds the [Armbian image](/docs/os/armbian-build.md), using the `build/` contents as inputs. For users that have the Go toolchain installed on the host system, `make build-go` should also work fine, and if the Go environment is not configured correctly, the command should produce some useful information to debug the issue.

--- a/docs/go/middleware.md
+++ b/docs/go/middleware.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Middleware
+nav_order: 200
+parent: Go applications
+---
+## BitBox Base: Middleware
+
+We have a `middleware` application written in Go, which exposes a single endpoint to the network, acting as a server when the user connects using the [BitBox App](https://github.com/digitalbitbox/bitbox-wallet-app/):
+
+[`middleware/`](https://github.com/digitalbitbox/bitbox-base/tree/master/middleware)

--- a/docs/go/tools.md
+++ b/docs/go/tools.md
@@ -1,0 +1,12 @@
+---
+layout: default
+title: Go tools
+nav_order: 300
+parent: Go applications
+---
+## BitBox Base: Go tools
+
+Several Go tools are part of this repository:
+
+- [`tools/bbbfancontrol/`](https://github.com/digitalbitbox/bitbox-base/blob/master/tools/bbbfancontrol): Control the fan speed of the BitBox Base device
+- [`tools/bbbsupervisor/`](https://github.com/digitalbitbox/bitbox-base/tree/master/tools/bbbsupervisor): Monitors systemd  logs to detect potential issues and take action

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -1,8 +1,0 @@
----
-layout: default
-title: Middleware
-nav_order: 500
-has_children: true
-permalink: /middleware
----
-## BitBox Base: Middleware

--- a/docs/os/build-details.md
+++ b/docs/os/build-details.md
@@ -15,7 +15,7 @@ It performs the following steps:
 1. cloning the [`github.com/armbian/build`](https://github.com/armbian/build/) repo into `armbian/armbian-build/`, if it doesn't exist already
 1. copying over the following files from the host system into `armbian/armbian-build/userpatches/overlay/`:
     1. `armbian/base/`: scripts and configs included in the Armbian image
-    1. `build/`: contains all built Go binaries and their associated `.service` files
+    1. `build/`: contains all [built Go binaries](/docs/go-apps.md) and their associated `.service` files
     1. [`customize-image.sh`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/build/customize-image.sh): the hook which the Armbian build process calls
 1. constructing the appropriate build arguments
 1. calling the [`armbian/armbian-build/compile.sh`](https://github.com/armbian/build/blob/master/compile.sh) script with the `docker` argument, to kick off the dockerized build process


### PR DESCRIPTION
Also move middleware.md into docs/go/ and add some minimal content to
the page.

Also add /docs/go/build.md with a description of the Go build process.

Also add /docs/go/tools.md doc with a minimal description of `bbbfancontrol`
and `bbbsupervisor`.

Also add link to Go docs from docs/os/build-details.md.