### PR TITLE
Makefile: Add docker-jekyll rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,16 @@
+# Ignore the github.com/armbian/build repo we check out during builds.
 /armbian/armbian-build
+# Ignore the local configuration overrides for Armbian build.
 /armbian/base/build/build-local.conf
+# Ignore the generated file holding current git commit for Armbian build.
 /armbian/base/config/latest_commit
-/build
+# Ignore compiled Go binaries.
 /tools/bbbfancontrol/bbbfancontrol
 /tools/bbbsupervisor/bbbsupervisor
+# Ignore vim swap files.
 *.sw?
+# Ignore Jekyll-generated files.
+/.jekyll-metadata
+/_site/
+# Ignore the build outputs.
+/build

--- a/Makefile
+++ b/Makefile
@@ -39,3 +39,10 @@ docker-build-go: dockerinit
 
 ci: dockerinit
 	./scripts/travis-ci.sh
+
+docker-jekyll: dockerinit
+	# TODO(hkjn): Investigate why we need the 'rm -rf', or else Jekyll throws errors like the
+	# following, seemingly trying to read a non-existing 'share' file under armbian/armbian-build/packages/bsp/common/usr/
+	#   No such file or directory @ realpath_rec - /srv/jekyll/armbian/armbian-build/packages/bsp/common/usr/share
+	rm -rf armbian/armbian-build/packages/bsp/common/usr/
+	docker run --rm -it -p 4000:4000 -v $(REPO_ROOT):/srv/jekyll jekyll/jekyll:pages jekyll serve --watch --incremental


### PR DESCRIPTION
Second attempt to make it easier to serve https://base.shiftcrypto.ch/ locally during development. (See https://github.com/digitalbitbox/bitbox-base/pull/37 for the first one.)

We no longer use Vagrant for builds, so the issues seen in #37 no longer should affect us.

We have another odd interaction however between the dockerized Armbian build process and Jekyll, where Jekyll appears to try to read a non-existing directory. In this change, we work around that issue by removing the parent directory from the build cache, and we also add a TODO to describe how this could be improved.