### PR TITLE
Revert "Use host user for Docker builds (#98)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,6 @@ RUN make -C "tools"
 
 # Final
 FROM golang:1.12.5-stretch as final
-ARG builder_uid
-RUN adduser --disabled-password --gecos "" --uid ${builder_uid} builder
-USER builder
+
 COPY --from=middleware-builder /go/src/github.com/digitalbitbox/bitbox-base/build/. /opt/build/.
 COPY --from=middleware-tools /go/src/github.com/digitalbitbox/bitbox-base/build/. /opt/build/.

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 .DEFAULT_GOAL=build-all
 HAS_DOCKER := $(shell which docker 2>/dev/null)
 REPO_ROOT=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-BUILDER_UID=$(shell id -u)
 
 check-docker:
 ifndef HAS_DOCKER
@@ -27,10 +26,11 @@ clean:
 	docker rmi digitalbitbox/bitbox-base
 
 dockerinit: check-docker
-	docker build --build-arg builder_uid=$(BUILDER_UID) --tag digitalbitbox/bitbox-base .
+	docker build --tag digitalbitbox/bitbox-base .
 
 docker-build-go: dockerinit
 	@echo "Building tools and middleware inside Docker container.."
+	docker build --tag digitalbitbox/bitbox-base .
 	docker run \
 	       --rm \
 	       --tty \

--- a/docs/base-image.md
+++ b/docs/base-image.md
@@ -28,19 +28,3 @@ Unpacking the steps above, what happens when you type `make` is:
 1. [`make build-all`](https://github.com/digitalbitbox/bitbox-base/blob/master/Makefile#L20): the default target if `make` is called, and depends on `make docker-build-go`, and after that performs the main Armbian image build
     1. [`cd armbian && make`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/Makefile): builds the Armbian `.img` file, using the Go binaries in `build/` as inputs
     1. finally, the `.img` file is moved to the `build/` directory
-
-### Overriding user for containerized builds
-
-By default, the `make` commands that use Docker to perform the builds will use a user with the same id as the calling user on the host.
-This behavior allows the build to produce outputs to the host `build/` directory without making it owned by the super-user (with id `0`), which could cause permission issues if the non-privileged host user attempts to delete files in the `build/` directory.
-Unfortunately, for users who choose to require `sudo` to run `docker` commands, this means that a command like `sudo make` will run as the super-user, so there is no way for the `make` command to find the non-privileged user's id.
-As a workaround, such users can either:
-
-1. run `make` and similar commands as usual, and deal with `build/` being owned by the super-user, i.e user with id `0`
-1. specify the non-privileged user explicitly when calling `make`:
-
-```bash
-sudo make BUILDER_UID=$(id -u)
-```
-
-Since the `id -u` is invoked before `sudo` has switched to the super-user, it will return the non-privileged user's id, making it available to the `Makefile`.


### PR DESCRIPTION
This reverts commit 0e5efd51eb8b082a2a014a7fe28f18d60504bdb5.

We noticed that 0e5efd51 introduced a regression, which made it
necessary for users who require `sudo` for their `docker` commands
to also specify `BUILDER_UID=$(id -u)` explicitly on the commandline.

(We were aware that this parameter was needed if users wanted to run
`docker` commands with `sudo`, and they also wanted the `build/`
directory to be owned by their non-privileged user, but it was not known
or intended that the build wouldn't work at all with `sudo make`.)