### PR TITLE
tools/bbbsupervisor: Rework supervisor to avoid 3rd party deps

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,5 +1,3 @@
 default:
 	$(MAKE) -C bbbfancontrol
-
-	# TODO(Stadicus): uncomment once bbbsupervisor compiles including all dependencies
-	#$(MAKE) -C bbbsupervisor
+	$(MAKE) -C bbbsupervisor


### PR DESCRIPTION
With this change, we have no 3rd party dependencies remaining for
bbbsupervisor.go.

If we fail to start the `journalctl` command or receive any output
on stderr, we currently pass on the message and crash with non-success
exit status.

Also enable building bbbsupervisor in tools/Makefile.