### PR TITLE
Docker regtest

### DIFF
--- a/middleware/.gitignore
+++ b/middleware/.gitignore
@@ -20,3 +20,4 @@ tags
 [._]*.un~
 
 .base
+integration_test/volumes

--- a/middleware/Makefile
+++ b/middleware/Makefile
@@ -28,3 +28,14 @@ build:
 aarch64: check-go-env fetch-deps ci
 	GOARCH=arm64 go install $(REPO_ROOT)/middleware/cmd/middleware
 	cp ${GOPATH}/bin/linux_arm64/middleware $(REPO_ROOT)/build/base-middleware
+
+regtest-up:
+	cd $(REPO_ROOT)/middleware/integration_test ;\
+	docker-compose up -d ;\
+	sudo chown ${USER} volumes/clightning1/lightning-rpc ;\
+	sudo chown ${USER} volumes/clightning2/lightning-rpc ;\
+
+regtest-down:
+	cd $(REPO_ROOT)/middleware/integration_test ;\
+	docker-compose down ;\
+

--- a/middleware/README.md
+++ b/middleware/README.md
@@ -12,7 +12,7 @@ clients.
 
 ## Developing
 
-Currently, to build an run, install go and run:
+Currently, to build and run, install go and run:
 
     make native
 
@@ -25,17 +25,6 @@ Before committing be sure to run `gofmt -w *` to properly indent the code.
 You can also run `make envinit` to setup a development environment (dep and ci
 tools)
 
-If the protobuf messages need to be re-generated a specific version of protobuf
-needs to be installed. The current messages are compiled with protobuf v1.2.0 .
-To install a specific version locally, run:
-
-```
-GIT_TAG="v1.2.0" # change as needed
-go get -d -u github.com/golang/protobuf/protoc-gen-go
-git -C "$(go env GOPATH)"/src/github.com/golang/protobuf checkout $GIT_TAG
-go install github.com/golang/protobuf/protoc-gen-go
-```
-
 ## Running
 
 The middleware accepts some command line arguments to connect to c-lightning
@@ -45,13 +34,51 @@ and bitcoind. The arguments are expected to be passed in the following fashion:
 
 Running `./base-middleware -h` will print the following help:
     
-    -lightning-rpc-path string
+  -bbbconfigscript string
+    	Path to the bbb-config file that allows setting system configuration (default "/opt/shift/scripts/bbb-config.sh")
+  -datadir string
+    	Directory where middleware persistent data like noise keys is stored (default ".base")
+  -electrsport string
+    	Electrs rpc port (default "51002")
+  -lightning-rpc-path string
     	Path to the lightning rpc unix socket (default "/home/bitcoin/.lightning/lightning-rpc")
-    -rpcpassword string
-      	Bitcoin rpc password (default "rpcpassword")
-    -rpcport string
-      	Bitcoin rpc port, localhost is assumed as an address (default "8332")
-    -rpcuser string
+  -network string
+    	Indicate wether running bitcoin on regtest, testnet or mainnet (default "testnet")
+  -rpcpassword string
+    	Bitcoin rpc password (default "rpcpassword")
+  -rpcport string
+    	Bitcoin rpc port, localhost is assumed as an address (default "18332")
+  -rpcuser string
     	Bitcoin rpc user name (default "rpcuser")
 
+## Testing
+
+The Makefile also provides a target to run bitcoind, electrs and lightningd on
+regtest in a docker container. Install docker-compose on your machine and run
+`make regtest-up` to start the regtest setup and `make regtest-down` to shutdown.
+The ports available are:
+
+ - 18443 for bitcoin-cli
+ - 60401 for electrs rpc
+
+The current regtest docker-compose file will start two lightnind instances. Their
+rpc files can be accessed in `integration_test/volumes/clightning1` and 
+`intergation_test/volumes/clightning2` respectively.
+To acces the lightningd unix port, the makefile target will ask for a sudo password 
+to change permissions of the lightning-rpc file.
+
+Once the docker container is up, use `bitcoin-cli` and `lightning-cli` to communicate:
+
+    bitcoin-cli -regtest -rpcport=18443 -rpcuser=rpcuser -rpcpassword=rpcpass getblockchaininfo
+    lightning-cli --rpc-file integration_test/volumes/clightning1/lightning-rpc getinfo
+
+For the middleware run:
+
+    middleware -rpcport=18443 -rpcpassword=rpcpass -rpcuser=rpcuser -electrsport=60401 -lightning-rpc-path=integration_test/volumes/clightning1/lightning-rpc
+
+The two c-lightning instances allow communication between each other. To
+connect clightning1 with clightning2, run getinfo on clightning2 and then
+connect to its id on clightning1 with:
+
+    docker exec -ti lightningd1 lightning-cli connect 026c213484d4b3cb8aff9d4186439bf4032b793831051cf1b4189c7d83a6ec47f1 10.10.0.13:9735
 

