### PR TITLE
Middleware: Bitcoin resync and bitcoin reindex option

### DIFF
--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -20,7 +20,7 @@ type Middleware interface {
 	Start() <-chan []byte
 	SystemEnv() (middleware.GetEnvResponse, error)
 	SampleInfo() (middleware.SampleInfoResponse, error)
-	ResyncBitcoin() (middleware.ResyncBitcoinResponse, error)
+	ResyncBitcoin(middleware.ResyncBitcoinOptions) (middleware.ResyncBitcoinResponse, error)
 	VerificationProgress() (middleware.VerificationProgressResponse, error)
 }
 

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -23,7 +23,7 @@ func TestMiddleware(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, systemEnvResponse.ElectrsRPCPort, "18442")
 	require.Equal(t, systemEnvResponse.Network, "testnet")
-	resyncBitcoinResponse, err := middlewareInstance.ResyncBitcoin()
+	resyncBitcoinResponse, err := middlewareInstance.ResyncBitcoin(middleware.ResyncOption)
 	require.NoError(t, err)
 	require.Equal(t, resyncBitcoinResponse.Success, false)
 }

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -45,7 +45,7 @@ func (conn *rpcConn) Close() error {
 // Middleware provides an interface to the middleware package.
 type Middleware interface {
 	SystemEnv() (middleware.GetEnvResponse, error)
-	ResyncBitcoin() (middleware.ResyncBitcoinResponse, error)
+	ResyncBitcoin(middleware.ResyncBitcoinOptions) (middleware.ResyncBitcoinResponse, error)
 	SampleInfo() (middleware.SampleInfoResponse, error)
 	VerificationProgress() (middleware.VerificationProgressResponse, error)
 }
@@ -79,14 +79,14 @@ func (server *RPCServer) GetSystemEnv(args int, reply *middleware.GetEnvResponse
 }
 
 // ResyncBitcoin sends the middleware's ResyncBitcoinResponse over rpc
-func (server *RPCServer) ResyncBitcoin(args int, reply *middleware.ResyncBitcoinResponse) error {
+func (server *RPCServer) ResyncBitcoin(args *middleware.ResyncBitcoinOptions, reply *middleware.ResyncBitcoinResponse) error {
 	var err error
-	*reply, err = server.middleware.ResyncBitcoin()
+	*reply, err = server.middleware.ResyncBitcoin(*args)
 	log.Printf("sent reply %v: ", reply)
 	return err
 }
 
-// GetSampleInfo send the middleware's SampleInfoResponse over rpc
+// GetSampleInfo sends the middleware's SampleInfoResponse over rpc
 func (server *RPCServer) GetSampleInfo(args int, reply *middleware.SampleInfoResponse) error {
 	var err error
 	*reply, err = server.middleware.SampleInfo()
@@ -94,7 +94,7 @@ func (server *RPCServer) GetSampleInfo(args int, reply *middleware.SampleInfoRes
 	return err
 }
 
-// GetSampleInfo send the middleware's SampleInfoResponse over rpc
+// GetVerificationProgress sends the middleware's VerificationProgressResponse over rpc
 func (server *RPCServer) GetVerificationProgress(args int, reply *middleware.VerificationProgressResponse) error {
 	var err error
 	*reply, err = server.middleware.VerificationProgress()


### PR DESCRIPTION
Add an argument to the ResyncBitcoin rpc endpoint in the rpcserver package to allow the client caller to choose between executing a full bitcoin resync, and wiping the chanstate and reindex again from existing blocks.