### PR TITLE
Middleware: Add prometheus package to track bitcoin verification progress 

### DIFF
--- a/middleware/cmd/middleware/main.go
+++ b/middleware/cmd/middleware/main.go
@@ -20,6 +20,7 @@ func main() {
 	dataDir := flag.String("datadir", ".base", "Directory where middleware persistent data like noise keys is stored")
 	network := flag.String("network", "testnet", "Indicate wether running bitcoin on testnet or mainnet")
 	bbbConfigScript := flag.String("bbbconfigscript", "/opt/shift/scripts/bbb-config.sh", "Path to the bbb-config file that allows setting system configuration")
+	prometheusURL := flag.String("prometheusurl", "http://localhost:9090", "Url of the prometheus server in the form of 'http://localhost:9090'")
 	flag.Parse()
 
 	argumentMap := make(map[string]string)
@@ -30,6 +31,7 @@ func main() {
 	argumentMap["electrsRPCPort"] = *electrsRPCPort
 	argumentMap["network"] = *network
 	argumentMap["bbbConfigScript"] = *bbbConfigScript
+	argumentMap["prometheusURL"] = *prometheusURL
 
 	logBeforeExit := func() {
 		// Recover from all panics and log error before panicking again.

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -18,9 +18,10 @@ import (
 type Middleware interface {
 	// Start triggers the main middleware event loop that emits events to be caught by the handlers.
 	Start() <-chan []byte
-	SystemEnv() middleware.GetEnvResponse
-	SampleInfo() middleware.SampleInfoResponse
-	ResyncBitcoin() middleware.ResyncBitcoinResponse
+	SystemEnv() (middleware.GetEnvResponse, error)
+	SampleInfo() (middleware.SampleInfoResponse, error)
+	ResyncBitcoin() (middleware.ResyncBitcoinResponse, error)
+	VerificationProgress() (middleware.VerificationProgressResponse, error)
 }
 
 // Handlers provides a web api

--- a/middleware/src/handlers/websocket.go
+++ b/middleware/src/handlers/websocket.go
@@ -76,6 +76,9 @@ func (handlers *Handlers) runWebsocket(client *websocket.Conn, readChan chan<- [
 				return
 			default:
 				select {
+				case <-closeChan:
+					log.Println("Read Loop break, closing write loop")
+					return
 
 				case message, ok := <-writeChan:
 					if !ok {
@@ -89,9 +92,6 @@ func (handlers *Handlers) runWebsocket(client *websocket.Conn, readChan chan<- [
 						_ = client.WriteMessage(websocket.CloseMessage, []byte{})
 						return
 					}
-				case <-closeChan:
-					log.Println("Read Loop break, closing write loop")
-					return
 				}
 			}
 		}

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -19,9 +19,11 @@ func TestMiddleware(t *testing.T) {
 
 	middlewareInstance := middleware.NewMiddleware(argumentMap)
 
-	systemEnvResponse := middlewareInstance.SystemEnv()
+	systemEnvResponse, err := middlewareInstance.SystemEnv()
+	require.NoError(t, err)
 	require.Equal(t, systemEnvResponse.ElectrsRPCPort, "18442")
 	require.Equal(t, systemEnvResponse.Network, "testnet")
-	resyncBitcoinResponse := middlewareInstance.ResyncBitcoin()
+	resyncBitcoinResponse, err := middlewareInstance.ResyncBitcoin()
+	require.NoError(t, err)
 	require.Equal(t, resyncBitcoinResponse.Success, false)
 }

--- a/middleware/src/prometheus/prometheus.go
+++ b/middleware/src/prometheus/prometheus.go
@@ -1,0 +1,78 @@
+package prometheus
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+	"time"
+
+	"github.com/tidwall/gjson"
+)
+
+const (
+	success = "success"
+)
+
+type PromClient struct {
+	address string
+}
+
+func NewPromClient(address string) *PromClient {
+	return &PromClient{
+		address: address,
+	}
+}
+
+func (client *PromClient) query(endpoint string) string {
+	httpClient := http.Client{
+		Timeout: 5 * time.Second,
+	}
+	response, err := httpClient.Get(client.address + "/api/v1/query?query=" + endpoint)
+	if err != nil {
+		log.Printf("Some weird http error: %v", err)
+	}
+	defer response.Body.Close()
+	body, err := ioutil.ReadAll(response.Body)
+	if err != nil {
+		log.Println("Could not read prometheus response body")
+	}
+	bodyString := string(body)
+	if !gjson.Valid(bodyString) {
+		log.Println("Received unvalid json from prometheus")
+	}
+
+	return bodyString
+}
+
+func (client *PromClient) Headers() int64 {
+	response := client.query("bitcoin_headers")
+	if success != gjson.Get(response, "status").String() {
+		log.Println("Failed")
+	}
+	queryResult := gjson.Get(response, "data.result").Array()
+	firstResultValue := queryResult[0].Map()["value"].Array()
+	log.Println("result")
+	return firstResultValue[1].Int()
+}
+
+func (client *PromClient) Blocks() int64 {
+	response := client.query("bitcoin_blocks")
+	if success != gjson.Get(response, "status").String() {
+		log.Println("Failed")
+	}
+	queryResult := gjson.Get(response, "data.result").Array()
+	firstResultValue := queryResult[0].Map()["value"].Array()
+	log.Println("result")
+	return firstResultValue[1].Int()
+}
+
+func (client *PromClient) VerificationProgress() float64 {
+	response := client.query("bitcoin_verification_progress")
+	if success != gjson.Get(response, "status").String() {
+		log.Println("Failed")
+	}
+	queryResult := gjson.Get(response, "data.result").Array()
+	firstResultValue := queryResult[0].Map()["value"].Array()
+	log.Println("result")
+	return firstResultValue[1].Float()
+}

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -44,9 +44,10 @@ func (conn *rpcConn) Close() error {
 
 // Middleware provides an interface to the middleware package.
 type Middleware interface {
-	SystemEnv() middleware.GetEnvResponse
-	ResyncBitcoin() middleware.ResyncBitcoinResponse
-	SampleInfo() middleware.SampleInfoResponse
+	SystemEnv() (middleware.GetEnvResponse, error)
+	ResyncBitcoin() (middleware.ResyncBitcoinResponse, error)
+	SampleInfo() (middleware.SampleInfoResponse, error)
+	VerificationProgress() (middleware.VerificationProgressResponse, error)
 }
 
 // RPCServer provides rpc calls to the middleware
@@ -71,25 +72,37 @@ func NewRPCServer(middleware Middleware) *RPCServer {
 
 // GetSystemEnv sends the middleware's GetEnvResponse over rpc
 func (server *RPCServer) GetSystemEnv(args int, reply *middleware.GetEnvResponse) error {
-	*reply = server.middleware.SystemEnv()
+	var err error
+	*reply, err = server.middleware.SystemEnv()
 	log.Printf("sent reply %v: ", reply)
-	return nil
+	return err
 }
 
 // ResyncBitcoin sends the middleware's ResyncBitcoinResponse over rpc
 func (server *RPCServer) ResyncBitcoin(args int, reply *middleware.ResyncBitcoinResponse) error {
-	*reply = server.middleware.ResyncBitcoin()
+	var err error
+	*reply, err = server.middleware.ResyncBitcoin()
 	log.Printf("sent reply %v: ", reply)
-	return nil
+	return err
 }
 
 // GetSampleInfo send the middleware's SampleInfoResponse over rpc
 func (server *RPCServer) GetSampleInfo(args int, reply *middleware.SampleInfoResponse) error {
-	*reply = server.middleware.SampleInfo()
+	var err error
+	*reply, err = server.middleware.SampleInfo()
 	log.Printf("sent reply %v: ", reply)
-	return nil
+	return err
 }
 
+// GetSampleInfo send the middleware's SampleInfoResponse over rpc
+func (server *RPCServer) GetVerificationProgress(args int, reply *middleware.VerificationProgressResponse) error {
+	var err error
+	*reply, err = server.middleware.VerificationProgress()
+	log.Printf("sent reply %v: ", reply)
+	return err
+}
+
+// Serve starts a gob rpc server
 func (server *RPCServer) Serve() {
 	rpc.ServeConn(server.RPCConnection)
 }

--- a/middleware/src/system/system.go
+++ b/middleware/src/system/system.go
@@ -10,6 +10,7 @@ type Environment struct {
 	bitcoinRPCPort     string
 	lightningRPCPath   string
 	bbbConfigScript    string
+	prometheusURL      string
 }
 
 // NewEnvironment returns a new Environment instance.
@@ -24,6 +25,7 @@ func NewEnvironment(argumentMap map[string]string) Environment {
 		ElectrsRPCPort:     argumentMap["electrsRPCPort"],
 		Network:            argumentMap["network"],
 		bbbConfigScript:    argumentMap["bbbConfigScript"],
+		prometheusURL:      argumentMap["prometheusURL"],
 	}
 	return environment
 }
@@ -51,4 +53,9 @@ func (environment *Environment) GetLightningRPCPath() string {
 // GetBBBConfigScript is a getter for the location of the bbb config script
 func (environment *Environment) GetBBBConfigScript() string {
 	return environment.bbbConfigScript
+}
+
+// GetPrometheusURL is a getter for the url the prometheus server is reachable on
+func (environment *Environment) GetPrometheusURL() string {
+	return environment.prometheusURL
 }

--- a/middleware/src/system/system_test.go
+++ b/middleware/src/system/system_test.go
@@ -16,6 +16,7 @@ func TestSystem(t *testing.T) {
 	argumentMap["electrsRPCPort"] = "18442"
 	argumentMap["network"] = "testnet"
 	argumentMap["bbbConfigScript"] = "/home/bitcoin/script.sh"
+	argumentMap["prometheusURL"] = "http://localhost:9090"
 
 	environmentInstance := system.NewEnvironment(argumentMap)
 	require.Equal(t, environmentInstance.GetBitcoinRPCPort(), "8332")
@@ -25,6 +26,7 @@ func TestSystem(t *testing.T) {
 	require.Equal(t, environmentInstance.GetBBBConfigScript(), "/home/bitcoin/script.sh")
 	require.Equal(t, environmentInstance.Network, "testnet")
 	require.Equal(t, environmentInstance.ElectrsRPCPort, "18442")
+	require.Equal(t, environmentInstance.GetPrometheusURL(), "http://localhost:9090")
 
 	//tset unhappy path
 	argumentMap = make(map[string]string)


### PR DESCRIPTION
During initial blockchain download we do not want to hit bitcoind with direct rpc calls, instead call prometheus, which schedules the calls at healthy intervals. Add a rpc call that returns the syncing progress as given by bitcoin core and the total number of blocks and headers synced.

Improve channel close handling in the websocket loop 