### PR TITLE
Use host user for Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ RUN make -C "tools"
 
 # Final
 FROM golang:1.12.5-stretch as final
-
+ARG builder_uid
+RUN adduser --disabled-password --gecos "" --uid ${builder_uid} builder
+USER builder
 COPY --from=middleware-builder /go/src/github.com/digitalbitbox/bitbox-base/build/. /opt/build/.
 COPY --from=middleware-tools /go/src/github.com/digitalbitbox/bitbox-base/build/. /opt/build/.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 .DEFAULT_GOAL=build-all
 HAS_DOCKER := $(shell which docker 2>/dev/null)
 REPO_ROOT=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
+BUILDER_UID=$(shell id -u)
 
 check-docker:
 ifndef HAS_DOCKER
@@ -26,11 +27,10 @@ clean:
 	docker rmi digitalbitbox/bitbox-base
 
 dockerinit: check-docker
-	docker build --tag digitalbitbox/bitbox-base .
+	docker build --build-arg builder_uid=$(BUILDER_UID) --tag digitalbitbox/bitbox-base .
 
 docker-build-go: dockerinit
 	@echo "Building tools and middleware inside Docker container.."
-	docker build --tag digitalbitbox/bitbox-base .
 	docker run \
 	       --rm \
 	       --tty \


### PR DESCRIPTION
By using the same user inside the container as on the host, we avoid
issues with the host user lacking the privileges to e.g remove files
under `build/`, which are bind-mounted from the host into the container.

Before this change, those files would run as the super-user (`id -u` of
`0`), which caused the issues mentioned above, specifically on Gitlab,
where subsequent test runners would find themselves unable to clean up
the `build/` artifacts from prior builds.

The unfortunate edge case here is for users that (wisely!) require
`sudo` to run `docker` commands, there is no way for the `Makefile`
to deduce what their non-privileged user's id is. Those users
need to either deal with the super-user (id `0`, commonly `root`)
owning the files under `build/`, or to explicitly specify their
non-privileged user's id when calling `make` commands:

```
sudo make BUILDER_UID=$(id -u)
```