### PR TITLE
armbian/base: Allow ICMP/ping

### DIFF
--- a/armbian/base/config/iptables/iptables.rules
+++ b/armbian/base/config/iptables/iptables.rules
@@ -41,9 +41,9 @@
 
 # Allow inbound ICMP type 0, 3 and 8 ("Echo Reply", "Destination
 # Unreachable" and "Echo", i.e. ping).
-# -A INPUT -p icmp -m icmp --icmp-type 0 -j ACCEPT
-# -A INPUT -p icmp -m icmp --icmp-type 3 -j ACCEPT
-# -A INPUT -p icmp -m icmp --icmp-type 8 -j ACCEPT
+-A INPUT -p icmp -m icmp --icmp-type 0 -j ACCEPT
+-A INPUT -p icmp -m icmp --icmp-type 3 -j ACCEPT
+-A INPUT -p icmp -m icmp --icmp-type 8 -j ACCEPT
 
 # Explicitly whitelist established / related connections. This is a
 # last-ditch safeguard to avoid locking yourself out if a too-restrictive


### PR DESCRIPTION
I'm not sure why these ended up as commented out in aa44547af9679cfbdf7b945fc2093eeef2992da6, but it wasn't intentional, and the current state doesn't respond to `ping` since the packets end up being `DROP`'ed.