### PR TITLE
rename base-middleware to bbbmiddleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 !/build/README.md
 /provisioning/*
 !/provisioning/README.md
+
+# Ignore Docker volume files for Middleware integration test
+/middleware/integration_test/volumes/*

--- a/armbian/base/build/customize-armbian-rockpro64.sh
+++ b/armbian/base/build/customize-armbian-rockpro64.sh
@@ -613,19 +613,19 @@ else
   echo "WARN: bbbfancontrol not found."
 fi
 
-## base-middleware
+## bbbmiddleware
 ## see https://github.com/digitalbitbox/bitbox-base/blob/master/middleware/README.md
-if [ -f /tmp/overlay/bin/base-middleware ]; then
-  cp /tmp/overlay/bin/base-middleware /usr/local/sbin/
+if [ -f /tmp/overlay/bin/bbbmiddleware ]; then
+  cp /tmp/overlay/bin/bbbmiddleware /usr/local/sbin/
 
-  mkdir -p /etc/base-middleware/
-  cat << EOF > /etc/base-middleware/base-middleware.conf
+  mkdir -p /etc/bbbmiddleware/
+  cat << EOF > /etc/bbbmiddleware/bbbmiddleware.conf
 BITCOIN_RPCUSER=__cookie__
 BITCOIN_RPCPORT=18332
 LIGHTNING_RPCPATH=/mnt/ssd/bitcoin/.lightning-testnet/lightning-rpc
 EOF
 
-  cat << 'EOF' > /etc/systemd/system/base-middleware.service
+  cat << 'EOF' > /etc/systemd/system/bbbmiddleware.service
 [Unit]
 Description=BitBox Base Middleware
 Wants=bitcoind.service lightningd.service electrs.service
@@ -633,9 +633,9 @@ After=lightningd.service
 
 [Service]
 Type=simple
-EnvironmentFile=/etc/base-middleware/base-middleware.conf
+EnvironmentFile=/etc/bbbmiddleware/bbbmiddleware.conf
 EnvironmentFile=/mnt/ssd/bitcoin/.bitcoin/.cookie.env
-ExecStart=/usr/local/sbin/base-middleware -rpcuser=${BITCOIN_RPCUSER} -rpcpassword=${RPCPASSWORD} -rpcport=${BITCOIN_RPCPORT} -lightning-rpc-path=${LIGHTNING_RPCPATH} -datadir=/mnt/ssd/system/middleware
+ExecStart=/usr/local/sbin/bbbmiddleware -rpcuser=${BITCOIN_RPCUSER} -rpcpassword=${RPCPASSWORD} -rpcport=${BITCOIN_RPCPORT} -lightning-rpc-path=${LIGHTNING_RPCPATH} -datadir=/mnt/ssd/system/bbbmiddleware
 Restart=always
 RestartSec=10
 
@@ -643,10 +643,10 @@ RestartSec=10
 WantedBy=multi-user.target
 EOF
 
-  systemctl enable base-middleware.service
+  systemctl enable bbbmiddleware.service
 else
   #TODO(Stadicus): for ondevice build, retrieve binary from GitHub release
-  echo "WARN: base-middleware not found."
+  echo "WARN: bbbmiddleware not found."
 fi
 
 

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -156,8 +156,8 @@ case "${COMMAND}" in
                         sed -i '/LIGHTNING-DIR=/Ic\lightning-dir=/mnt/ssd/bitcoin/.lightning' /etc/lightningd/lightningd.conf
                         sed -i '/NETWORK=/Ic\NETWORK=mainnet' /etc/electrs/electrs.conf
                         sed -i '/RPCPORT=/Ic\RPCPORT=8332' /etc/electrs/electrs.conf
-                        sed -i '/BITCOIN_RPCPORT=/Ic\BITCOIN_RPCPORT=8332' /etc/base-middleware/base-middleware.conf || true
-                        sed -i '/LIGHTNING_RPCPATH=/Ic\LIGHTNING_RPCPATH=/mnt/ssd/bitcoin/.lightning/lightning-rpc' /etc/base-middleware/base-middleware.conf || true
+                        sed -i '/BITCOIN_RPCPORT=/Ic\BITCOIN_RPCPORT=8332' /etc/bbbmiddleware/bbbmiddleware.conf || true
+                        sed -i '/LIGHTNING_RPCPATH=/Ic\LIGHTNING_RPCPATH=/mnt/ssd/bitcoin/.lightning/lightning-rpc' /etc/bbbmiddleware/bbbmiddleware.conf || true
                         echo "BITCOIN_NETWORK=mainnet" > "${SYSCONFIG_PATH}/${SETTING}"
                         ;;
 
@@ -170,8 +170,8 @@ case "${COMMAND}" in
                         sed -i '/BITCOIN-RPCPORT=/Ic\bitcoin-rpcport=18332' /etc/lightningd/lightningd.conf
                         sed -i '/NETWORK=/Ic\NETWORK=testnet' /etc/electrs/electrs.conf
                         sed -i '/RPCPORT=/Ic\RPCPORT=18332' /etc/electrs/electrs.conf
-                        sed -i '/BITCOIN_RPCPORT=/Ic\BITCOIN_RPCPORT=18332' /etc/base-middleware/base-middleware.conf || true
-                        sed -i '/LIGHTNING_RPCPATH=/Ic\LIGHTNING_RPCPATH=/mnt/ssd/bitcoin/.lightning-testnet/lightning-rpc' /etc/base-middleware/base-middleware.conf || true
+                        sed -i '/BITCOIN_RPCPORT=/Ic\BITCOIN_RPCPORT=18332' /etc/bbbmiddleware/bbbmiddleware.conf || true
+                        sed -i '/LIGHTNING_RPCPATH=/Ic\LIGHTNING_RPCPATH=/mnt/ssd/bitcoin/.lightning-testnet/lightning-rpc' /etc/bbbmiddleware/bbbmiddleware.conf || true
                         echo "BITCOIN_NETWORK=testnet" > "${SYSCONFIG_PATH}/${SETTING}"
                         ;;
 

--- a/armbian/base/scripts/bbb-systemctl.sh
+++ b/armbian/base/scripts/bbb-systemctl.sh
@@ -31,7 +31,7 @@ case ${ACTION} in
                 echo "bitcoind:                 $(systemctl is-active bitcoind.service)"
                 echo "electrs:                  $(systemctl is-active electrs.service)"
                 echo "lightningd:               $(systemctl is-active lightningd.service)"
-                echo "base-middleware:          $(systemctl is-active base-middleware.service)"
+                echo "bbbmiddleware:            $(systemctl is-active bbbmiddleware.service)"
                 echo "nginx:                    $(systemctl is-active nginx.service)"
                 echo "prometheus:               $(systemctl is-active prometheus.service)"
                 echo "prometheus-node-exporter: $(systemctl is-active prometheus-node-exporter.service)"
@@ -56,7 +56,7 @@ case ${ACTION} in
                 systemctl $ACTION prometheus-bitcoind.service 
                 systemctl $ACTION prometheus-node-exporter.service 
                 systemctl $ACTION grafana-server.service 
-                systemctl $ACTION base-middleware.service
+                systemctl $ACTION bbbmiddleware.service
                 systemctl $ACTION nginx.service 
                 systemctl $ACTION electrs.service 
                 systemctl $ACTION lightningd.service 

--- a/armbian/base/scripts/systemd-bitcoind-post.sh
+++ b/armbian/base/scripts/systemd-bitcoind-post.sh
@@ -10,7 +10,7 @@ mkdir -p /mnt/ssd/bitcoin/.bitcoin/testnet3/
 ln -fs /mnt/ssd/bitcoin/.bitcoin/.cookie /mnt/ssd/bitcoin/.bitcoin/testnet3/.cookie
 
 # wait a few seconds before providing cookie authentication 
-# as .env file for electrs and base-middleware 
+# as .env file for electrs and bbbmiddleware 
 sleep 10
 echo -n 'RPCPASSWORD=' > /mnt/ssd/bitcoin/.bitcoin/.cookie.env
 tail -c +12 /mnt/ssd/bitcoin/.bitcoin/.cookie >> /mnt/ssd/bitcoin/.bitcoin/.cookie.env

--- a/docs/go/middleware.md
+++ b/docs/go/middleware.md
@@ -6,6 +6,6 @@ parent: Go applications
 ---
 ## BitBox Base: Middleware
 
-We have a `middleware` application written in Go, which exposes a single endpoint to the network, acting as a server when the user connects using the [BitBox App](https://github.com/digitalbitbox/bitbox-wallet-app/):
+We have a `bbbmiddleware` application written in Go, which exposes a single endpoint to the network, acting as a server when the user connects using the [BitBox App](https://github.com/digitalbitbox/bitbox-wallet-app/):
 
-[`middleware/`](https://github.com/digitalbitbox/bitbox-base/tree/master/middleware)
+[`bbbmiddleware/`](https://github.com/digitalbitbox/bitbox-base/tree/master/middleware)

--- a/docs/start/build-process.md
+++ b/docs/start/build-process.md
@@ -22,7 +22,7 @@ Unpacking the steps above, what happens when you type `make` is:
     1. [`cd tools && make`](https://github.com/digitalbitbox/bitbox-base/blob/master/tools/Makefile#L38): inside the `digitalbitbox/bitbox-base` container, all Go binaries under the `tools/`  subdirectory are built
         1. [`cd bbbfancontrol && make`](https://github.com/digitalbitbox/bitbox-base/blob/master/tools/bbbfancontrol/Makefile): compiles the `build/bbbfancontrol` binary
         1. [`cd bbbsupervisor && make`](https://github.com/digitalbitbox/bitbox-base/blob/master/tools/supervisor/Makefile): compiles the `build/bbbsupervisor` binary
-    1. [`cd middleware && make`](https://github.com/digitalbitbox/bitbox-base/blob/master/middleware/Makefile#L39): inside the `digitalbitbox/bitbox-base` container, the `build/base-middleware` binary is built from the `middleware/` subdirectory
+    1. [`cd middleware && make`](https://github.com/digitalbitbox/bitbox-base/blob/master/middleware/Makefile#L39): inside the `digitalbitbox/bitbox-base` container, the `build/bbbmiddleware` binary is built from the `middleware/` subdirectory
 1. [`make build-all`](https://github.com/digitalbitbox/bitbox-base/blob/master/Makefile#L20): the default target if `make` is called, and depends on `make docker-build-go`, and after that performs the main Armbian image build
     1. [`cd armbian && make`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/Makefile): builds the Armbian `.img` file, using the Go binaries in `build/` as inputs
     1. finally, the `.img` file is moved to the `build/` directory

--- a/middleware/.gitignore
+++ b/middleware/.gitignore
@@ -1,4 +1,4 @@
-base-middleware
+bbbmiddleware
 
 ### Vim ###
 # Swap

--- a/middleware/.gitignore
+++ b/middleware/.gitignore
@@ -1,5 +1,3 @@
-bbbmiddleware
-
 ### Vim ###
 # Swap
 [._]*.s[a-v][a-z]

--- a/middleware/Makefile
+++ b/middleware/Makefile
@@ -27,7 +27,7 @@ build:
 
 aarch64: check-go-env fetch-deps ci
 	GOARCH=arm64 go install $(REPO_ROOT)/middleware/cmd/middleware
-	cp ${GOPATH}/bin/linux_arm64/middleware $(REPO_ROOT)/build/base-middleware
+	cp ${GOPATH}/bin/linux_arm64/middleware $(REPO_ROOT)/build/bbbmiddleware
 
 regtest-up:
 	cd $(REPO_ROOT)/middleware/integration_test ;\

--- a/middleware/README.md
+++ b/middleware/README.md
@@ -30,9 +30,9 @@ tools)
 The middleware accepts some command line arguments to connect to c-lightning
 and bitcoind. The arguments are expected to be passed in the following fashion:
 
-    ./base-middleware -rpcuser rpcuser -rpcpassword rpcpassword -rpcport 18332 -lightning-rpc-path /home/bitcoin/.lightning/lightning-rpc
+    ./bbbmiddleware -rpcuser rpcuser -rpcpassword rpcpassword -rpcport 18332 -lightning-rpc-path /home/bitcoin/.lightning/lightning-rpc
 
-Running `./base-middleware -h` will print the following help:
+Running `./bbbmiddleware -h` will print the following help:
     
   -bbbconfigscript string
     	Path to the bbb-config file that allows setting system configuration (default "/opt/shift/scripts/bbb-config.sh")

--- a/middleware/base-middleware.service
+++ b/middleware/base-middleware.service
@@ -4,7 +4,7 @@ After=lightningd.service
 
 [Service]
 Type=simple
-ExecStart=/usr/local/sbin/base-middleware
+ExecStart=/usr/local/sbin/bbbmiddleware
 Restart=always
 RestartSec=10
 


### PR DESCRIPTION
Renaming gives consistency over all our own tools, like bbbsupervisor or bbbfancontrol