### PR TITLE
Move to Ubuntu 18.04 and read-only rootfs

### DIFF
--- a/armbian/Makefile
+++ b/armbian/Makefile
@@ -12,5 +12,8 @@ update:
 mender-artefacts:
 	bash $(MAKE_PATH)/mender-convert.sh
 
+build-ondevice:
+	bash $(MAKE_PATH)/build.sh ondevice
+
 clean:
 	rm -rf $(MAKE_PATH)/armbian/armbian-build

--- a/armbian/base/build/build.conf
+++ b/armbian/base/build/build.conf
@@ -43,5 +43,4 @@
 # Build c-lightning from source (true), or use prebuilt binary (false)
 # the prebuilt binary speeds up the image build process and is meant for development only
 # https://github.com/digitalbitbox/bitbox-base-deps
-
 #BASE_BUILD_LIGHTNINGD="true"

--- a/armbian/base/build/build.conf
+++ b/armbian/base/build/build.conf
@@ -44,3 +44,7 @@
 # the prebuilt binary speeds up the image build process and is meant for development only
 # https://github.com/digitalbitbox/bitbox-base-deps
 #BASE_BUILD_LIGHTNINGD="true"
+
+# Make root filesystem read-only and overlay it with a temporary filesystem.
+# All changes are lost on reboot, guaranteeing a safe state (experimental)
+#BASE_OVERLAYROOT="false"

--- a/armbian/base/build/build.conf
+++ b/armbian/base/build/build.conf
@@ -45,6 +45,9 @@
 # https://github.com/digitalbitbox/bitbox-base-deps
 #BASE_BUILD_LIGHTNINGD="true"
 
+# Remove unnecessary packages (takes a while, but reduces image size by 50%)
+#BASE_MINIMAL="true"
+
 # Make root filesystem read-only and overlay it with a temporary filesystem.
 # All changes are lost on reboot, guaranteeing a safe state (experimental)
 #BASE_OVERLAYROOT="false"

--- a/armbian/base/build/build.conf
+++ b/armbian/base/build/build.conf
@@ -15,17 +15,17 @@
 
 # Auto-initialize SSD: <true|false> 
 # WARNING: existing data on external drive is deleted!
-#BASE_AUTOSETUP_SSD=1
+#BASE_AUTOSETUP_SSD="true"
 
 # Manual root password, 8 characters min, with numbers
 # WARNING: very unsafe, for DEVELOPMENT ONLY!
 #BASE_ROOTPW=""
 
 # Enable root login for SSH: <true|false> 
-#BASE_SSH_ROOT_LOGIN=false
+#BASE_SSH_ROOT_LOGIN="false"
 
 # Enable password login for SSH: <true|false> 
-#BASE_SSH_PASSWORD_LOGIN=false
+#BASE_SSH_PASSWORD_LOGIN="false"
 
 # Wifi settings (optional)
 #BASE_WIFI_SSID=""

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -49,6 +49,7 @@ CONFIGURATION:
 BUILD OPTIONS:
     BUILD MODE:         ${BASE_BUILDMODE}
     LINUX DISTRIBUTION: ${BASE_DISTRIBUTION}
+    MINIMAL IMAGE:      ${BASE_MINIMAL}
     BUILD LIGHTNINGD:   ${BASE_BUILD_LIGHTNINGD}
     HDMI OUTPUT:        ${BASE_HDMI_BUILD}
 ================================================================================
@@ -66,6 +67,7 @@ source /opt/shift/build/build-local.conf || true
 
 BASE_BUILDMODE=${1:-"armbian-build"}
 BASE_DISTRIBUTION=${BASE_DISTRIBUTION:-"stretch"}
+BASE_MINIMAL=${BASE_MINIMAL:-"true"}
 BASE_HOSTNAME=${BASE_HOSTNAME:-"bitbox-base"}
 BASE_BITCOIN_NETWORK=${BASE_BITCOIN_NETWORK:-"testnet"}
 BASE_AUTOSETUP_SSD=${BASE_AUTOSETUP_SSD:-"false"}
@@ -182,29 +184,31 @@ apt -y upgrade
 apt -y --fix-broken install
 
 ## remove unnecessary packages (only when building image, not ondevice)
-if [[ "${BASE_BUILDMODE}" != "ondevice" ]]; then
+if [[ "${BASE_BUILDMODE}" != "ondevice" ]] && [[ "${BASE_MINIMAL}" == "true" ]]; then
   pkgToRemove="git libllvmkk build-essential libtool autotools-dev automake pkg-config gcc gcc-6 libgcc-6-dev
-  alsa-utils* autoconf* bc* bison* bridge-utils* btrfs-tools* bwm-ng* cmake* command-not-found* console-setup*"
+  alsa-utils* autoconf* bc* bison* bridge-utils* btrfs-tools* bwm-ng* cmake* command-not-found* console-setup*
+  console-setup-linux* crda* dconf-gsettings-backend* dconf-service* debconf-utils* device-tree-compiler* dialog* dirmngr* 
+  dnsutils* dosfstools* ethtool* evtest* f2fs-tools* f3* fancontrol* figlet* fio* flex* fping* glib-networking* glib-networking-services* 
+  gnome-icon-theme* gnupg2* gsettings-desktop-schemas* gtk-update-icon-cache* haveged* hdparm* hostapd* html2text* ifenslave* iotop* 
+  iperf3* iputils-arping* iw* kbd* libatk1.0-0* libcroco3* libcups2* libdbus-glib-1-2* libgdk-pixbuf2.0-0* libglade2-0* libnl-3-dev* 
+  libpango-1.0-0* libpolkit-agent-1-0* libpolkit-backend-1-0* libpolkit-gobject-1-0* libpython-stdlib* libpython2.7-stdlib* libssl-dev* 
+  man-db* ncurses-term* psmisc* pv* python-avahi* python-pip* python2.7-minimal screen* shared-mime-info* 
+  unattended-upgrades* unicode-data* unzip* vim* wireless-regdb* wireless-tools* wpasupplicant* "
 
 for pkg in $pkgToRemove
 do
   apt -y remove "$pkg" || true
 done
 
