### PR TITLE
General stability improvements and scripting cleanup

### DIFF
--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -185,11 +185,15 @@ SYSCONFIG_PATH="/opt/shift/sysconfig"
 mkdir -p "${SYSCONFIG_PATH}"
 echo "BITCOIN_NETWORK=testnet" > "${SYSCONFIG_PATH}/BITCOIN_NETWORK"
 
-# store build information
+## store build information
 echo "BUILD_DATE='$(date +%Y-%m-%d)'" > "${SYSCONFIG_PATH}/BUILD_DATE"
 echo "BUILD_TIME='$(date +%H:%M)'" > "${SYSCONFIG_PATH}/BUILD_TIME"
 echo "BUILD_COMMIT='$(cat /opt/shift/config/latest_commit)'" > "${SYSCONFIG_PATH}/BUILD_COMMIT"
 
+## configure swap file (disable Armbian zram, configure custom swapfile on ssd)
+sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-zram-config
+echo "/mnt/ssd/swapfile swap swap defaults 0 0" >> /etc/fstab
+sysctl vm.swappiness=10
 
 # OS CONFIG --------------------------------------------------------------------
 # customize MOTD

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -192,8 +192,8 @@ echo "BUILD_COMMIT='$(cat /opt/shift/config/latest_commit)'" > "${SYSCONFIG_PATH
 
 ## configure swap file (disable Armbian zram, configure custom swapfile on ssd)
 sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-zram-config
+sed -i '/vm.swappiness=/Ic\vm.swappiness=10' /etc/sysctl.conf
 echo "/mnt/ssd/swapfile swap swap defaults 0 0" >> /etc/fstab
-sysctl vm.swappiness=10
 
 # OS CONFIG --------------------------------------------------------------------
 # customize MOTD

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -161,7 +161,7 @@ apt purge -y ntp network-manager
 # DEPENDENCIES -----------------------------------------------------------------
 apt update
 apt upgrade -y
-
+apt install -y  tmux
 apt install -y  git openssl net-tools fio libnss-mdns \
                 avahi-daemon avahi-discover avahi-utils \
                 fail2ban acl ifmetric
@@ -870,42 +870,6 @@ fi
 # mDNS services
 sed -i '/PUBLISH-WORKSTATION/Ic\publish-workstation=yes' /etc/avahi/avahi-daemon.conf
 
-cat << EOF > /etc/avahi/services/bitcoind.service
-<?xml version="1.0" standalone='no'?>
-<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
-<service-group>
-  <name>bitcoin</name>
-  <service>
-    <type>_bitcoin._tcp</type>
-    <port>18333</port>
-  </service>
-</service-group>
-EOF
-
-cat << 'EOF' > /etc/avahi/services/electrs.service
-<?xml version="1.0" standalone='no'?>
-<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
-<service-group>
-  <name>bitcoin electrum server</name>
-  <service>
-    <type>_electrumx-tls._tcp</type>
-    <port>50002</port>
-  </service>
-</service-group>
-EOF
-
-cat << 'EOF' > /etc/avahi/services/lightning.service
-<?xml version="1.0" standalone='no'?>
-<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
-<service-group>
-  <name>lightning</name>
-  <service>
-    <type>_lightning._tcp</type>
-    <port>9735</port>
-  </service>
-</service-group>
-EOF
-
 cat << 'EOF' > /etc/avahi/services/bitboxbase.service
 <?xml version="1.0" standalone='no'?>
 <!DOCTYPE service-group SYSTEM "avahi-service.dtd">
@@ -942,7 +906,7 @@ apt -y remove libllvm* build-essential libtool autotools-dev automake pkg-config
               gnome-icon-theme* gnupg2* gsettings-desktop-schemas* gtk-update-icon-cache* haveged* hdparm* hostapd* html2text* ifenslave* iotop* \
               iperf3* iputils-arping* iw* kbd* libatk1.0-0* libcroco3* libcups2* libdbus-glib-1-2* libgdk-pixbuf2.0-0* libglade2-0* libnl-3-dev* \
               libpango-1.0-0* libpolkit-agent-1-0* libpolkit-backend-1-0* libpolkit-gobject-1-0* libpython-stdlib* libpython2.7-stdlib* libssl-dev* \
