### PR TITLE
remove local 'theme' to prevent GitHub page build warning

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -6,5 +6,7 @@ aux_links:
     "Contribute! Source on GitHub":
       - "https://github.com/digitalbitbox/bitbox-base"
 ga_tracking: UA-133876831-2
-theme: "just-the-docs"
+
+# enable theme for local usage
+#theme: "just-the-docs"
 


### PR DESCRIPTION
remove local Jekyll 'theme' to prevent GitHub page build warning