### PR TITLE
armbian: Move .img to build/ after build is done

### DIFF
--- a/armbian/Makefile
+++ b/armbian/Makefile
@@ -1,10 +1,13 @@
+.DEFAULT_GOAL := build
 MAKE_PATH=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
-default:
+build:
 	bash $(MAKE_PATH)/build.sh build
+	bash $(MAKE_PATH)/../scripts/move-armbian-image.sh
 
 update:
 	bash $(MAKE_PATH)/build.sh update
+	bash $(MAKE_PATH)/../scripts/move-armbian-image.sh
 
 clean:
 	rm -rf $(MAKE_PATH)/armbian/armbian-build

--- a/docs/base-image.md
+++ b/docs/base-image.md
@@ -26,4 +26,5 @@ Unpacking the steps above, what happens when you type `make` is:
         1. [`cd bbbsupervisor && make`](https://github.com/digitalbitbox/bitbox-base/blob/master/tools/supervisor/Makefile): compiles the `build/bbbsupervisor` binary
     1. [`cd middleware && make`](https://github.com/digitalbitbox/bitbox-base/blob/master/middleware/Makefile#L39): inside the `digitalbitbox/bitbox-base` container, the `build/base-middleware` binary is built from the `middleware/` subdirectory
 1. [`make build-all`](https://github.com/digitalbitbox/bitbox-base/blob/master/Makefile#L20): the default target if `make` is called, and depends on `make docker-build-go`, and after that performs the main Armbian image build
-    1. [`cd armbian && make`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/Makefile): builds the `armbian/armbian-build/output/images/Armbian_*.img`, using the Go binaries in `build/` as inputs
+    1. [`cd armbian && make`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/Makefile): builds the Armbian `.img` file, using the Go binaries in `build/` as inputs
+    1. finally, the `.img` file is moved to the `build/` directory

--- a/docs/os/armbian-build.md
+++ b/docs/os/armbian-build.md
@@ -65,11 +65,11 @@ Now the operating system image can be built. The whole BitBox Base configuration
   make
   ```
 
-* The resulting image is available in `armbian-build/output/images/` and can be written to eMMC or SD card using a program like [Etcher](https://www.balena.io/etcher/). On the Linux command line you can use `dd`: once the target medium is connected to your computer, get the device name (e.g. `/dev/sdb`). Check it carefully, all data on this device will be lost!  
+* The resulting image is available in `build/` and can be written to eMMC or SD card using a program like [Etcher](https://www.balena.io/etcher/). On the Linux command line you can use `dd`: once the target medium is connected to your computer, get the device name (e.g. `/dev/sdb`). Check it carefully, all data on this device will be lost!
   
   ```bash
   lsblk
-  sudo dd if=armbian-build/output/images/Armbian_5.77_Rockpro64_Debian_stretch_default_4.4.176.img of=/dev/sdb bs=64K conv=sync status=progress
+  sudo dd if=build/Armbian_5.77_Rockpro64_Debian_stretch_default_4.4.176.img of=/dev/sdb bs=64K conv=sync status=progress
   sync
   ```  
 

--- a/scripts/move-armbian-image.sh
+++ b/scripts/move-armbian-image.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# Move the armbian .img to build/.
+#
+set -eu
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+# TODO(hkjn): Consider defining these config values somewhere higher-level than inside this script.
+KERNEL_VERSION="${KERNEL_VERSION:-4.4.176}"
+ARMBIAN_VERSION="${ARMBIAN_VERSION:-5.77}"
+IMG_FILE="${SCRIPT_DIR}/../armbian/armbian-build/output/images/Armbian_${ARMBIAN_VERSION}_Rockpro64_Debian_stretch_default_${KERNEL_VERSION}.img"
+
+if [[ ! -e "${IMG_FILE}" ]]; then
+  echo "fatal: no Armbian image exists at expected path:" >&2
+  echo "  ${IMG_FILE}" >&2
+  exit 1
+fi
+mv -v "${IMG_FILE}" "${SCRIPT_DIR}/../build/"
+# Image moved successfully.
+exit 0


### PR DESCRIPTION
This setup simplifies the build process, by making all build outputs
(whether intermediary like Go binaries or the final Armbian build
output) end up in build/.