### PR TITLE
Middleware: Add RPCMessage file to centralize definition of rpc messages

### DIFF
--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"sync"
 
-	middleware "github.com/digitalbitbox/bitbox-base/middleware/src"
 	noisemanager "github.com/digitalbitbox/bitbox-base/middleware/src/noise"
+	"github.com/digitalbitbox/bitbox-base/middleware/src/rpcmessages"
 	"github.com/digitalbitbox/bitbox-base/middleware/src/rpcserver"
 
 	"github.com/gorilla/mux"
@@ -18,10 +18,10 @@ import (
 type Middleware interface {
 	// Start triggers the main middleware event loop that emits events to be caught by the handlers.
 	Start() <-chan []byte
-	SystemEnv() (middleware.GetEnvResponse, error)
-	SampleInfo() (middleware.SampleInfoResponse, error)
-	ResyncBitcoin(middleware.ResyncBitcoinOptions) (middleware.ResyncBitcoinResponse, error)
-	VerificationProgress() (middleware.VerificationProgressResponse, error)
+	SystemEnv() (rpcmessages.GetEnvResponse, error)
+	SampleInfo() (rpcmessages.SampleInfoResponse, error)
+	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
+	VerificationProgress() (rpcmessages.VerificationProgressResponse, error)
 }
 
 // Handlers provides a web api

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	middleware "github.com/digitalbitbox/bitbox-base/middleware/src"
+	"github.com/digitalbitbox/bitbox-base/middleware/src/rpcmessages"
 	"github.com/stretchr/testify/require"
 )
 
@@ -23,7 +24,7 @@ func TestMiddleware(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, systemEnvResponse.ElectrsRPCPort, "18442")
 	require.Equal(t, systemEnvResponse.Network, "testnet")
