### PR TITLE
bitcoind: signing key & Tor listening

### DIFF
--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -268,7 +268,14 @@ fi
 apt update
 apt -y install tor --no-install-recommends
 
+# allow user 'bitcoin' to access Tor proxy socket
+usermod -a -G debian-tor bitcoin
+
 cat << EOF > /etc/tor/torrc
+ControlPort 9051                                          #TOR#
+CookieAuthentication 1                                    #TOR#
+CookieAuthFileGroupReadable 1                             #TOR#
+
 HiddenServiceDir /var/lib/tor/hidden_service_bitcoind/    #BITCOIND#
 HiddenServiceVersion 3                                    #BITCOIND#
 HiddenServicePort 18333 127.0.0.1:18333                   #BITCOIND#
@@ -317,6 +324,7 @@ testnet=1
 # server
 server=1
 listen=1
+listenonion=1
 daemon=1
 txindex=0
 prune=0

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -168,7 +168,7 @@ apt install -y  git tmux qrencode
 # system
 apt install -y  openssl net-tools fio libnss-mdns \
                 avahi-daemon avahi-discover avahi-utils \
-                fail2ban acl ifmetric 
+                fail2ban acl ifmetric
 
 
 # STARTUP CHECKS ---------------------------------------------------------------
@@ -306,11 +306,10 @@ BITCOIN_VERSION="0.18.0"
 
 mkdir -p /usr/local/src/bitcoin
 cd /usr/local/src/bitcoin/
-#curl --retry 5 -SL https://bitcoincore.org/keys/laanwj-releases.asc | gpg --import
 curl --retry 5 -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
 curl --retry 5 -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-aarch64-linux-gnu.tar.gz
 
-## get Bitcoin Core signing key
+## get Bitcoin Core signing key, verify sha256 checksum of applications and signature of SHA256SUMS.asc
 gpg --keyserver pool.sks-keyservers.net --recv-keys 01EA5486DE18A882D4C2684590C8019E36C2E964
 gpg --refresh-keys || true
 gpg --verify SHA256SUMS.asc || exit 1

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -168,7 +168,7 @@ apt install -y  git tmux qrencode
 # system
 apt install -y  openssl net-tools fio libnss-mdns \
                 avahi-daemon avahi-discover avahi-utils \
-                fail2ban acl ifmetric
+                fail2ban acl ifmetric 
 
 
 # STARTUP CHECKS ---------------------------------------------------------------
@@ -306,10 +306,12 @@ BITCOIN_VERSION="0.18.0"
 
 mkdir -p /usr/local/src/bitcoin
 cd /usr/local/src/bitcoin/
-curl --retry 5 -SL https://bitcoincore.org/keys/laanwj-releases.asc | gpg --import
+#curl --retry 5 -SL https://bitcoincore.org/keys/laanwj-releases.asc | gpg --import
 curl --retry 5 -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/SHA256SUMS.asc
 curl --retry 5 -SLO https://bitcoincore.org/bin/bitcoin-core-${BITCOIN_VERSION}/bitcoin-${BITCOIN_VERSION}-aarch64-linux-gnu.tar.gz
 
+## get Bitcoin Core signing key
+gpg --keyserver pool.sks-keyservers.net --recv-keys 01EA5486DE18A882D4C2684590C8019E36C2E964
 gpg --refresh-keys || true
 gpg --verify SHA256SUMS.asc || exit 1
 grep "bitcoin-${BITCOIN_VERSION}-aarch64-linux-gnu.tar.gz\$" SHA256SUMS.asc | sha256sum -c - || exit 1

--- a/docs/applications/bitcoin-core.md
+++ b/docs/applications/bitcoin-core.md
@@ -25,6 +25,7 @@ The application configuration is specified in the local `/etc/bitcoin/bitcoin.co
 testnet=1
 server=1
 listen=1
+listenonion=1
 daemon=1
 txindex=0
 prune=0
@@ -55,6 +56,7 @@ Some notes about this specific configuration:
     * or by running the command `bbb-config.sh set bitcoin_network mainnet` manually on the BitBox Base (see [OS/Helper Scripts](../os/helper-scripts.md)).
   * `server`: enables the RPC interface
   * `listen`: accept connections from other nodes
+  * `listenonion`: create a Tor hidden service and accept incoming connections from other nodes on that address
   * `daemon`: run bitcoind as a server in the background
   * `txindex`: a full transaction index is not necessary, as we use electrs - which has its own indices - to serve transaction information.
   * `prune`: both c-lightning as well as electrs do not support pruned Bitcoin nodes at the moment.


### PR DESCRIPTION
* get Bitcoin Core signing key from keyserver instead of downloading it directly
* make `bitcoind` listen over Tor directly

Built & tested on Alice