-#                 alsa-utils* autoconf* bc* bison* bridge-utils* btrfs-tools* bwm-ng* cmake* command-not-found* console-setup* \
-#                 console-setup-linux* crda* dconf-gsettings-backend* dconf-service* debconf-utils* device-tree-compiler* dialog* dirmngr* \
-#                 dnsutils* dosfstools* ethtool* evtest* f2fs-tools* f3* fancontrol* figlet* fio* flex* fping* glib-networking* glib-networking-services* \
-#                 gnome-icon-theme* gnupg2* gsettings-desktop-schemas* gtk-update-icon-cache* haveged* hdparm* hostapd* html2text* ifenslave* iotop* \
-#                 iperf3* iputils-arping* iw* kbd* libatk1.0-0* libcroco3* libcups2* libdbus-glib-1-2* libgdk-pixbuf2.0-0* libglade2-0* libnl-3-dev* \
-#                 libpango-1.0-0* libpolkit-agent-1-0* libpolkit-backend-1-0* libpolkit-gobject-1-0* libpython-stdlib* libpython2.7-stdlib* libssl-dev* \
-#                 man-db* ncurses-term* psmisc* pv* python-avahi* python-pip* python2.7-minimal screen* shared-mime-info* \
-#                 unattended-upgrades* unicode-data* unzip* vim* wireless-regdb* wireless-tools* wpasupplicant*
+  apt -y --fix-broken install
 fi
+
 
 # install dependecies
 apt install -y --no-install-recommends \
-  tmux git openssl network-manager net-tools fio libnss-mdns avahi-daemon avahi-discover avahi-utils fail2ban acl rsync
+  git openssl network-manager net-tools fio libnss-mdns avahi-daemon avahi-discover avahi-utils fail2ban acl rsync
 apt install -y --no-install-recommends ifmetric
+apt install -y --no-install-recommends tmux
 
 
 # SYSTEM CONFIGURATION ---------------------------------------------------------

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -191,7 +191,6 @@ echo "BUILD_COMMIT='$(cat /opt/shift/config/latest_commit)'" > "${SYSCONFIG_PATH
 ## configure swap file (disable Armbian zram, configure custom swapfile on ssd)
 sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-zram-config
 sed -i '/vm.swappiness=/Ic\vm.swappiness=10' /etc/sysctl.conf
-echo "/mnt/ssd/swapfile swap swap defaults 0 0" >> /etc/fstab
 
 ## startup checks
 cat << 'EOF' > /etc/systemd/system/startup-checks.service

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -240,6 +240,8 @@ alias llog='sudo journalctl -f -u lightningd'
 
 # Electrum
 alias elog='sudo journalctl -n 100 -f -u electrs'
+
+export PATH=$PATH:/sbin:/usr/local/sbin
 EOF
 
 echo "source /home/base/.bashrc-custom" >> /home/base/.bashrc

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -169,12 +169,12 @@ apt -y remove libllvm* build-essential libtool autotools-dev automake pkg-config
               gnome-icon-theme* gnupg2* gsettings-desktop-schemas* gtk-update-icon-cache* haveged* hdparm* hostapd* html2text* ifenslave* iotop* \
               iperf3* iputils-arping* iw* kbd* libatk1.0-0* libcroco3* libcups2* libdbus-glib-1-2* libgdk-pixbuf2.0-0* libglade2-0* libnl-3-dev* \
               libpango-1.0-0* libpolkit-agent-1-0* libpolkit-backend-1-0* libpolkit-gobject-1-0* libpython-stdlib* libpython2.7-stdlib* libssl-dev* \
-              man-db* ncurses-term* psmisc* pv* python-avahi* python-pip* python2.7-minimal rsync* screen* shared-mime-info* \
+              man-db* ncurses-term* psmisc* pv* python-avahi* python-pip* python2.7-minimal screen* shared-mime-info* \
               unattended-upgrades* unicode-data* unzip* vim* wireless-regdb* wireless-tools* wpasupplicant*
 
 # install dependecies
 apt install -y --no-install-recommends \
-  tmux git openssl network-manager net-tools fio libnss-mdns avahi-daemon avahi-discover avahi-utils fail2ban acl
+  tmux git openssl network-manager net-tools fio libnss-mdns avahi-daemon avahi-discover avahi-utils fail2ban acl rsync
 apt install -y --no-install-recommends ifmetric
 
 
@@ -258,6 +258,8 @@ middleware      8845/tcp
 EOF
 
 ## retain journal logs between reboots 
