### PR TITLE
set hostname on first boot

### DIFF
--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -18,6 +18,9 @@ if [ ! -f /data/triggers/datadir_set_up ]; then
   else
     ln -sf /data_source /data
   fi
+
+  # update hostname after symlink /etc/hostname -> /data/network/hostname becomes valid
+  hostnamectl set-hostname `cat /etc/hostname`
 fi
 
 # check for TLS certificate and create it if missing


### PR DESCRIPTION
The hostname is not stored directly in /etc/hostname, which is a symlink to /data/network/hostname. As the /data directory is prepared on first boot, the hostname is still set to 'localhost' and must be set manually, otherwise it is not correctly announced to the network.