### PR TITLE
.dockerignore: Also ignore _site/

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,1 +1,2 @@
 armbian/armbian-build/
+_site/


### PR DESCRIPTION
This directory is present if the user has run `make docker-jekyll`,
added in 5b3477c4, and can be multiple GB. Excluding it from Docker
builds speeds things up significantly.