+## /etc/default/armbian-zram-config
+/usr/lib/armbian/armbian-ramlog write
 ln -sf /mnt/ssd/system/journal/ /var/log/journal
 
 ## make bbb scripts executable with sudo

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -195,10 +195,10 @@ if [[ "${BASE_BUILDMODE}" != "ondevice" ]] && [[ "${BASE_MINIMAL}" == "true" ]];
   man-db* ncurses-term* psmisc* pv* python-avahi* python-pip* python2.7-minimal screen* shared-mime-info* 
   unattended-upgrades* unicode-data* unzip* vim* wireless-regdb* wireless-tools* wpasupplicant* "
 
-for pkg in $pkgToRemove
-do
-  apt -y remove "$pkg" || true
-done
+  for pkg in $pkgToRemove
+  do
+    apt -y remove "$pkg" || true
+  done
 
   apt -y --fix-broken install
 fi
@@ -301,8 +301,8 @@ EOF
 ln -sf /mnt/ssd/system/journal/ /var/log/journal
 
 ## make bbb scripts executable with sudo
-sudo ln -sf /opt/shift/scripts/bbb-config.sh    /usr/local/sbin/bbb-config.sh
-sudo ln -sf /opt/shift/scripts/bbb-systemctl.sh /usr/local/sbin/bbb-systemctl.sh
+ln -sf /opt/shift/scripts/bbb-config.sh    /usr/local/sbin/bbb-config.sh
+ln -sf /opt/shift/scripts/bbb-systemctl.sh /usr/local/sbin/bbb-systemctl.sh
 
 
 # TOR --------------------------------------------------------------------------
@@ -865,7 +865,7 @@ EOF
 # DASHBOARD OVER HDMI ----------------------------------------------------------
 if [[ "${BASE_HDMI_BUILD}" == "true" ]]; then
 
-  sudo apt-get install -y --no-install-recommends xserver-xorg x11-xserver-utils xinit openbox chromium
+  apt-get install -y --no-install-recommends xserver-xorg x11-xserver-utils xinit openbox chromium
 
   cat << 'EOF' > /etc/xdg/openbox/autostart
 # Disable any form of screen saver / screen blanking / power management