-              locales* man-db* ncurses-term* psmisc* pv* python-avahi* python-pip* python2.7-minimal rsync* screen* shared-mime-info* \
+              man-db* ncurses-term* psmisc* pv* python-avahi* python-pip* python2.7-minimal rsync* screen* shared-mime-info* \
               unattended-upgrades* unicode-data* unzip* vim* wireless-regdb* wireless-tools* wpasupplicant*
 
 ## Delete unnecessary local files
@@ -950,6 +914,7 @@ rm -rf /usr/share/doc/*
 rm -rf /var/lib/apt/lists/*
 rm /usr/bin/test_bitcoin /usr/bin/bitcoin-qt /usr/bin/bitcoin-wallet
 find /var/log -maxdepth 1 -type f -delete
+locale-gen en_US.UTF-8
 
 ## Clean up
 apt install -f

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -154,30 +154,28 @@ if ! mountpoint /mnt/ssd -q; then
   chmod 700 /mnt/ssd
 fi
 
-apt remove -y ntp network-manager
-apt purge -y ntp network-manager
 
-
-# DEPENDENCIES -----------------------------------------------------------------
+# SOFTWARE PACKAGE MGMT --------------------------------------------------------
+## update system
 apt update
 apt upgrade -y
-apt install -y  tmux
-apt install -y  git openssl net-tools fio libnss-mdns \
-                avahi-daemon avahi-discover avahi-utils \
-                fail2ban acl ifmetric
 
+## remove unnecessary packages
+apt -y remove git
+apt -y remove libllvm* build-essential libtool autotools-dev automake pkg-config gcc gcc-6 libgcc-6-dev \
+              alsa-utils* autoconf* bc* bison* bridge-utils* btrfs-tools* bwm-ng* cmake* command-not-found* console-setup* \
+              console-setup-linux* crda* dconf-gsettings-backend* dconf-service* debconf-utils* device-tree-compiler* dialog* dirmngr* \
+              dnsutils* dosfstools* ethtool* evtest* f2fs-tools* f3* fancontrol* figlet* fio* flex* fping* glib-networking* glib-networking-services* \
+              gnome-icon-theme* gnupg2* gsettings-desktop-schemas* gtk-update-icon-cache* haveged* hdparm* hostapd* html2text* ifenslave* iotop* \
+              iperf3* iputils-arping* iw* kbd* libatk1.0-0* libcroco3* libcups2* libdbus-glib-1-2* libgdk-pixbuf2.0-0* libglade2-0* libnl-3-dev* \
+              libpango-1.0-0* libpolkit-agent-1-0* libpolkit-backend-1-0* libpolkit-gobject-1-0* libpython-stdlib* libpython2.7-stdlib* libssl-dev* \
+              man-db* ncurses-term* psmisc* pv* python-avahi* python-pip* python2.7-minimal rsync* screen* shared-mime-info* \
+              unattended-upgrades* unicode-data* unzip* vim* wireless-regdb* wireless-tools* wpasupplicant*
 
-# STARTUP CHECKS ---------------------------------------------------------------
-cat << 'EOF' > /etc/systemd/system/startup-checks.service
-[Unit]
-Description=BitBox Base startup checks
-After=network-online.target
-[Service]
-ExecStart=/opt/shift/scripts/systemd-startup-checks.sh
-Type=simple
-[Install]
-WantedBy=multi-user.target
-EOF
+# install dependecies
+apt install -y --no-install-recommends \
+  tmux git openssl network-manager net-tools fio libnss-mdns avahi-daemon avahi-discover avahi-utils fail2ban acl
+apt install -y --no-install-recommends ifmetric
 
 
 # SYSTEM CONFIGURATION ---------------------------------------------------------
@@ -195,8 +193,19 @@ sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-zram-config
 sed -i '/vm.swappiness=/Ic\vm.swappiness=10' /etc/sysctl.conf
 echo "/mnt/ssd/swapfile swap swap defaults 0 0" >> /etc/fstab
 
-# OS CONFIG --------------------------------------------------------------------
-# customize MOTD
+## startup checks
+cat << 'EOF' > /etc/systemd/system/startup-checks.service
+[Unit]
+Description=BitBox Base startup checks
+After=network-online.target
+[Service]
+ExecStart=/opt/shift/scripts/systemd-startup-checks.sh
+Type=simple
+[Install]
+WantedBy=multi-user.target
+EOF
+
+## customize ssh login message
 echo "MOTD_DISABLE='header tips updates armbian-config'" >> /etc/default/armbian-motd
 cat << EOF > /etc/update-motd.d/20-shift
 #!/bin/bash
@@ -210,13 +219,13 @@ echo "Configured for Bitcoin TESTNET"; echo
 EOF
 chmod 755 /etc/update-motd.d/20-shift
 
-# set hostname
+## set hostname
 /opt/shift/scripts/bbb-config.sh set hostname "${BASE_HOSTNAME}"
 
-# prepare SSD mount point
+## prepare SSD mount point
 mkdir -p /mnt/ssd/
 
-# add shortcuts
+## add shortcuts
 cat << EOF > /home/base/.bashrc-custom
 export LS_OPTIONS='--color=auto'
 alias l='ls $LS_OPTIONS -l'
@@ -232,9 +241,6 @@ alias llog='sudo journalctl -f -u lightningd'
 
 # Electrum
 alias elog='sudo journalctl -n 100 -f -u electrs'
-
-export PATH=$PATH:/usr/local/go/bin
-export GOPATH=$HOME/go
 EOF
 
 echo "source /home/base/.bashrc-custom" >> /home/base/.bashrc
@@ -250,10 +256,10 @@ lightning       9735/tcp
 middleware      8845/tcp
 EOF
 
-# retain journal logs between reboots 
+## retain journal logs between reboots 
 ln -sf /mnt/ssd/system/journal/ /var/log/journal
 
-# make bbb scripts executable with sudo
+## make bbb scripts executable with sudo
 sudo ln -s /opt/shift/scripts/bbb-config.sh    /usr/local/sbin/bbb-config.sh
 sudo ln -s /opt/shift/scripts/bbb-systemctl.sh /usr/local/sbin/bbb-systemctl.sh
 
@@ -268,17 +274,13 @@ fi
 apt update
 apt -y install tor --no-install-recommends
 
-# allow user 'bitcoin' to access Tor proxy socket
+## allow user 'bitcoin' to access Tor proxy socket
 usermod -a -G debian-tor bitcoin
 
 cat << EOF > /etc/tor/torrc
 ControlPort 9051                                          #TOR#
 CookieAuthentication 1                                    #TOR#
 CookieAuthFileGroupReadable 1                             #TOR#
-
-HiddenServiceDir /var/lib/tor/hidden_service_bitcoind/    #BITCOIND#
-HiddenServiceVersion 3                                    #BITCOIND#
-HiddenServicePort 18333 127.0.0.1:18333                   #BITCOIND#
 
 HiddenServiceDir /var/lib/tor/hidden_service_ssh/         #SSH#
 HiddenServiceVersion 3                                    #SSH#
@@ -287,9 +289,6 @@ HiddenServicePort 22 127.0.0.1:22                         #SSH#
 HiddenServiceDir /var/lib/tor/hidden_service_electrum/    #ELECTRUM#
 HiddenServiceVersion 3                                    #ELECTRUM#
 HiddenServicePort 50002 127.0.0.1:50002                   #ELECTRUM#
-
-HiddenServiceDir /var/lib/tor/lightningd-service_v2/      #LN2#
-HiddenServicePort 9375 127.0.0.1:9735                     #LN2#
 
 HiddenServiceDir /var/lib/tor/lightningd-service_v3/      #LN#
 HiddenServiceVersion 3                                    #LN#
@@ -395,7 +394,7 @@ if [ "${BASE_BUILD_LIGHTNINGD}" == "true" ]; then
 
 else
   cd /usr/local/src/
-  # temporary storage of 'lightningd' until official arm64 binaries work with stable Armbian release
+  ## temporary storage of 'lightningd' until official arm64 binaries work with stable Armbian release
   curl --retry 5 -SLO https://github.com/digitalbitbox/bitbox-base-deps/releases/download/${BIN_DEPS_TAG}/lightningd_${LIGHTNING_VERSION}-1_arm64.deb
   if ! echo "52be094f8162749acb207bf9ad08125d25288a9d03eb25690f364ba42fcff3c4  lightningd_0.7.0-1_arm64.deb" | sha256sum -c -; then
     echo "sha256sum for precompiled 'lightningd' failed" >&2
@@ -403,7 +402,7 @@ else
   fi
   dpkg -i lightningd_${LIGHTNING_VERSION}-1_arm64.deb
 
-  # symlink is needed, as the direct compilation (default) installs into /usr/local/bin, while this package uses '/usr/bin'
+  ## symlink is needed, as the direct compilation (default) installs into /usr/local/bin, while this package uses '/usr/bin'
   ln -s /usr/bin/lightningd /usr/local/bin/lightningd
   
 fi
@@ -453,7 +452,7 @@ ELECTRS_VERSION="0.6.2"
 
 mkdir -p /usr/local/src/electrs/
 cd /usr/local/src/electrs/
-# temporary storage of 'electrs' until official binary releases are available
+## temporary storage of 'electrs' until official binary releases are available
 curl --retry 5 -SLO https://github.com/digitalbitbox/bitbox-base-deps/releases/download/${BIN_DEPS_TAG}/electrs-${ELECTRS_VERSION}-aarch64-linux-gnu.tar.gz
 if ! echo "291e05c33c83002245b5805574001424f6f45be926fef81a2d74b12c5002509f  electrs-${ELECTRS_VERSION}-aarch64-linux-gnu.tar.gz" | sha256sum -c -; then
   echo "sha256sum for precompiled 'electrs' failed" >&2
@@ -823,12 +822,12 @@ sed -i 's/"exited_cleanly":false/"exited_cleanly":true/; s/"exit_type":"[^"]\+"/
 chromium --disable-infobars --kiosk --incognito 'http://localhost/info/d/BitBoxBase/bitbox-base?refresh=10s&from=now-24h&to=now&kiosk'
 EOF
 
-  # start x-server on user 'hdmi' login
+  ## start x-server on user 'hdmi' login
   cat << 'EOF' > /home/hdmi/.bashrc
 startx -- -nocursor && exit
 EOF
 
-  # enable autologin for user 'hdmi'
+  ## enable autologin for user 'hdmi'
   if [[ "${BASE_DASHBOARD_HDMI_ENABLED}" == "true" ]]; then
     /opt/shift/scripts/bbb-config.sh enable dashboard_hdmi
   fi
@@ -836,22 +835,6 @@ EOF
 fi
 
 # NETWORK ----------------------------------------------------------------------
-cat << 'EOF' > /etc/NetworkManager/NetworkManager.conf
-[main]
-plugins=ifupdown,keyfile
-
-[ifupdown]
-managed=false
-EOF
-
-cat << 'EOF' > /etc/systemd/network/ethernet.network
-[Match]
-Name=eth*
-
-[Network]
-DHCP=yes
-EOF
-
 cat << 'EOF' > /etc/systemd/resolved.conf
 [Resolve]
 FallbackDNS=1.1.1.1 8.8.8.8 8.8.4.4 2001:4860:4860::8888 2001:4860:4860::8844
@@ -859,7 +842,7 @@ DNSSEC=yes
 Cache=yes
 EOF
 
-# include Wifi credentials, if specified
+## include Wifi credentials, if specified (experimental)
 if [[ -n "${BASE_WIFI_SSID}" ]]; then
   sed -i "/WPA-SSID/Ic\  wpa-ssid ${BASE_WIFI_SSID}" /opt/shift/config/wifi/wlan0.conf
   sed -i "/WPA-PSK/Ic\  wpa-psk ${BASE_WIFI_PW}" /opt/shift/config/wifi/wlan0.conf
@@ -867,7 +850,7 @@ if [[ -n "${BASE_WIFI_SSID}" ]]; then
   echo "WIFI=1" > ${SYSCONFIG_PATH}/WIFI
 fi
 
-# mDNS services
+## mDNS services
 sed -i '/PUBLISH-WORKSTATION/Ic\publish-workstation=yes' /etc/avahi/avahi-daemon.conf
 
 cat << 'EOF' > /etc/avahi/services/bitboxbase.service
@@ -882,7 +865,7 @@ cat << 'EOF' > /etc/avahi/services/bitboxbase.service
 </service-group>
 EOF
 
-# firewall: restore iptables rules on startup
+## firewall: restore iptables rules on startup
 cat << 'EOF' > /etc/systemd/system/iptables-restore.service
 [Unit]
 Description=BitBox Base: restore iptables rules
@@ -897,17 +880,8 @@ EOF
 
 # FINALIZE ---------------------------------------------------------------------
 
-## Remove unnecessary packages
+## Remove build-only packages
 apt -y remove git
-apt -y remove libllvm* build-essential libtool autotools-dev automake pkg-config gcc gcc-6 libgcc-6-dev \
-              alsa-utils* autoconf* bc* bison* bridge-utils* btrfs-tools* bwm-ng* cmake* command-not-found* console-setup* \
-              console-setup-linux* crda* dconf-gsettings-backend* dconf-service* debconf-utils* device-tree-compiler* dialog* dirmngr* \
-              dnsutils* dosfstools* ethtool* evtest* f2fs-tools* f3* fancontrol* figlet* fio* flex* fping* glib-networking* glib-networking-services* \
-              gnome-icon-theme* gnupg2* gsettings-desktop-schemas* gtk-update-icon-cache* haveged* hdparm* hostapd* html2text* ifenslave* iotop* \
-              iperf3* iputils-arping* iw* kbd* libatk1.0-0* libcroco3* libcups2* libdbus-glib-1-2* libgdk-pixbuf2.0-0* libglade2-0* libnl-3-dev* \
-              libpango-1.0-0* libpolkit-agent-1-0* libpolkit-backend-1-0* libpolkit-gobject-1-0* libpython-stdlib* libpython2.7-stdlib* libssl-dev* \
-              man-db* ncurses-term* psmisc* pv* python-avahi* python-pip* python2.7-minimal rsync* screen* shared-mime-info* \
-              unattended-upgrades* unicode-data* unzip* vim* wireless-regdb* wireless-tools* wpasupplicant*
 
 ## Delete unnecessary local files
 rm -rf /usr/share/doc/*
@@ -939,7 +913,7 @@ systemctl enable grafana-server.service
 systemctl enable base-middleware.service
 systemctl enable iptables-restore.service
 
-# Set to mainnet if configured
+## Set to mainnet if configured
 if [ "${BASE_BITCOIN_NETWORK}" == "mainnet" ]; then
   /opt/shift/scripts/bbb-config.sh set bitcoin_network mainnet
 fi

--- a/armbian/base/config/grafana/dashboard/grafana_bitbox_base.json
+++ b/armbian/base/config/grafana/dashboard/grafana_bitbox_base.json
@@ -17,7 +17,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1559726386323,
+  "iteration": 1561969474956,
   "links": [],
   "panels": [
     {
@@ -930,7 +930,7 @@
             "h": 2,
             "w": 3,
             "x": 0,
-            "y": 10
+            "y": 6
           },
           "id": 87,
           "links": [],
@@ -960,7 +960,7 @@
             "h": 8,
             "w": 10,
             "x": 3,
-            "y": 10
+            "y": 6
           },
           "id": 24,
           "legend": {
@@ -1084,7 +1084,7 @@
             "h": 8,
             "w": 11,
             "x": 13,
-            "y": 10
+            "y": 6
           },
           "id": 50,
           "legend": {
@@ -1187,7 +1187,7 @@
             "h": 2,
             "w": 3,
             "x": 0,
-            "y": 12
+            "y": 8
           },
           "id": 88,
           "links": [],
@@ -1212,7 +1212,7 @@
             "h": 2,
             "w": 3,
             "x": 0,
-            "y": 14
+            "y": 10
           },
           "id": 90,
           "links": [],
@@ -1240,7 +1240,7 @@
             "h": 8,
             "w": 10,
             "x": 3,
-            "y": 18
+            "y": 14
           },
           "id": 52,
           "legend": {
@@ -1367,7 +1367,7 @@
             "h": 8,
             "w": 11,
             "x": 13,
-            "y": 18
+            "y": 14
           },
           "id": 32,
           "legend": {
@@ -1460,6 +1460,310 @@
               "max": null,
               "min": null,
               "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "Apps": "#629E51",
+            "Buffers": "#614D93",
+            "Cache": "#6D1F62",
+            "Cached": "#511749",
+            "Committed": "#508642",
+            "Free": "#0A437C",
+            "Harware Corrupted - Amount of RAM that the kernel identified as corrupted / not working": "#CFFAFF",
+            "Inactive": "#584477",
+            "PageTables": "#0A50A1",
+            "Page_Tables": "#0A50A1",
+            "RAM_Free": "#E0F9D7",
+            "SWAP Used": "#BF1B00",
+            "Slab": "#806EB7",
+            "Slab_Cache": "#E0752D",
+            "Swap": "#BF1B00",
+            "Swap Used": "#BF1B00",
+            "Swap_Cache": "#C15C17",
+            "Swap_Free": "#2F575E",
+            "Unused": "#EAB839"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 2,
+          "description": "Basic memory usage",
+          "fill": 4,
+          "gridPos": {
+            "h": 10,
+            "w": 10,
+            "x": 0,
+            "y": 22
+          },
+          "id": 96,
+          "legend": {
+            "alignAsTable": false,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": 350,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxPerRow": 6,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [
+            {
+              "alias": "RAM Total",
+              "color": "#E0F9D7",
+              "fill": 0,
+              "stack": false
+            },
+            {
+              "alias": "RAM Cache + Buffer",
+              "color": "#052B51"
+            },
+            {
+              "alias": "RAM Free",
+              "color": "#7EB26D"
+            },
+            {
+              "alias": "Avaliable",
+              "color": "#DEDAF7",
+              "fill": 0,
+              "stack": false
+            }
+          ],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "node_memory_MemTotal_bytes{instance=~\"$node:$port\",job=~\"$job\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "RAM Total",
+              "refId": "A",
+              "step": 240
+            },
+            {
+              "expr": "node_memory_MemTotal_bytes{instance=~\"$node:$port\",job=~\"$job\"} - node_memory_MemFree_bytes{instance=~\"$node:$port\",job=~\"$job\"} - (node_memory_Cached_bytes{instance=~\"$node:$port\",job=~\"$job\"} + node_memory_Buffers_bytes{instance=~\"$node:$port\",job=~\"$job\"})",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "RAM Used",
+              "refId": "D",
+              "step": 240
+            },
+            {
+              "expr": "node_memory_Cached_bytes{instance=~\"$node:$port\",job=~\"$job\"} + node_memory_Buffers_bytes{instance=~\"$node:$port\",job=~\"$job\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "RAM Cache + Buffer",
+              "refId": "B",
+              "step": 240
+            },
+            {
+              "expr": "node_memory_MemFree_bytes{instance=~\"$node:$port\",job=~\"$job\"}",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "RAM Free",
+              "refId": "F",
+              "step": 240
+            },
+            {
+              "expr": "(node_memory_SwapTotal_bytes{instance=~\"$node:$port\",job=~\"$job\"} - node_memory_SwapFree_bytes{instance=~\"$node:$port\",job=~\"$job\"})",
+              "format": "time_series",
+              "intervalFactor": 2,
+              "legendFormat": "SWAP Used",
+              "refId": "G",
+              "step": 240
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "RAM memory",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": "",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "short",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": false
+            }
+          ],
+          "yaxis": {
+            "align": false,
+            "alignLevel": null
+          }
+        },
+        {
+          "aliasColors": {
+            "Apps": "#629E51",
+            "Buffers": "#614D93",
+            "Cache": "#6D1F62",
+            "Cached": "#511749",
+            "Committed": "#508642",
+            "Free": "#0A437C",
+            "Harware Corrupted - Amount of RAM that the kernel identified as corrupted / not working": "#CFFAFF",
+            "Inactive": "#584477",
+            "PageTables": "#0A50A1",
+            "Page_Tables": "#0A50A1",
+            "RAM_Free": "#E0F9D7",
+            "Slab": "#806EB7",
+            "Slab_Cache": "#E0752D",
+            "Swap": "#BF1B00",
+            "Swap_Cache": "#C15C17",
+            "Swap_Free": "#2F575E",
+            "Unused": "#EAB839"
+          },
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "Prometheus",
+          "decimals": 2,
+          "fill": 2,
+          "gridPos": {
+            "h": 10,
+            "w": 14,
+            "x": 10,
+            "y": 22
+          },
+          "id": 92,
+          "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": true,
+            "min": true,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": 350,
+            "total": false,
+            "values": true
+          },
+          "lines": true,
+          "linewidth": 1,
+          "links": [],
+          "maxPerRow": 6,
+          "nullPointMode": "null",
+          "percentage": false,
+          "pointradius": 5,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": true,
+          "steppedLine": false,
+          "targets": [
+            {
+              "expr": "node_memory_Inactive_file_bytes{instance=~\"$node:$port\",job=~\"$job\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "Inactive_file - File-backed memory on inactive LRU list",
+              "refId": "A",
+              "step": 4
+            },
+            {
+              "expr": "node_memory_Inactive_anon_bytes{instance=~\"$node:$port\",job=~\"$job\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "Inactive_anon - Anonymous and swap cache on inactive LRU list, including tmpfs (shmem)",
+              "refId": "D",
+              "step": 4
+            },
+            {
+              "expr": "node_memory_Active_file_bytes{instance=~\"$node:$port\",job=~\"$job\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "Active_file - File-backed memory on active LRU list",
+              "refId": "B",
+              "step": 4
+            },
+            {
+              "expr": "node_memory_Active_anon_bytes{instance=~\"$node:$port\",job=~\"$job\"}",
+              "format": "time_series",
+              "hide": false,
+              "intervalFactor": 2,
+              "legendFormat": "Active_anon - Anonymous and swap cache on active least-recently-used (LRU) list, including tmpfs",
+              "refId": "C",
+              "step": 4
+            }
+          ],
+          "thresholds": [],
+          "timeFrom": null,
+          "timeRegions": [],
+          "timeShift": null,
+          "title": "RAM Memory Active / Inactive",
+          "tooltip": {
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+          },
+          "type": "graph",
+          "xaxis": {
+            "buckets": null,
+            "mode": "time",
+            "name": null,
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "bytes",
+              "label": "Bytes",
+              "logBase": 1,
+              "max": null,
+              "min": "0",
+              "show": true
+            },
+            {
+              "format": "bytes",
+              "label": null,
+              "logBase": 1,
+              "max": null,
+              "min": null,
+              "show": true
             }
           ],
           "yaxis": {
@@ -3899,7 +4203,7 @@
     ]
   },
   "time": {
-    "from": "now-6h",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -3926,5 +4230,5 @@
   "timezone": "",
   "title": "BitBox Base",
   "uid": "BitBoxBase",
-  "version": 19
+  "version": 20
 }

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -144,7 +144,6 @@ case "${COMMAND}" in
                         sed -i '/RPCPORT=/Ic\RPCPORT=8332' /etc/electrs/electrs.conf
                         sed -i '/BITCOIN_RPCPORT=/Ic\BITCOIN_RPCPORT=8332' /etc/base-middleware/base-middleware.conf
                         sed -i '/LIGHTNING_RPCPATH=/Ic\LIGHTNING_RPCPATH=/mnt/ssd/bitcoin/.lightning/lightning-rpc' /etc/base-middleware/base-middleware.conf
-                        sed -i '/<PORT>18333/Ic\<port>8333</port>' /etc/avahi/services/bitcoind.service
                         echo "BITCOIN_NETWORK=mainnet" > "${SYSCONFIG_PATH}/${SETTING}"
                         ;;
 
@@ -160,7 +159,6 @@ case "${COMMAND}" in
                         sed -i '/RPCPORT=/Ic\RPCPORT=18332' /etc/electrs/electrs.conf
                         sed -i '/BITCOIN_RPCPORT=/Ic\BITCOIN_RPCPORT=18332' /etc/base-middleware/base-middleware.conf
                         sed -i '/LIGHTNING_RPCPATH=/Ic\LIGHTNING_RPCPATH=/mnt/ssd/bitcoin/.lightning-testnet/lightning-rpc' /etc/base-middleware/base-middleware.conf
-                        sed -i '/<PORT>8333/Ic\<port>18333</port>' /etc/avahi/services/bitcoind.service
                         echo "BITCOIN_NETWORK=testnet" > "${SYSCONFIG_PATH}/${SETTING}"
                         ;;
 


### PR DESCRIPTION
Minor improvements
* disable UART serical console output, as a preparation for HSM connectivity
* disable Armbian ZRAM swapfile and replace it with custom swapfile on SSD (includes additional Grafana charts)
* allow `bbb-config.sh exec bitcoind_reindex` to wipe chainstate and reindex downloaded blocks
* use standard `network-manager` instead of hardcoded files
* remove unnecessary Avahi service announcements
* general cleanup of customize script