### PR TITLE
Configure main apps to log to systemd journal

### DIFF
--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -224,7 +224,7 @@ alias ll='ls $LS_OPTIONS -la'
 
 # Bitcoin
 alias bcli='bitcoin-cli -conf=/etc/bitcoin/bitcoin.conf'
-alias blog='tail -f /mnt/ssd/bitcoin/.bitcoin/testnet3/debug.log'
+alias blog='sudo journalctl -f -u bitcoind'
 
 # Lightning
 alias lcli='lightning-cli --lightning-dir=/mnt/ssd/bitcoin/.lightning-testnet'

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -326,13 +326,12 @@ testnet=1
 server=1
 listen=1
 listenonion=1
-daemon=1
 txindex=0
 prune=0
 disablewallet=1
-pid=/run/bitcoind/bitcoind.pid
 rpccookiefile=/mnt/ssd/bitcoin/.bitcoin/.cookie
 sysparms=1
+printtoconsole=1
 
 # rpc
 rpcconnect=127.0.0.1
@@ -356,12 +355,12 @@ Description=Bitcoin daemon
 After=network-online.target startup-checks.service tor.service
 Requires=startup-checks.service
 [Service]
-ExecStart=/opt/shift/scripts/systemd-start-bitcoind.sh
+ExecStart=/usr/bin/bitcoind -conf=/etc/bitcoin/bitcoin.conf
+ExecStartPost=/opt/shift/scripts/systemd-bitcoind-post.sh
 RuntimeDirectory=bitcoind
 User=bitcoin
 Group=bitcoin
-Type=forking
-PIDFile=/run/bitcoind/bitcoind.pid
+Type=simple
 Restart=always
 RestartSec=60
 TimeoutSec=300
@@ -419,7 +418,6 @@ lightning-dir=/mnt/ssd/bitcoin/.lightning-testnet
 bind-addr=127.0.0.1:9735
 proxy=127.0.0.1:9050
 log-level=debug
-daemon
 plugin=/opt/shift/scripts/prometheus-lightningd.py
 EOF
 
@@ -430,12 +428,12 @@ Wants=bitcoind.service
 After=bitcoind.service
 [Service]
 ExecStartPre=/bin/systemctl is-active bitcoind.service
-ExecStart=/opt/shift/scripts/systemd-start-lightningd.sh
+ExecStart=/usr/local/bin/lightningd --conf=/etc/lightningd/lightningd.conf
+ExecStartPost=/opt/shift/scripts/systemd-lightningd-post.sh
 RuntimeDirectory=lightningd
 User=bitcoin
 Group=bitcoin
-Type=forking
-#PIDFile=/run/lightningd/lightningd.pid
+Type=simple
 Restart=always
 RestartSec=10
 TimeoutSec=240
@@ -483,7 +481,7 @@ Wants=bitcoind.service
 After=bitcoind.service
 [Service]
 ExecStartPre=/bin/systemctl is-active bitcoind.service
-ExecStart=/opt/shift/scripts/systemd-start-electrs.sh
+ExecStart=/opt/shift/scripts/systemd-electrs-start.sh
 RuntimeDirectory=electrs
 User=electrs
 Group=bitcoin

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -132,7 +132,6 @@ case "${COMMAND}" in
                 case "${3}" in
                     mainnet)
                         sed -i '/CONFIGURED FOR/Ic\echo "Configured for Bitcoin MAINNET"; echo' /etc/update-motd.d/20-shift
-                        sed -i "/ALIAS BLOG=/Ic\alias blog='tail -f /mnt/ssd/bitcoin/.bitcoin/debug.log'" /home/base/.bashrc-custom
                         sed -i "/ALIAS LCLI=/Ic\alias lcli='lightning-cli --lightning-dir=/mnt/ssd/bitcoin/.lightning'" /home/base/.bashrc-custom
                         sed -i '/HIDDENSERVICEPORT 18333/Ic\HiddenServicePort 8333 127.0.0.1:8333' /etc/tor/torrc
                         sed -i '/TESTNET=/Ic\#testnet=1' /etc/bitcoin/bitcoin.conf
@@ -149,7 +148,6 @@ case "${COMMAND}" in
 
                     testnet)
                         sed -i '/CONFIGURED FOR/Ic\echo "Configured for Bitcoin TESTNET"; echo' /etc/update-motd.d/20-shift
-                        sed -i "/ALIAS BLOG=/Ic\alias blog='tail -f /mnt/ssd/bitcoin/.bitcoin/testnet3/debug.log'" /home/base/.bashrc-custom
                         sed -i "/ALIAS LCLI=/Ic\alias lcli='lightning-cli --lightning-dir=/mnt/ssd/bitcoin/.lightning-testnet'" /home/base/.bashrc-custom
                         sed -i '/HIDDENSERVICEPORT 8333/Ic\HiddenServicePort 18333 127.0.0.1:18333' /etc/tor/torrc
                         sed -i '/TESTNET=/Ic\testnet=1' /etc/bitcoin/bitcoin.conf

--- a/armbian/base/scripts/systemd-bitcoind-post.sh
+++ b/armbian/base/scripts/systemd-bitcoind-post.sh
@@ -1,19 +1,13 @@
 #!/bin/bash
 #
-# This script is called by the bitcoind.service to start bitcoind.
+# This script is called by the bitcoind.service AFTER starting bitcoind.
 #
-
-# wait a few seconds for Tor networking to be ready
-sleep 10
 
 # We set rpccookiefile=/mnt/ssd/bitcoin/.bitcoin/.cookie, but there seems to be
 # no way to specify where to expect the bitcoin cookie for c-lightning, so let's
 # create a symlink at the expected testnet location.
 mkdir -p /mnt/ssd/bitcoin/.bitcoin/testnet3/
 ln -fs /mnt/ssd/bitcoin/.bitcoin/.cookie /mnt/ssd/bitcoin/.bitcoin/testnet3/.cookie
-
-# start main bitcoind daemon
-/usr/bin/bitcoind -daemon -conf=/etc/bitcoin/bitcoin.conf
 
 # wait a few seconds before providing cookie authentication 
 # as .env file for electrs and base-middleware 

--- a/armbian/base/scripts/systemd-electrs-start.sh
+++ b/armbian/base/scripts/systemd-electrs-start.sh
@@ -8,7 +8,7 @@ source /etc/electrs/electrs.conf
 source /mnt/ssd/bitcoin/.bitcoin/.cookie.env
 
 # start main application
-/usr/bin/electrs \
+exec /usr/bin/electrs \
     --network ${NETWORK} \
     --db-dir ${DB_DIR} \
     --daemon-dir ${DAEMON_DIR} \

--- a/armbian/base/scripts/systemd-lightningd-post.sh
+++ b/armbian/base/scripts/systemd-lightningd-post.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 #
-# This script is called by the lightningd.service to start c-lightning.
+# This script is called by the lightningd.service AFTER starting c-lightning.
 #
-
-# start main lightningd daemon
-/usr/local/bin/lightningd --daemon --conf=/etc/lightningd/lightningd.conf
 
 # make available lightningd socket to group "bitcoin"
 source /opt/shift/sysconfig/BITCOIN_NETWORK


### PR DESCRIPTION
Configuration of `bitcoind` and `lightningd` to log to the systemd journal:
* run executable directly from the systemd unit file (not from a script)
* use option `printtoconsole` to log to stdout
* run as regular program (not `daemon`), otherwise `printtoconsole` is ignored
* run systemd unit as `Type=simple` due to not using the `daemon` option