--- a/armbian/base/build/customize-image.sh
+++ b/armbian/base/build/customize-image.sh
@@ -37,7 +37,7 @@ CustomizeArmbian() {
     cp -aR /tmp/overlay/config /opt/shift
 
     # copy built Go binaries and their associated .service files to filesystem
-    cp -aR /tmp/overlay/build/* /opt/shift
+    cp -aR /tmp/overlay/build /opt/shift
 
     # run our own customization script
     /bin/bash /tmp/overlay/build/customize-armbian-rockpro64.sh

--- a/armbian/base/build/customize-image.sh
+++ b/armbian/base/build/customize-image.sh
@@ -20,7 +20,7 @@ Main() {
                         CustomizeArmbian
                         ;;
                 bionic)
-                        exit 1
+                        CustomizeArmbian
                         ;;
         esac
 } # Main

--- a/armbian/base/config/grafana/dashboard/grafana_bitbox_base.json
+++ b/armbian/base/config/grafana/dashboard/grafana_bitbox_base.json
@@ -17,7 +17,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "iteration": 1561969474956,
+  "iteration": 1562259807266,
   "links": [],
   "panels": [
     {
@@ -3919,7 +3919,7 @@
       "type": "row"
     }
   ],
-  "refresh": false,
+  "refresh": "10s",
   "schemaVersion": 18,
   "style": "dark",
   "tags": [],
@@ -4003,8 +4003,8 @@
       {
         "allValue": null,
         "current": {
-          "text": "HAPPYGLEE",
-          "value": "HAPPYGLEE"
+          "text": "",
+          "value": ""
         },
         "datasource": "Prometheus",
         "definition": "label_values(lightning_node_info, alias)",
@@ -4028,8 +4028,8 @@
       {
         "allValue": null,
         "current": {
-          "text": "02e8cc34df4f8d06cd6013c0781626ebefd024c5607a66309610a3fc79be50eee1",
-          "value": "02e8cc34df4f8d06cd6013c0781626ebefd024c5607a66309610a3fc79be50eee1"
+          "text": "",
+          "value": ""
         },
         "datasource": "Prometheus",
         "definition": "label_values(lightning_node_info, id)",
@@ -4103,8 +4103,8 @@
       {
         "allValue": null,
         "current": {
-          "text": "carol",
-          "value": "carol"
+          "text": "bitbox-base",
+          "value": "bitbox-base"
         },
         "datasource": "Prometheus",
         "definition": "label_values(base_system_info, hostname)",
@@ -4128,8 +4128,8 @@
       {
         "allValue": null,
         "current": {
-          "text": "2019-06-05",
-          "value": "2019-06-05"
+          "text": "2019-07-04",
+          "value": "2019-07-04"
         },
         "datasource": "Prometheus",
         "definition": "label_values(base_system_info, build_date)",
@@ -4153,8 +4153,8 @@
       {
         "allValue": null,
         "current": {
-          "text": "07:41",
-          "value": "07:41"
+          "text": "14:10",
+          "value": "14:10"
         },
         "datasource": "Prometheus",
         "definition": "label_values(base_system_info, build_time)",
@@ -4178,8 +4178,8 @@
       {
         "allValue": null,
         "current": {
-          "text": "f6b62f3",
-          "value": "f6b62f3"
+          "text": "8392b7a",
+          "value": "8392b7a"
         },
         "datasource": "Prometheus",
         "definition": "label_values(base_system_info, build_commit)",
@@ -4203,7 +4203,7 @@
     ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-12h",
     "to": "now"
   },
   "timepicker": {
@@ -4230,5 +4230,5 @@
   "timezone": "",
   "title": "BitBox Base",
   "uid": "BitBoxBase",
-  "version": 20
+  "version": 21
 }

--- a/armbian/base/config/iptables/iptables.rules
+++ b/armbian/base/config/iptables/iptables.rules
@@ -35,6 +35,9 @@
 -A INPUT -p tcp --dport 8333 -j ACCEPT
 -A INPUT -p tcp --dport 18333 -j ACCEPT
 
+# Allow inbound TCP traffic to Base Middleware port.
+-A INPUT -p tcp --dport 8845 -j ACCEPT
+
 # Allow inbound TCP traffic to Tor port.
 -A INPUT -p tcp --dport 9001 -j ACCEPT
 -A INPUT -p tcp --sport 9001 -j ACCEPT

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -238,23 +238,27 @@ case "${COMMAND}" in
 
     exec)
         case "${SETTING}" in
-            BITCOIND_REINDEX)
+            BITCOIN_REINDEX)
                 systemctl stop bitcoind
 
                 if ! /bin/systemctl -q is-active bitcoind.service; then 
                     # deleting bitcoind chainstate in /mnt/ssd/bitcoin/.bitcoin/chainstate
                     rm -rf /mnt/ssd/bitcoin/.bitcoin/chainstate
 
-                    # set optioin reindex-chainstate, restart bitcoind and remove option
-                    sed -i '/reindex-chainstate/Ic\reindex-chainstate=1' /etc/bitcoin/bitcoin.conf
+                    # set option reindex-chainstate, restart bitcoind and remove option
+                    echo "reindex-chainstate=1" >> /etc/bitcoin/bitcoin.conf
                     systemctl start bitcoind
                     sleep 10
-                    sed -i '/reindex-chainstate/Ic\#reindex-chainstate=1' /etc/bitcoin/bitcoin.conf
+                    sed -i '/reindex/Id' /etc/bitcoin/bitcoin.conf
 
                 else
                     echo "bitcoind is still running, cannot delete chainstate"
                     exit 1
                 fi
+                ;;
+
+            *)
+                echo "Invalid argument: exec command ${SETTING} unknown."
         esac
         ;;
 

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -14,7 +14,7 @@ usage: bbb-config.sh [--version] [--help]
 
 possible commands:
   enable    <dashboard_hdmi|dashboard_web|wifi|autosetup_ssd|
-             tor_ssh|tor_electrum>
+             tor_ssh|tor_electrum|overlayroot>
 
   disable   any 'enable' argument
 
@@ -114,6 +114,18 @@ case "${COMMAND}" in
                 fi
                 echo "${SETTING}=${ENABLE}" > "${SYSCONFIG_PATH}/${SETTING}"
                 systemctl restart tor.service
+                ;;
+
+            OVERLAYROOT)
+                if [[ ${ENABLE} -eq 1 ]]; then
+                    echo 'overlayroot="tmpfs:swap=1,recurse=0"' > /etc/overlayroot.local.conf
+                    echo "${SETTING}=${ENABLE}" > "${SYSCONFIG_PATH}/${SETTING}"
+                    echo "Overlay root filesystem will be enabled on next boot."
+                else
+                    overlayroot-chroot /bin/bash -c "echo 'overlayroot=disabled' > /etc/overlayroot.local.conf"
+                    echo "${SETTING}=${ENABLE}" > "${SYSCONFIG_PATH}/${SETTING}"
+                    echo "Overlay root filesystem will be disabled on next boot."
+                fi
                 ;;
 
             *)

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -142,8 +142,8 @@ case "${COMMAND}" in
                         sed -i '/LIGHTNING-DIR=/Ic\lightning-dir=/mnt/ssd/bitcoin/.lightning' /etc/lightningd/lightningd.conf
                         sed -i '/NETWORK=/Ic\NETWORK=mainnet' /etc/electrs/electrs.conf
                         sed -i '/RPCPORT=/Ic\RPCPORT=8332' /etc/electrs/electrs.conf
-                        sed -i '/BITCOIN_RPCPORT=/Ic\BITCOIN_RPCPORT=8332' /etc/base-middleware/base-middleware.conf
-                        sed -i '/LIGHTNING_RPCPATH=/Ic\LIGHTNING_RPCPATH=/mnt/ssd/bitcoin/.lightning/lightning-rpc' /etc/base-middleware/base-middleware.conf
+                        sed -i '/BITCOIN_RPCPORT=/Ic\BITCOIN_RPCPORT=8332' /etc/base-middleware/base-middleware.conf || true
+                        sed -i '/LIGHTNING_RPCPATH=/Ic\LIGHTNING_RPCPATH=/mnt/ssd/bitcoin/.lightning/lightning-rpc' /etc/base-middleware/base-middleware.conf || true
                         echo "BITCOIN_NETWORK=mainnet" > "${SYSCONFIG_PATH}/${SETTING}"
                         ;;
 
@@ -157,8 +157,8 @@ case "${COMMAND}" in
                         sed -i '/BITCOIN-RPCPORT=/Ic\bitcoin-rpcport=18332' /etc/lightningd/lightningd.conf
                         sed -i '/NETWORK=/Ic\NETWORK=testnet' /etc/electrs/electrs.conf
                         sed -i '/RPCPORT=/Ic\RPCPORT=18332' /etc/electrs/electrs.conf
-                        sed -i '/BITCOIN_RPCPORT=/Ic\BITCOIN_RPCPORT=18332' /etc/base-middleware/base-middleware.conf
-                        sed -i '/LIGHTNING_RPCPATH=/Ic\LIGHTNING_RPCPATH=/mnt/ssd/bitcoin/.lightning-testnet/lightning-rpc' /etc/base-middleware/base-middleware.conf
+                        sed -i '/BITCOIN_RPCPORT=/Ic\BITCOIN_RPCPORT=18332' /etc/base-middleware/base-middleware.conf || true
+                        sed -i '/LIGHTNING_RPCPATH=/Ic\LIGHTNING_RPCPATH=/mnt/ssd/bitcoin/.lightning-testnet/lightning-rpc' /etc/base-middleware/base-middleware.conf || true
                         echo "BITCOIN_NETWORK=testnet" > "${SYSCONFIG_PATH}/${SETTING}"
                         ;;
 

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -28,7 +28,7 @@ possible commands:
   apply     no argument, applies all configuration settings to the system 
             [not yet implemented]
 
-  exec      <bitcoind_reindex>
+  exec      <bitcoin_reindex>
 
 "
 }

--- a/armbian/base/scripts/prometheus-bitcoind.py
+++ b/armbian/base/scripts/prometheus-bitcoind.py
@@ -21,6 +21,7 @@ bitcoind_conf = "-conf=/etc/bitcoin/bitcoin.conf"
 
 
 # Create Prometheus metrics to track bitcoind stats.
+BITCOIN_IBD = Gauge("bitcoind_ibd", "Bitcoin is in Initial Block Download mode")
 BITCOIN_NETWORK = Gauge("bitcoin_network", "Bitcoin network (1=main/2=test/3=reg")
 BITCOIN_BLOCKS = Gauge("bitcoin_blocks", "Block height")
 BITCOIN_VERIFICATION_PROGRESS = Gauge(
@@ -139,6 +140,11 @@ def main():
             # map network names to int (0 = undefined)
             networks = {"main": 1, "test": 2, "regtest": 3}
             BITCOIN_NETWORK.set(networks.get(blockchaininfo["chain"], 0))
+            
+            # map ibd numerical values
+            ibd = {True: 1, False: 0}
+            BITCOIN_IBD.set(ibd.get(blockchaininfo["initialblockdownload"], 3))
+
             BITCOIN_VERIFICATION_PROGRESS.set(blockchaininfo["verificationprogress"])
             BITCOIN_BLOCKS.set(blockchaininfo["blocks"])
             BITCOIN_PEERS.set(networkinfo["connections"])

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -120,6 +120,7 @@ mount -a
 # ------------------------------------------------------------------------------
 ## create missing directories & always set correct owner
 ## access control lists (setfacl) are used to control permissions of newly created files 
+chown bitcoin:system /mnt/ssd/
 chown bitcoin:system /mnt/ssd/bitcoin 
 
 ## bitcoin data storage

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -19,44 +19,38 @@ ifmetric eth0 10
 timedatectl set-ntp true
 echo "180" > /sys/class/hwmon/hwmon0/pwm1
 
+# UART configuration
+# ------------------------------------------------------------------------------
+# TODO(Stadicus): Adjust to new Mender configuration
+
 # disable serial output on UART0
-if ! grep -Fiq "console=display" /boot/armbianEnv.txt; then
-  if ! grep -Fiq "console=" /boot/armbianEnv.txt; then
-    echo "console=display" >> /boot/armbianEnv.txt
-  else
-    sed -i '/console=/Ic\console=display' /boot/armbianEnv.txt
-  fi
-  mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr > /opt/shift/config/uartconfig.log
+# if ! grep -Fiq "console=display" /boot/armbianEnv.txt; then
+#   if ! grep -Fiq "console=" /boot/armbianEnv.txt; then
+#     echo "console=display" >> /boot/armbianEnv.txt
+#   else
+#     sed -i '/console=/Ic\console=display' /boot/armbianEnv.txt
+#   fi
+#   mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr > /opt/shift/config/uartconfig.log
+#
+#   UART_REBOOT=0
+#   [ -f "${SYSCONFIG_PATH}/UART_REBOOT" ] && source "${SYSCONFIG_PATH}/UART_REBOOT"
+#   if [ ${UART_REBOOT} -eq 1 ]; then 
+#     echo "ERR: previous UART_REBOOT not successful, check system"
+#   else
+#     echo "UART_REBOOT=1" > /opt/shift/sysconfig/UART_REBOOT
+#     reboot
+#   fi
 
-  source /opt/shift/sysconfig/UART_REBOOT
-  if [ ${UART_REBOOT} -eq 1 ]; then 
-    echo "ERR: previous UART_REBOOT not successful, check system"
-  else
-    echo "UART_REBOOT=1" > /opt/shift/sysconfig/UART_REBOOT
-    reboot
-  fi
+# else
+#   echo "UART_REBOOT=0" > /opt/shift/sysconfig/UART_REBOOT
+# fi
 
-else
-  echo "UART_REBOOT=0" > /opt/shift/sysconfig/UART_REBOOT
-fi
+# SSD configuration
+# ------------------------------------------------------------------------------
+## check if SSD mount is configured in /etc/fstab (trailing space is essential!)
+if ! grep -q '/mnt/ssd ' /etc/fstab ; then
 
-# check if swapfile exists on ssd
-if [ ! -f /mnt/ssd/swapfile ]; then
-  fallocate --length 2GiB /mnt/ssd/swapfile
-  chmod 600 /mnt/ssd/swapfile
-  mkswap /mnt/ssd/swapfile
-  swapon /mnt/ssd/swapfile
-fi
-
-# check if swapfile is configured in /etc/fstab, and add it if necessary
-if ! grep -q '/mnt/ssd/swapfile' /etc/fstab ; then
-  echo "/mnt/ssd/swapfile swap swap defaults 0 0" >> /etc/fstab
-fi
-
-# check if SSD mount is configured in /etc/fstab
-if ! grep -q '/mnt/ssd' /etc/fstab ; then
-
-  # valid partition present?
+  ## valid partition present?
   if lsblk | grep -q 'nvme0n1p1'; then
     echo "/dev/nvme0n1p1 /mnt/ssd ext4 rw,nosuid,dev,noexec,noatime,nodiratime,auto,nouser,async,nofail 0 2" >> /etc/fstab
 
@@ -64,7 +58,9 @@ if ! grep -q '/mnt/ssd' /etc/fstab ; then
     echo "/dev/sda1 /mnt/ssd ext4 rw,nosuid,dev,noexec,noatime,nodiratime,auto,nouser,async,nofail 0 2" >> /etc/fstab
 
   else
-    # if no valid partition present, is image configured for autosetup of SSD?
+    ## if no valid partition present, is image configured for autosetup of SSD?
+    
+    AUTOSETUP_SSD=0
     [ -f "${SYSCONFIG_PATH}/AUTOSETUP_SSD" ] && source "${SYSCONFIG_PATH}/AUTOSETUP_SSD"
 
     if ! mountpoint /mnt/ssd -q && [[ ${AUTOSETUP_SSD} -eq 1 ]]; then
@@ -74,7 +70,7 @@ if ! grep -q '/mnt/ssd' /etc/fstab ; then
       fi
     fi
 
-    # check for newly created partition
+    ## check for newly created partition
     if lsblk | grep -q 'nvme0n1p1'; then
       echo "/dev/nvme0n1p1 /mnt/ssd ext4 rw,nosuid,dev,noexec,noatime,nodiratime,auto,nouser,async,nofail 0 2" >> /etc/fstab
     elif lsblk | grep -q 'sda1'; then
@@ -91,40 +87,55 @@ fi
 
 sudo mount -a
 
-# abort check if SSD mount is not successful
+## abort check if SSD mount is not successful
 if ! mountpoint /mnt/ssd -q; then 
   echo "Mounting of SSD failed"
   exit 1
 fi
 
-# mount potentially updated /etc/fstab or new swap file
+# Swap configuration
+# ------------------------------------------------------------------------------
+## check if swapfile exists on ssd
+if [ ! -f /mnt/ssd/swapfile ]; then
+  fallocate --length 2GiB /mnt/ssd/swapfile
+  chmod 600 /mnt/ssd/swapfile
+  mkswap /mnt/ssd/swapfile
+  swapon /mnt/ssd/swapfile
+fi
+
+## check if swapfile is configured in /etc/fstab, and add it if necessary
+if ! grep -q '/mnt/ssd/swapfile' /etc/fstab ; then
+  echo "/mnt/ssd/swapfile swap swap defaults 0 0" >> /etc/fstab
+fi
+
+## mount potentially updated /etc/fstab
 mount -a
 
-# create missing directories & always set correct owner
-# access control lists (setfacl) are used to control permissions of newly created files 
-chown bitcoin:system /mnt/ssd 
+# Folders & permissions
+# ------------------------------------------------------------------------------
+## create missing directories & always set correct owner
+## access control lists (setfacl) are used to control permissions of newly created files 
+chown bitcoin:system /mnt/ssd/bitcoin 
 
-# bitcoin data storage
+## bitcoin data storage
 mkdir -p /mnt/ssd/bitcoin/.bitcoin/testnet3
 chown -R bitcoin:bitcoin /mnt/ssd/bitcoin/
+chmod -R 750 /mnt/ssd/bitcoin/
 setfacl -dR -m g::rx /mnt/ssd/bitcoin/.bitcoin/
 setfacl -dR -m o::- /mnt/ssd/bitcoin/.bitcoin/
 
-# electrs data storage
+## electrs data storage
 mkdir -p /mnt/ssd/electrs/
 chown -R electrs:bitcoin /mnt/ssd/electrs/
+chmod -R 750 /mnt/ssd/electrs/
 
-# system folders
+## system folders
 mkdir -p /mnt/ssd/prometheus
 chown -R prometheus:system /mnt/ssd/prometheus/
 mkdir -p /mnt/ssd/system/journal/
 
-# set permissions for whole ssd 
-# (user:rwx group:r-x other:---)
-chmod -R 750 /mnt/ssd
-
-# We set rpccookiefile=/mnt/ssd/bitcoin/.bitcoin/.cookie, but there seems to be
-# no way to specify where to expect the bitcoin cookie for c-lightning, so let's
-# create a symlink at the expected testnet location.
+## We set rpccookiefile=/mnt/ssd/bitcoin/.bitcoin/.cookie, but there seems to be
+## no way to specify where to expect the bitcoin cookie for c-lightning, so let's
+## create a symlink at the expected testnet location.
 mkdir -p /mnt/ssd/bitcoin/.bitcoin/testnet3/
 ln -fs /mnt/ssd/bitcoin/.bitcoin/.cookie /mnt/ssd/bitcoin/.bitcoin/testnet3/.cookie

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -97,10 +97,15 @@ fi
 # ------------------------------------------------------------------------------
 ## check if swapfile exists on ssd
 if [ ! -f /mnt/ssd/swapfile ]; then
-  fallocate --length 2GiB /mnt/ssd/swapfile
-  chmod 600 /mnt/ssd/swapfile
-  mkswap /mnt/ssd/swapfile
-  swapon /mnt/ssd/swapfile
+  if [ mountpoint /mnt/ssd -q ]; then
+    echo "Creating /mnt/ssd/swapfile."
+    fallocate --length 2GiB /mnt/ssd/swapfile
+    chmod 600 /mnt/ssd/swapfile
+    mkswap /mnt/ssd/swapfile
+    swapon /mnt/ssd/swapfile
+  else
+    echo "ERR: No swapfile found, but SSD not mounted."
+  fi
 fi
 
 ## check if swapfile is configured in /etc/fstab, and add it if necessary

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -138,6 +138,7 @@ chmod -R 750 /mnt/ssd/electrs/
 mkdir -p /mnt/ssd/prometheus
 chown -R prometheus:system /mnt/ssd/prometheus/
 mkdir -p /mnt/ssd/system/journal/
+ln -sf /mnt/ssd/system/journal/ /var/log/journal
 
 ## We set rpccookiefile=/mnt/ssd/bitcoin/.bitcoin/.cookie, but there seems to be
 ## no way to specify where to expect the bitcoin cookie for c-lightning, so let's

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -48,6 +48,11 @@ if [ ! -f /mnt/ssd/swapfile ]; then
   swapon /mnt/ssd/swapfile
 fi
 
+# check if swapfile is configured in /etc/fstab, and add it if necessary
+if ! grep -q '/mnt/ssd/swapfile' /etc/fstab ; then
+  echo "/mnt/ssd/swapfile swap swap defaults 0 0" >> /etc/fstab
+fi
+
 # check if SSD mount is configured in /etc/fstab
 if ! grep -q '/mnt/ssd' /etc/fstab ; then
 

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -113,6 +113,9 @@ if ! grep -q '/mnt/ssd/swapfile' /etc/fstab ; then
   echo "/mnt/ssd/swapfile swap swap defaults 0 0" >> /etc/fstab
 fi
 
+## if overlayroot disabled swapfile on ssd, enable it again
+sed -i 's/#overlayroot:swapfile#//g' /etc/fstab
+
 ## mount potentially updated /etc/fstab
 mount -a
 

--- a/armbian/build.sh
+++ b/armbian/build.sh
@@ -62,5 +62,5 @@ case ${ACTION} in
     	# copy built Go binaries and their associated .service files to filesystem
     	cp -aR base/build /opt/shift
 
-		base/build/customize-armbian-rockpro64.sh
+		base/build/customize-armbian-rockpro64.sh ondevice
 esac

--- a/armbian/build.sh
+++ b/armbian/build.sh
@@ -43,7 +43,8 @@ case ${ACTION} in
 		cp -a  ../base/build/customize-image.sh userpatches/	# copy customize script to standard Armbian build hook
 
 		BOARD=${BOARD:-rockpro64}
-		BUILD_ARGS="docker BOARD=${BOARD} KERNEL_ONLY=no KERNEL_CONFIGURE=no RELEASE=stretch BRANCH=default BUILD_DESKTOP=no WIREGUARD=no LIB_TAG=sunxi-4.20"
+		#BUILD_ARGS="docker BOARD=${BOARD} KERNEL_ONLY=no KERNEL_CONFIGURE=no RELEASE=stretch BRANCH=default BUILD_DESKTOP=no WIREGUARD=no LIB_TAG=sunxi-4.20"
+		BUILD_ARGS="docker BOARD=${BOARD} KERNEL_ONLY=no KERNEL_CONFIGURE=no RELEASE=stretch BRANCH=default BUILD_DESKTOP=no WIREGUARD=no"
 		if ! [ "${ACTION}" == "build" ]; then
 			BUILD_ARGS="${BUILD_ARGS} CLEAN_LEVEL=oldcache PROGRESS_LOG_TO_FILE=yes"
 		fi

--- a/armbian/build.sh
+++ b/armbian/build.sh
@@ -40,13 +40,13 @@ case ${ACTION} in
 		cd armbian-build
 
 		mkdir -p output/
-		mkdir -p userpatches/overlay
+		mkdir -p userpatches/overlay/bin
 		cp -aR ../base/* userpatches/overlay/					# copy scripts and configuration items to overlay
-		cp -aR ../../build/* userpatches/overlay/				# copy additional software binaries to overlay
+		cp -aR ../../build/* userpatches/overlay/bin			# copy additional software binaries to overlay
 		cp -a  ../base/build/customize-image.sh userpatches/	# copy customize script to standard Armbian build hook
 
 		BOARD=${BOARD:-rockpro64}
-		BUILD_ARGS="docker BOARD=${BOARD} KERNEL_ONLY=no KERNEL_CONFIGURE=no RELEASE=buster BRANCH=default BUILD_DESKTOP=no WIREGUARD=no"
+		BUILD_ARGS="docker BOARD=${BOARD} KERNEL_ONLY=no KERNEL_CONFIGURE=no RELEASE=bionic BRANCH=default BUILD_DESKTOP=no WIREGUARD=no"
 		if ! [ "${ACTION}" == "build" ]; then
 			BUILD_ARGS="${BUILD_ARGS} CLEAN_LEVEL=oldcache PROGRESS_LOG_TO_FILE=yes"
 		fi

--- a/armbian/build.sh
+++ b/armbian/build.sh
@@ -9,7 +9,10 @@ set -eu
 
 function usage() {
 	echo "Build customized Armbian base image for BitBox Base"
-	echo "Usage: ${0} [build|update]"
+	echo "Usage: ${0} [build|update|ondevice]"
+	echo
+	echo "running the setup directly ondevice currently support"
+	echo "Armbian releases Debian Buster and Ubuntu Bionic"
 }
 
 ACTION=${1:-"build"}

--- a/armbian/mender-convert.sh
+++ b/armbian/mender-convert.sh
@@ -58,12 +58,14 @@ case ${ACTION} in
 		echo "Cleaning up..."
 		rm "input/${SOURCE_NAME}.img"
 		rm "output/${TARGET_NAME}.ext4"
+		mv "output/${TARGET_NAME}.sdimg" "output/${TARGET_NAME}.img"
 		mv output/${SOURCE_NAME}* ../../provisioning/
 
 		echo "Mender files ready for provisioning:"
 		stat -c "%y %s %n" ../../provisioning/${TARGET_NAME}*
 		echo 
 		echo "Write to eMMC with the following command (check target device /dev/sdb first!):"
-		echo "dd if=./provisioning/${TARGET_NAME}.sdimg of=/dev/sdb bs=4M conv=sync status=progress"
+		echo "dd if=./provisioning/${TARGET_NAME}.sdimg of=/dev/sdb bs=4M conv=sync status=progress && sync"
+		echo
         ;;
 esac

--- a/scripts/move-armbian-image.sh
+++ b/scripts/move-armbian-image.sh
@@ -7,8 +7,8 @@ set -eu
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # TODO(hkjn): Consider defining these config values somewhere higher-level than inside this script.
-KERNEL_VERSION="${KERNEL_VERSION:-4.4.176}"
-ARMBIAN_VERSION="${ARMBIAN_VERSION:-5.77}"
+KERNEL_VERSION="${KERNEL_VERSION:-4.4.182}"
+ARMBIAN_VERSION="${ARMBIAN_VERSION:-5.90}"
 IMG_FILE="${SCRIPT_DIR}/../armbian/armbian-build/output/images/Armbian_${ARMBIAN_VERSION}_Rockpro64_Debian_stretch_default_${KERNEL_VERSION}.img"
 TARGET_FILE="BitBoxBase_Armbian_RockPro64.img"
 

--- a/scripts/move-armbian-image.sh
+++ b/scripts/move-armbian-image.sh
@@ -7,9 +7,10 @@ set -eu
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # TODO(hkjn): Consider defining these config values somewhere higher-level than inside this script.
-KERNEL_VERSION="${KERNEL_VERSION:-4.4.182}"
+KERNEL_VERSION="${KERNEL_VERSION:-4.4.184}"
 ARMBIAN_VERSION="${ARMBIAN_VERSION:-5.91}"
-IMG_FILE="${SCRIPT_DIR}/../armbian/armbian-build/output/images/Armbian_${ARMBIAN_VERSION}_Rockpro64_Debian_buster_default_${KERNEL_VERSION}.img"
+DISTRIBUTION="Ubuntu_bionic"
+IMG_FILE="${SCRIPT_DIR}/../armbian/armbian-build/output/images/Armbian_${ARMBIAN_VERSION}_Rockpro64_${DISTRIBUTION}_default_${KERNEL_VERSION}.img"
 TARGET_FILE="BitBoxBase_Armbian_RockPro64.img"
 
 if [[ ! -e "${IMG_FILE}" ]]; then

--- a/scripts/move-armbian-image.sh
+++ b/scripts/move-armbian-image.sh
@@ -8,8 +8,8 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # TODO(hkjn): Consider defining these config values somewhere higher-level than inside this script.
 KERNEL_VERSION="${KERNEL_VERSION:-4.4.182}"
-ARMBIAN_VERSION="${ARMBIAN_VERSION:-5.90}"
-IMG_FILE="${SCRIPT_DIR}/../armbian/armbian-build/output/images/Armbian_${ARMBIAN_VERSION}_Rockpro64_Debian_stretch_default_${KERNEL_VERSION}.img"
+ARMBIAN_VERSION="${ARMBIAN_VERSION:-5.91}"
+IMG_FILE="${SCRIPT_DIR}/../armbian/armbian-build/output/images/Armbian_${ARMBIAN_VERSION}_Rockpro64_Debian_buster_default_${KERNEL_VERSION}.img"
 TARGET_FILE="BitBoxBase_Armbian_RockPro64.img"
 
 if [[ ! -e "${IMG_FILE}" ]]; then


### PR DESCRIPTION
**overlayroot**
This pull request mainly improves the stability of the operating system by
* using the latest build of Armbian Ubuntu 18.04 (Bionic Beaver)
* optionally enabling `overlayroot` that mounts the rootfs as read-only and adds an ephemeral tmpfs overlay filesystem on top

With `overlayroot`, corrupting the rootfs should be almost impossible and it also extends the lifetime of the eMMC significantly.

**make ondevice**
The configuration script now supports multiple Linux distributions Armbian (Debian Stretch or Buster, Ubuntu Bionic) or Ayufancan, and can be run directly on the device to configure a BitBox Base.
```
# run directly on  image for RockPro64
git clone https://github.com/digitalbitbox/bitbox-base.git
cd bitbox-base/armbian/
nano base/build/build.conf
make build-ondevice
```