-	resyncBitcoinResponse, err := middlewareInstance.ResyncBitcoin(middleware.ResyncOption)
+	resyncBitcoinResponse, err := middlewareInstance.ResyncBitcoin(rpcmessages.Resync)
 	require.NoError(t, err)
 	require.Equal(t, resyncBitcoinResponse.Success, false)
 }

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -1,0 +1,53 @@
+package rpcmessages
+
+/*
+Put notification constants here. Notifications for new rpc data should have the format 'OpUCanHas' + 'RPC Method Name'.
+*/
+const (
+	// OpRPCCall is prepended to every rpc response messages, to indicate that the message is rpc response and not a notification.
+	OpRPCCall = "r"
+	// OpUCanHasSampleInfo notifies when new SampleInfo data is available.
+	OpUCanHasSampleInfo = "d"
+)
+
+/*
+Put Incoming Args below this line. They should have the format of 'RPC Method Name' + 'Args'.
+*/
+
+// ResyncBitcoinArgs is an iota that holds the options for the ResyncBitcoin rpc call
+type ResyncBitcoinArgs int
+
+// The ResyncBitcoinArgs has two options. Other resync bitcon from scratch with an IBD, or delete the chainstate and reindex.
+const (
+	Resync ResyncBitcoinArgs = iota
+	Reindex
+)
+
+/*
+Put Response structs below this line. They should have the format of 'RPC Method Name' + 'Response'.
+*/
+
+// GetEnvResponse is the struct that gets sent by the rpc server during a GetSystemEnv call
+type GetEnvResponse struct {
+	Network        string
+	ElectrsRPCPort string
+}
+
+// ResyncBitcoinResponse is the struct that gets sent by the rpc server during a ResyncBitcoin call
+type ResyncBitcoinResponse struct {
+	Success bool
+}
+
+// SampleInfoResponse holds sample information from c-lightning and bitcoind. It is temporary for testing purposes
+type SampleInfoResponse struct {
+	Blocks         int64   `json:"blocks"`
+	Difficulty     float64 `json:"difficulty"`
+	LightningAlias string  `json:"lightningAlias"`
+}
+
+// VerificationProgressResponse is the struct that gets sent by the rpc server during a VerificationProgress rpc call
+type VerificationProgressResponse struct {
+	Blocks               int64   `json:"blocks"`
+	Headers              int64   `json:"headers"`
+	VerificationProgress float64 `json:"verificationProgress"`
+}

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -4,7 +4,7 @@ import (
 	"log"
 	"net/rpc"
 
-	middleware "github.com/digitalbitbox/bitbox-base/middleware/src"
+	"github.com/digitalbitbox/bitbox-base/middleware/src/rpcmessages"
 )
 
 type rpcConn struct {
@@ -34,7 +34,7 @@ func (conn *rpcConn) Read(p []byte) (n int, err error) {
 }
 
 func (conn *rpcConn) Write(p []byte) (n int, err error) {
-	conn.writeChan <- append([]byte("r"), p...)
+	conn.writeChan <- append([]byte(rpcmessages.OpRPCCall), p...)
 	return len(p), nil
 }
 
@@ -44,10 +44,10 @@ func (conn *rpcConn) Close() error {
 
 // Middleware provides an interface to the middleware package.
 type Middleware interface {
-	SystemEnv() (middleware.GetEnvResponse, error)
-	ResyncBitcoin(middleware.ResyncBitcoinOptions) (middleware.ResyncBitcoinResponse, error)
-	SampleInfo() (middleware.SampleInfoResponse, error)
-	VerificationProgress() (middleware.VerificationProgressResponse, error)
+	SystemEnv() (rpcmessages.GetEnvResponse, error)
+	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
+	SampleInfo() (rpcmessages.SampleInfoResponse, error)
+	VerificationProgress() (rpcmessages.VerificationProgressResponse, error)
 }
 
 // RPCServer provides rpc calls to the middleware
@@ -71,7 +71,7 @@ func NewRPCServer(middleware Middleware) *RPCServer {
 }
 
 // GetSystemEnv sends the middleware's GetEnvResponse over rpc
-func (server *RPCServer) GetSystemEnv(args int, reply *middleware.GetEnvResponse) error {
+func (server *RPCServer) GetSystemEnv(args int, reply *rpcmessages.GetEnvResponse) error {
 	var err error
 	*reply, err = server.middleware.SystemEnv()
 	log.Printf("sent reply %v: ", reply)
@@ -79,7 +79,7 @@ func (server *RPCServer) GetSystemEnv(args int, reply *middleware.GetEnvResponse
 }
 
 // ResyncBitcoin sends the middleware's ResyncBitcoinResponse over rpc
-func (server *RPCServer) ResyncBitcoin(args *middleware.ResyncBitcoinOptions, reply *middleware.ResyncBitcoinResponse) error {
+func (server *RPCServer) ResyncBitcoin(args *rpcmessages.ResyncBitcoinArgs, reply *rpcmessages.ResyncBitcoinResponse) error {
 	var err error
 	*reply, err = server.middleware.ResyncBitcoin(*args)
 	log.Printf("sent reply %v: ", reply)
@@ -87,7 +87,7 @@ func (server *RPCServer) ResyncBitcoin(args *middleware.ResyncBitcoinOptions, re
 }
 
 // GetSampleInfo sends the middleware's SampleInfoResponse over rpc
-func (server *RPCServer) GetSampleInfo(args int, reply *middleware.SampleInfoResponse) error {
+func (server *RPCServer) GetSampleInfo(args int, reply *rpcmessages.SampleInfoResponse) error {
 	var err error
 	*reply, err = server.middleware.SampleInfo()
 	log.Printf("sent reply %v: ", reply)
@@ -95,7 +95,7 @@ func (server *RPCServer) GetSampleInfo(args int, reply *middleware.SampleInfoRes
 }
 
 // GetVerificationProgress sends the middleware's VerificationProgressResponse over rpc
-func (server *RPCServer) GetVerificationProgress(args int, reply *middleware.VerificationProgressResponse) error {
+func (server *RPCServer) GetVerificationProgress(args int, reply *rpcmessages.VerificationProgressResponse) error {
 	var err error
 	*reply, err = server.middleware.VerificationProgress()
 	log.Printf("sent reply %v: ", reply)

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	middleware "github.com/digitalbitbox/bitbox-base/middleware/src"
+	"github.com/digitalbitbox/bitbox-base/middleware/src/rpcmessages"
 	rpcserver "github.com/digitalbitbox/bitbox-base/middleware/src/rpcserver"
 
 	"github.com/stretchr/testify/require"
@@ -51,7 +52,7 @@ func TestRPCServer(t *testing.T) {
 	client := rpc.NewClient(&rpcConn{readChan: clientReadChan, writeChan: clientWriteChan})
 
 	request := 1
-	var reply middleware.GetEnvResponse
+	var reply rpcmessages.GetEnvResponse
 	wg := sync.WaitGroup{}
 	wg.Add(1)
 
@@ -71,7 +72,7 @@ func TestRPCServer(t *testing.T) {
 	require.Equal(t, "testnet", reply.Network)
 	require.Equal(t, "18442", reply.ElectrsRPCPort)
 
-	var resyncReply middleware.ResyncBitcoinResponse
+	var resyncReply rpcmessages.ResyncBitcoinResponse
 	wg = sync.WaitGroup{}
 	wg.Add(1)
 


### PR DESCRIPTION
The rpcmessage.go file now specifies how to structure the incoming arguments, the outgoing reply and the notifications of rpccalls.