### PR TITLE
add 'exec bitcoin_resync' option to bbb-config.sh

### DIFF
--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -30,7 +30,8 @@ possible commands:
   apply     no argument, applies all configuration settings to the system 
             [not yet implemented]
 
-  exec      <bitcoin_reindex>
+  exec      bitcoin_reindex   (wipes UTXO set and validates existing blocks)
+            bitcoin_resync    (re-download and validate all blocks)
 
 "
 }


### PR DESCRIPTION
The command 'bbb-config.sh exec bitcoin_resync' deletes the following directories:
* /mnt/ssd/bitcoin/.bitcoin/blocks
* /mnt/ssd/bitcoin/.bitcoin/chainstate
* /mnt/ssd/electrs/db

It removes the trigger file /data/triggers/bitcoind_fully_synced and restarts bitcoind. The dbcache needs to be set to a higher value manually, or by the supervisor.