### PR TITLE
Minor fixes

### DIFF
--- a/armbian/base/config/iptables/iptables.rules
+++ b/armbian/base/config/iptables/iptables.rules
@@ -42,6 +42,9 @@
 -A INPUT -p tcp --dport 9001 -j ACCEPT
 -A INPUT -p tcp --sport 9001 -j ACCEPT
 
+# Allow inbound TCP traffic to electrs port.
+-A INPUT -p tcp --dport 50002 -j ACCEPT
+
 # Allow inbound ICMP type 0, 3 and 8 ("Echo Reply", "Destination
 # Unreachable" and "Echo", i.e. ping).
 -A INPUT -p icmp -m icmp --icmp-type 0 -j ACCEPT

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -571,7 +571,7 @@ PartOf=bitcoind.service
 [Service]
 EnvironmentFile=/etc/electrs/electrs.conf
 EnvironmentFile=/mnt/ssd/bitcoin/.bitcoin/.cookie.env
-ExecStartPre=/opt/shift/scripts/systemd-electrs-startpre.sh
+ExecStartPre=+/opt/shift/scripts/systemd-electrs-startpre.sh
 ExecStart=/usr/bin/electrs \
     --network ${NETWORK} \
     --db-dir ${DB_DIR} \


### PR DESCRIPTION
Two minor fixes:
* execute systemd-electrs-startpre.sh as root 
* allow incoming TCP port 50002 for electrs in iptables by default  
  Enabling / disabling electrs port should later become part of the configuration management.