### PR TITLE
Fix some broken links, add Go applications to index.md

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -88,7 +88,7 @@ As the BitBox Base is designed as a networked appliance, it's important that the
 
 The Debian-based Linux distribution Armbian also features a reliable build environment that allows to build the operating system from source, configure the resulting kernel in minute detail and customize the resulting disk image using regular bash scripts within a chroot environment.
 
-More detail on how to build the base operating image yourself will be detailed in the [Armbian build](docs/armbian-build.md) docs.
+More detail on how to build the base operating image yourself will be detailed in the [Armbian build](armbian-build.md) docs.
 
 ### Integrated HSM
 

--- a/docs/go/build.md
+++ b/docs/go/build.md
@@ -9,7 +9,7 @@ parent: Go applications
 The BitBox Base runs custom software written in Go that has to be compiled and become part of [the Armbian image](/os/armbian-build.md).
 This page describes the process used to build those images.
 
-The top-level [`Makefile`](https://github.com/digitalbitbox/bitbox-base/blob/master/Makefile#L27) for the repository has two targets:
+The top-level [`Makefile`](https://github.com/digitalbitbox/bitbox-base/blob/master/Makefile) for the repository has two targets:
 
 - `make docker-build-go`: Build the Go applications inside a Docker container
 - `make build-go`: Build the Go applications on the host

--- a/docs/go/build.md
+++ b/docs/go/build.md
@@ -6,7 +6,7 @@ parent: Go applications
 ---
 ## BitBox Base: Building Go binaries
 
-The BitBox Base runs custom software written in Go that has to be compiled and become part of [the Armbian image](/os/armbian-build.html).
+The BitBox Base runs custom software written in Go that has to be compiled and become part of [the Armbian image](/os/armbian-build.md).
 This page describes the process used to build those images.
 
 The top-level [`Makefile`](https://github.com/digitalbitbox/bitbox-base/blob/master/Makefile#L27) for the repository has two targets:
@@ -14,4 +14,4 @@ The top-level [`Makefile`](https://github.com/digitalbitbox/bitbox-base/blob/mas
 - `make docker-build-go`: Build the Go applications inside a Docker container
 - `make build-go`: Build the Go applications on the host
 
-The default `make` target invokes the `make docker-build-go` target to produce Go binaries compiled for the target CPU architecture in the `build/` directory, and then builds the [Armbian image](/docs/os/armbian-build.md), using the `build/` contents as inputs. For users that have the Go toolchain installed on the host system, `make build-go` should also work fine, and if the Go environment is not configured correctly, the command should produce some useful information to debug the issue.
+The default `make` target invokes the `make docker-build-go` target to produce Go binaries compiled for the target CPU architecture in the `build/` directory, and then builds [the Armbian image](/os/armbian-build.md), using the `build/` contents as inputs. For users that have the Go toolchain installed on the host system, `make build-go` should also work fine, and if the Go environment is not configured correctly, the command should produce some useful information to debug the issue.

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,6 +18,10 @@ The BitBox Base is an ongoing project of [Shift Cryptosecurity](https://shiftcry
    1. Build system
    1. Build configuration
    1. Dependencies
+1. Go applications
+   1. [Building Go binaries](go/build.md)
+   1. [Middleware](go/middleware.md)
+   1. [Go tools](go/tools.md)
 1. Operating System
    1. [Build Armbian image](os/armbian-build.md)
    1. [Build details](os/build-details.md)

--- a/docs/os/build-details.md
+++ b/docs/os/build-details.md
@@ -15,7 +15,7 @@ It performs the following steps:
 1. cloning the [`github.com/armbian/build`](https://github.com/armbian/build/) repo into `armbian/armbian-build/`, if it doesn't exist already
 1. copying over the following files from the host system into `armbian/armbian-build/userpatches/overlay/`:
     1. `armbian/base/`: scripts and configs included in the Armbian image
-    1. `build/`: contains all [built Go binaries](/docs/go-apps.md) and their associated `.service` files
+    1. `build/`: contains all [built Go binaries](/go-apps.md) and their associated `.service` files
     1. [`customize-image.sh`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/build/customize-image.sh): the hook which the Armbian build process calls
 1. constructing the appropriate build arguments
 1. calling the [`armbian/armbian-build/compile.sh`](https://github.com/armbian/build/blob/master/compile.sh) script with the `docker` argument, to kick off the dockerized build process


### PR DESCRIPTION
As an aside, we might want to set up some quick scraper as part of CI to check that there's no links that 404s, since checking manually might become cumbersome..