### PR TITLE
Simplify build rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 armbian/armbian-build
 armbian/base/build/build-local.conf
 armbian/base/config/latest_commit
-build
 tools/bbbfancontrol/bbbfancontrol
 tools/bbbsupervisor/bbbsupervisor
 *.sw?

--- a/Makefile
+++ b/Makefile
@@ -2,28 +2,24 @@
 HAS_DOCKER := $(shell which docker 2>/dev/null)
 REPO_ROOT=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-build-target-exists:
-	@mkdir -p $(REPO_ROOT)/build
-
 check-docker:
 ifndef HAS_DOCKER
 	$(error "This command requires Docker.")
 endif
 
-build-go: build-target-exists
-	@mkdir -p $(REPO_ROOT)/build
+build-go:
 	@echo "Building tools.."
 	$(MAKE) -C tools
 	@echo "Building middleware.."
 	$(MAKE) -C middleware
 
-build-all: build-target-exists docker-build-go
+build-all: docker-build-go
 	@echo "Building armbian.."
 	$(MAKE) -C armbian
 
 clean:
 	$(MAKE) -C armbian clean
-	rm -rf $(REPO_ROOT)/build
+	bash $(REPO_ROOT)/scripts/clean.sh
 
 dockerinit: check-docker
 	docker build --tag digitalbitbox/bitbox-base .

--- a/armbian/Makefile
+++ b/armbian/Makefile
@@ -7,4 +7,4 @@ update:
 	bash $(MAKE_PATH)/build.sh update
 
 clean:
-	bash $(MAKE_PATH)/build.sh clean
+	rm -rf $(MAKE_PATH)/armbian/armbian-build

--- a/armbian/build.sh
+++ b/armbian/build.sh
@@ -9,12 +9,12 @@ set -eu
 
 function usage() {
 	echo "Build customized Armbian base image for BitBox Base"
-	echo "Usage: ${0} [update]"
+	echo "Usage: ${0} [build|update]"
 }
 
 ACTION=${1:-"build"}
 
-if ! [[ "${ACTION}" =~ ^(build|update|clean)$ ]]; then
+if ! [[ "${ACTION}" =~ ^(build|update)$ ]]; then
 	usage
 	exit 1
 fi
@@ -49,9 +49,5 @@ case ${ACTION} in
 		fi
 		time ./compile.sh ${BUILD_ARGS}
 
-		;;
-
-	clean)
-		rm -rf armbian-build
 		;;
 esac

--- a/build/README.md
+++ b/build/README.md
@@ -1,0 +1,6 @@
+# build
+
+This directory holds the build outputs for the BitBox Base project. See the main documentation
+for more information:
+
+* https://base.shiftcrypto.ch/base-image

--- a/middleware/Makefile
+++ b/middleware/Makefile
@@ -2,10 +2,7 @@
 REPO_ROOT=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/..
 SHELL:=/bin/bash
 
-build-target-exists:
-	@mkdir -p $(REPO_ROOT)/build
-
-check-go-env: build-target-exists
+check-go-env:
 	@echo "Checking that environment supports Go builds.."
 	@$(REPO_ROOT)/scripts/check-go-env.sh "$(REPO_ROOT)"
 

--- a/scripts/clean.sh
+++ b/scripts/clean.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Remove all build/ outputs.
+#
+set -eu
+
+# Enable extended pattern matching operators like !$("file").
+shopt -s extglob
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# Remove all contents of build/, except README.md. 
+rm -rf ${SCRIPT_DIR}/../build/!("README.md")

--- a/tools/bbbfancontrol/Makefile
+++ b/tools/bbbfancontrol/Makefile
@@ -1,10 +1,7 @@
 .DEFAULT_GOAL := aarch64
 REPO_ROOT=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/../..
 
-build-target-exists:
-	@mkdir -p $(REPO_ROOT)/build
-
-check-go-env: build-target-exists
+check-go-env:
 	@echo "Checking that environment supports Go builds.."
 	@$(REPO_ROOT)/scripts/check-go-env.sh "$(REPO_ROOT)"
 

--- a/tools/bbbsupervisor/Makefile
+++ b/tools/bbbsupervisor/Makefile
@@ -1,10 +1,7 @@
 .DEFAULT_GOAL := aarch64
 REPO_ROOT=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))/../..
 
-build-target-exists:
-	@mkdir -p $(REPO_ROOT)/build
-
-check-go-env: build-target-exists
+check-go-env:
 	@echo "Checking that environment supports Go builds.."
 	@$(REPO_ROOT)/scripts/check-go-env.sh "$(REPO_ROOT)"
 


### PR DESCRIPTION
### Makefile: add build/README.md, simplify build rules

By adding a build/README.md file, we can guarantee that the build/
directory always will exist, so we no longer need the
`build-target-exists` make targets.

h/t @NicolasDorier, who had questions prompting us to rethink this
setup which led to this patch.

### armbian: Remove trivial build.sh clean command

Instead just inline the command in the `Makefile`.