--- a/middleware/integration_test/docker-compose.yml
+++ b/middleware/integration_test/docker-compose.yml
@@ -1,0 +1,110 @@
+version: "3"
+services:
+  bitcoind:
+    image: nicolasdorier/docker-bitcoin:0.17.0
+    networks:
+      local:
+        ipv4_address: 10.10.0.10
+    environment:
+      EXPOSE_TCP: "true"
+      BITCOIN_EXTRA_ARGS: |
+        regtest=1
+        whitelist=0.0.0.0/0
+        server=1
+        regtest.rpcallowip=10.211.0.0/16
+        regtest.rpcallowip=172.17.0.0/16
+        regtest.rpcallowip=192.168.0.0/16
+        regtest.rpcallowip=0.0.0.0/16
+        regtest.rpcbind=0.0.0.0
+        rpcport=18443
+        rpcuser=rpcuser
+        rpcpassword=rpcpass
+    ports:
+      - 18443:18443
+    volumes:
+      - "./volumes/bitcoin:/data"
+
+  electrs:
+    image: vulpemventures/electrs:latest
+    entrypoint:
+      - /build/electrs
+    command:
+      - -vvvv
+      - --network
+      - regtest
+      - --daemon-dir
+      - /data
+      - --daemon-rpc-addr
+      - 10.10.0.10:18443
+      - --cookie
+      - rpcuser:rpcpass
+      - --electrum-rpc-addr
+      - 0.0.0.0:60401
+      - --cors
+      - "*"
+    networks:
+      local:
+        ipv4_address: 10.10.0.11
+    depends_on:
+      - bitcoind
+    volumes:
+      - "./volumes/bitcoin:/data"
+    restart: unless-stopped
+    ports:
+      - 60401:60401
+
+  clightning_bitcoin1:
+    image: elementsproject/lightningd
+    container_name: lightningd1
+    command:
+      - --bitcoin-rpcconnect=bitcoind
+      - --bitcoin-datadir=/data
+      - --bitcoin-rpcuser=rpcuser
+      - --bitcoin-rpcpassword=rpcpass
+      - --bitcoin-rpcport=18443
+      - --bitcoin-rpcconnect=10.10.0.10
+      - --lightning-dir=/data/.lightning
+      - --network=regtest
+      - --log-level=debug
+    environment:
+      EXPOSE_TCP: "true"
+    volumes:
+      - "./volumes/clightning1:/data/.lightning"
+      - "./volumes/bitcoin:/data"
+    depends_on:
+      - bitcoind
+    networks:
+      local:
+        ipv4_address: 10.10.0.12
+    restart: unless-stopped
+
+  clightning_bitcoin2:
+    image: elementsproject/lightningd
+    container_name: lightningd2
+    command:
+      - --bitcoin-rpcconnect=bitcoind
+      - --bitcoin-datadir=/data
+      - --bitcoin-rpcuser=rpcuser
+      - --bitcoin-rpcpassword=rpcpass
+      - --bitcoin-rpcport=18443
+      - --lightning-dir=/data/.lightning
+      - --network=regtest
+      - --log-level=debug
+    environment:
+      EXPOSE_TCP: "true"
+    volumes:
+      - "./volumes/clightning2:/data/.lightning"
+      - "./volumes/bitcoin:/data"
+    depends_on:
+      - bitcoind
+    networks:
+      local:
+        ipv4_address: 10.10.0.13
+    restart: unless-stopped
+
+networks:
+  local:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 10.10.0.0/24


### PR DESCRIPTION
Add a docker-compose file in the integration_test directory. `docker-compose` will then run, bitcoind, electrs and two instances of lightningd. It can be controlled with the `make regtest-up` and `make regtest-down` target.