### PR TITLE
middleware: Implement GOB RPC server

### DIFF
--- a/middleware/src/handlers/handlers_test.go
+++ b/middleware/src/handlers/handlers_test.go
@@ -3,10 +3,7 @@ package handlers_test
 import (
 	middleware "github.com/digitalbitbox/bitbox-base/middleware/src"
 	"github.com/digitalbitbox/bitbox-base/middleware/src/handlers"
-	basemessages "github.com/digitalbitbox/bitbox-base/middleware/src/messages"
 	"github.com/stretchr/testify/require"
-
-	"github.com/golang/protobuf/proto"
 
 	"github.com/flynn/noise"
 
@@ -84,43 +81,15 @@ func TestWebsocketHandler(t *testing.T) {
 	defer ws.Close()
 
 	//initialize noise
-	receiveCipher, sendCipher := initializeNoise(ws, t)
+	_, _ = initializeNoise(ws, t)
 
 	//do the pairing verificaion
 	err = ws.WriteMessage(1, []byte(opICanHasPairinVerificashun))
 	require.NoError(t, err)
 	_, responseBytes, err := ws.ReadMessage()
+	t.Logf("But this is too much!")
 	require.NoError(t, err)
 	require.Equal(t, string(responseBytes), string(responseSuccess))
-
-	outgoing := &basemessages.BitBoxBaseIn{
-		BitBoxBaseIn: &basemessages.BitBoxBaseIn_BaseSystemEnvIn{
-			BaseSystemEnvIn: &basemessages.BaseSystemEnvIn{},
-		},
-	}
-	data, err := proto.Marshal(outgoing)
-	require.NoError(t, err)
-	err = ws.WriteMessage(1, sendCipher.Encrypt(nil, nil, data))
-	require.NoError(t, err)
-	_, responseBytes, err = ws.ReadMessage()
-	require.NoError(t, err)
-	_, err = receiveCipher.Decrypt(nil, nil, responseBytes)
-	require.NoError(t, err)
-
-	outgoing = &basemessages.BitBoxBaseIn{
-		BitBoxBaseIn: &basemessages.BitBoxBaseIn_BaseResyncIn{
-			BaseResyncIn: &basemessages.BaseResyncIn{},
-		},
-	}
-	data, err = proto.Marshal(outgoing)
-	require.NoError(t, err)
-	err = ws.WriteMessage(1, sendCipher.Encrypt(nil, nil, data))
-	require.NoError(t, err)
-	_, responseBytes, err = ws.ReadMessage()
-	require.NoError(t, err)
-	_, err = receiveCipher.Decrypt(nil, nil, responseBytes)
-	require.NoError(t, err)
-
 }
 
 // initializeNoise sets up a new noise connection. First a fresh keypair is generated if none is locally found.

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -4,8 +4,6 @@ import (
 	"testing"
 
 	middleware "github.com/digitalbitbox/bitbox-base/middleware/src"
-	basemessages "github.com/digitalbitbox/bitbox-base/middleware/src/messages"
-	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/require"
 )
 
@@ -20,25 +18,10 @@ func TestMiddleware(t *testing.T) {
 	argumentMap["bbbConfigScript"] = "/home/bitcoin/script.sh"
 
 	middlewareInstance := middleware.NewMiddleware(argumentMap)
-	marshalled := middlewareInstance.SystemEnv()
-	unmarshalled := &basemessages.BitBoxBaseOut{}
-	err := proto.Unmarshal(marshalled, unmarshalled)
-	require.NoError(t, err)
 
-	unmarshalledSystemEnv, ok := unmarshalled.BitBoxBaseOut.(*basemessages.BitBoxBaseOut_BaseSystemEnvOut)
-	if !ok {
-		t.Error("Protobuf parsing into system env message failed")
-	}
-	port := unmarshalledSystemEnv.BaseSystemEnvOut.ElectrsRPCPort
-	require.Equal(t, port, "18442")
-	network := unmarshalledSystemEnv.BaseSystemEnvOut.Network
-	require.Equal(t, network, "testnet")
-
-	marshalled = middlewareInstance.ResyncBitcoin()
-	err = proto.Unmarshal(marshalled, unmarshalled)
-	require.NoError(t, err)
-	_, ok = unmarshalled.BitBoxBaseOut.(*basemessages.BitBoxBaseOut_BaseResyncOut)
-	if !ok {
-		t.Error("Protobuf parsing into resync bitcoin message failed")
-	}
+	systemEnvResponse := middlewareInstance.SystemEnv()
+	require.Equal(t, systemEnvResponse.ElectrsRPCPort, "18442")
+	require.Equal(t, systemEnvResponse.Network, "testnet")
+	resyncBitcoinResponse := middlewareInstance.ResyncBitcoin()
+	require.Equal(t, resyncBitcoinResponse.Success, false)
 }

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -1,0 +1,95 @@
+package rpcserver
+
+import (
+	"log"
+	"net/rpc"
+
+	middleware "github.com/digitalbitbox/bitbox-base/middleware/src"
+)
+
+type rpcConn struct {
+	readChan  chan []byte
+	writeChan chan []byte
+}
+
+func newRPCConn() *rpcConn {
+	RPCConn := &rpcConn{
+		readChan:  make(chan []byte),
+		writeChan: make(chan []byte),
+	}
+	return RPCConn
+}
+
+func (conn *rpcConn) ReadChan() chan []byte {
+	return conn.readChan
+}
+
+func (conn *rpcConn) WriteChan() chan []byte {
+	return conn.writeChan
+}
+
+func (conn *rpcConn) Read(p []byte) (n int, err error) {
+	message := <-conn.readChan
+	return copy(p, message), nil
+}
+
+func (conn *rpcConn) Write(p []byte) (n int, err error) {
+	conn.writeChan <- append([]byte("r"), p...)
+	return len(p), nil
+}
+
+func (conn *rpcConn) Close() error {
+	return nil
+}
+
+// Middleware provides an interface to the middleware package.
+type Middleware interface {
+	SystemEnv() middleware.GetEnvResponse
+	ResyncBitcoin() middleware.ResyncBitcoinResponse
+	SampleInfo() middleware.SampleInfoResponse
+}
+
+// RPCServer provides rpc calls to the middleware
+type RPCServer struct {
+	middleware    Middleware
+	RPCConnection *rpcConn
+}
+
+// NewRPCServer returns a new RPCServer
+func NewRPCServer(middleware Middleware) *RPCServer {
+	server := &RPCServer{
+		middleware:    middleware,
+		RPCConnection: newRPCConn(),
+	}
+	err := rpc.Register(server)
+	if err != nil {
+		log.Println("Unable to register new rpc server")
+	}
+
+	return server
+}
+
+// GetSystemEnv sends the middleware's GetEnvResponse over rpc
+func (server *RPCServer) GetSystemEnv(args int, reply *middleware.GetEnvResponse) error {
+	*reply = server.middleware.SystemEnv()
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// ResyncBitcoin sends the middleware's ResyncBitcoinResponse over rpc
+func (server *RPCServer) ResyncBitcoin(args int, reply *middleware.ResyncBitcoinResponse) error {
+	*reply = server.middleware.ResyncBitcoin()
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// GetSampleInfo send the middleware's SampleInfoResponse over rpc
+func (server *RPCServer) GetSampleInfo(args int, reply *middleware.SampleInfoResponse) error {
+	*reply = server.middleware.SampleInfo()
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+func (server *RPCServer) Serve() {
+	rpc.ServeConn(server.RPCConnection)
+}

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -1,0 +1,92 @@
+package rpcserver_test
+
+import (
+	"net/rpc"
+	"sync"
+	"testing"
+
+	middleware "github.com/digitalbitbox/bitbox-base/middleware/src"
+	rpcserver "github.com/digitalbitbox/bitbox-base/middleware/src/rpcserver"
+
+	"github.com/stretchr/testify/require"
+)
+
+type rpcConn struct {
+	readChan  <-chan []byte
+	writeChan chan<- []byte
+}
+
+func (conn *rpcConn) Read(p []byte) (n int, err error) {
+	return copy(p, <-conn.readChan), nil
+}
+
+func (conn *rpcConn) Write(p []byte) (n int, err error) {
+	conn.writeChan <- p
+	return len(p), nil
+}
+
+func (conn *rpcConn) Close() error {
+	return nil
+}
+
+func TestRPCServer(t *testing.T) {
+	argumentMap := make(map[string]string)
+	argumentMap["bitcoinRPCUser"] = "user"
+	argumentMap["bitcoinRPCPassword"] = "password"
+	argumentMap["bitcoinRPCPort"] = "8332"
+	argumentMap["lightningRPCPath"] = "/home/bitcoin/.lightning"
+	argumentMap["electrsRPCPort"] = "18442"
+	argumentMap["network"] = "testnet"
+	argumentMap["bbbConfigScript"] = "/home/bitcoin/script.sh"
+	middlewareInstance := middleware.NewMiddleware(argumentMap)
+
+	rpcServer := rpcserver.NewRPCServer(middlewareInstance)
+	serverWriteChan := rpcServer.RPCConnection.WriteChan()
+	serverReadChan := rpcServer.RPCConnection.ReadChan()
+
+	go rpcServer.Serve()
+
+	clientWriteChan := make(chan []byte)
+	clientReadChan := make(chan []byte)
+	client := rpc.NewClient(&rpcConn{readChan: clientReadChan, writeChan: clientWriteChan})
+
+	request := 1
+	var reply middleware.GetEnvResponse
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		err := client.Call("RPCServer.GetSystemEnv", request, &reply)
+		require.NoError(t, err)
+	}()
+	msgRequest := <-clientWriteChan
+	serverReadChan <- msgRequest
+	msgResponse := <-serverWriteChan
+	t.Logf("response message %s", string(msgResponse))
+	// Cut off the significant Byte in the response
+	clientReadChan <- msgResponse[1:]
+	wg.Wait()
+	t.Logf("reply: %v", reply)
+	require.Equal(t, "testnet", reply.Network)
+	require.Equal(t, "18442", reply.ElectrsRPCPort)
+
+	var resyncReply middleware.ResyncBitcoinResponse
+	wg = sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+		err := client.Call("RPCServer.ResyncBitcoin", request, &resyncReply)
+		require.NoError(t, err)
+	}()
+
+	msgRequest = <-clientWriteChan
+	serverReadChan <- msgRequest
+	msgResponse = <-serverWriteChan
+	t.Logf("Resync Bitcoin Response %q", string(msgResponse))
+	// Cut off the significant Byte in the response
+	clientReadChan <- msgResponse[1:]
+	wg.Wait()
+	require.Equal(t, false, resyncReply.Success)
+}


### PR DESCRIPTION
Each websocket connection now spawns a new gob encoded rpc server.
Protobuf encoding is dropped for this purpose.

The rpc server package creates read and write channels that are wrapped into a io.ReadWriteCloser interface. This interface is implemented in the rpcConn struct of the server package. The websocket loop in the handlers package now uses these rpcConn channels to read and write websocket messages.

When a new websocket connection is created in the wshandler in the handlers package, a new rpc server and subsequent websocket read and write loop is spawned. The rpcserver's write channel is also passed into a map of all clients and can then receive notification events again through the listenEvents() function.

The available rpc calls are implemented in the rpcserver.go file. Currently they are implemented as methods of RPCServer as GetSystemEnv(), ResyncBitcoin() and GetSampleInfo(). By passing the RPCServer struct to the served rpc connection these methods are implicitly registered.

Each of these RPCServer methods call a subsequent Middleware method and return a response struct in each case.