### PR TITLE
Setup CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,22 @@
+version: 2.0
+
+jobs:
+  "bbbase-ci":
+    machine: true
+    # working_directory: ~/
+    steps:
+      - run: uname -a
+      - run: make --version
+      - run: pwd
+      - checkout
+      - run: git log -1
+      - run: ls -lah
+      - run:
+          name: make docker-build-go
+          command: make docker-build-go
+workflows:
+  version: 2
+  build:
+    jobs:
+      - "bbbase-ci"
+


### PR DESCRIPTION
Please consider having an alternative CI, in case travis is down or slow.

In other projects CircleCI is starts and runs faster, but for bitbox-base it takes about the same amount.

example build with this PR's config
https://circleci.com/gh/thisconnect/bitbox-base/15

