### PR TITLE
Websocket cleanup

### DIFF
--- a/middleware/src/handlers/websocket.go
+++ b/middleware/src/handlers/websocket.go
@@ -6,10 +6,6 @@ import (
 	"github.com/gorilla/websocket"
 )
 
-const (
-	opICanHasPairinVerificashun = byte('v')
-)
-
 // runWebsocket sets up loops for sending/receiving, abstracting away the low level details about
 // timeouts, clients closing, etc.
 // It returns four channels: one to send messages to the client, one which notifies when the
@@ -42,14 +38,6 @@ func (handlers *Handlers) runWebsocket(client *websocket.Conn, readChan chan<- [
 			// check if it is the message to request the pairing
 			if len(msg) == 0 {
 				log.Println("Error, received a messaged with zero length, dropping it")
-				continue
-			}
-			if msg[0] == opICanHasPairinVerificashun {
-				msg = handlers.noiseConfig.CheckVerification()
-				err = client.WriteMessage(websocket.TextMessage, msg)
-				if err != nil {
-					log.Println("Error, websocket failed to write channel hash verification message")
-				}
 				continue
 			}
 

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -7,11 +7,13 @@ import (
 	"github.com/digitalbitbox/bitbox-base/middleware/src/rpcmessages"
 )
 
+// rpcConn wraps an io.ReadWriteCloser
 type rpcConn struct {
 	readChan  chan []byte
 	writeChan chan []byte
 }
 
+// newRPCConn returns an rpcConn struct that can be used as an interface to an io.ReadWriteCloser
 func newRPCConn() *rpcConn {
 	RPCConn := &rpcConn{
 		readChan:  make(chan []byte),
@@ -28,16 +30,19 @@ func (conn *rpcConn) WriteChan() chan []byte {
 	return conn.writeChan
 }
 
+// Read implements io.ReadWriteCloser
 func (conn *rpcConn) Read(p []byte) (n int, err error) {
 	message := <-conn.readChan
 	return copy(p, message), nil
 }
 
+// Write implements io.ReadWriteCloser
 func (conn *rpcConn) Write(p []byte) (n int, err error) {
 	conn.writeChan <- append([]byte(rpcmessages.OpRPCCall), p...)
 	return len(p), nil
 }
 
+// Close implements io.ReadWriteCloser. It is just a dummy function.
 func (conn *rpcConn) Close() error {
 	return nil
 }
@@ -59,7 +64,9 @@ type RPCServer struct {
 // NewRPCServer returns a new RPCServer
 func NewRPCServer(middleware Middleware) *RPCServer {
 	server := &RPCServer{
-		middleware:    middleware,
+		middleware: middleware,
+
+		//RPCConnection accepts an io.ReadWriteCloser interface from newRPCConn()
 		RPCConnection: newRPCConn(),
 	}
 	err := rpc.Register(server)


### PR DESCRIPTION
Remove Pairing Verification from Websocket Loop. The Verification Is now done directly in the noise handshake. If a verification call should be available later, make it available through a rpc call.

Document RPCConn roles as io.ReadWriteCloser.