### PR TITLE
Rpc event queue

### DIFF
--- a/middleware/README.md
+++ b/middleware/README.md
@@ -26,6 +26,10 @@ controls data flow to and from bitcoind, lightningd and prometheus. To limit
 calls to bitcoind during initial blockchain download and reindexing operations,
 sync progress and other informational data is fetched from prometheus.
 
+Data fetched from other services is cached in the middleware. These caching
+data structs should be initialized when the middleware is instantiated. A connected
+client should not trigger further rpc or http requests.
+
 The message format of the rpc server is defined in the
 [rpcmessages.go](src/rpcmessages/rpcmessages.go) file. To notify the wallet app
 that new data in the app is available the middleware backend package emits

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -19,9 +19,9 @@ type Middleware interface {
 	// Start triggers the main middleware event loop that emits events to be caught by the handlers.
 	Start() <-chan []byte
 	SystemEnv() (rpcmessages.GetEnvResponse, error)
-	SampleInfo() (rpcmessages.SampleInfoResponse, error)
+	SampleInfo() rpcmessages.SampleInfoResponse
 	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
-	VerificationProgress() (rpcmessages.VerificationProgressResponse, error)
+	VerificationProgress() rpcmessages.VerificationProgressResponse
 }
 
 // Handlers provides a web api

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -18,7 +18,7 @@ import (
 type Middleware interface {
 	// Start triggers the main middleware event loop that emits events to be caught by the handlers.
 	Start() <-chan []byte
-	SystemEnv() (rpcmessages.GetEnvResponse, error)
+	SystemEnv() rpcmessages.GetEnvResponse
 	SampleInfo() rpcmessages.SampleInfoResponse
 	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
 	VerificationProgress() rpcmessages.VerificationProgressResponse

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -150,10 +150,9 @@ func (middleware *Middleware) ResyncBitcoin(option rpcmessages.ResyncBitcoinArgs
 }
 
 // SystemEnv returns a new GetEnvResponse struct with the values as read from the environment
-func (middleware *Middleware) SystemEnv() (rpcmessages.GetEnvResponse, error) {
+func (middleware *Middleware) SystemEnv() rpcmessages.GetEnvResponse {
 	response := rpcmessages.GetEnvResponse{Network: middleware.environment.Network, ElectrsRPCPort: middleware.environment.ElectrsRPCPort}
-	log.Println(&response)
-	return response, nil
+	return response
 }
 
 // SampleInfo returns the chached SampleInfoResponse struct

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -15,10 +15,11 @@ import (
 
 // Middleware connects to services on the base with provided parrameters and emits events for the handler.
 type Middleware struct {
-	info             rpcmessages.SampleInfoResponse
-	environment      system.Environment
-	events           chan []byte
-	prometheusClient *prometheus.PromClient
+	info                 rpcmessages.SampleInfoResponse
+	environment          system.Environment
+	events               chan []byte
+	prometheusClient     *prometheus.PromClient
+	verificationProgress rpcmessages.VerificationProgressResponse
 }
 
 // NewMiddleware returns a new instance of the middleware
@@ -32,14 +33,19 @@ func NewMiddleware(argumentMap map[string]string) *Middleware {
 			Difficulty:     0.0,
 			LightningAlias: "disconnected",
 		},
+		verificationProgress: rpcmessages.VerificationProgressResponse{
+			Blocks:               0,
+			Headers:              0,
+			VerificationProgress: 0.0,
+		},
 	}
 	middleware.prometheusClient = prometheus.NewPromClient(middleware.environment.GetPrometheusURL())
 
 	return middleware
 }
 
-// demoBitcoinRPC is a function that demonstrates a connection to bitcoind. Currently it gets the blockcount and difficulty and writes it into the SampleInfo.
-func (middleware *Middleware) demoBitcoinRPC() {
+// demoBitcoinRPC is a function that demonstrates a connection to bitcoind. Currently it gets the blockcount and difficulty and writes it into the SampleInfo. Once the demo is no longer needed, it should be removed
+func (middleware *Middleware) GetSampleInfo() bool {
 	connCfg := rpcclient.ConnConfig{
 		HTTPPostMode: true,
 		DisableTLS:   true,
@@ -58,29 +64,15 @@ func (middleware *Middleware) demoBitcoinRPC() {
 	blockCount, err := client.GetBlockCount()
 	if err != nil {
 		log.Println(err.Error() + " No blockcount received")
-	} else {
-		middleware.info.Blocks = blockCount
+		return false
 	}
+
 	blockChainInfo, err := client.GetBlockChainInfo()
 	if err != nil {
 		log.Println(err.Error() + " GetBlockChainInfo rpc call failed")
-	} else {
-		middleware.info.Difficulty = blockChainInfo.Difficulty
+		return false
 	}
 
-}
-
-func (middleware *Middleware) VerificationProgress() (rpcmessages.VerificationProgressResponse, error) {
-	verificationProgress := rpcmessages.VerificationProgressResponse{
-		Blocks:               middleware.prometheusClient.Blocks(),
-		Headers:              middleware.prometheusClient.Headers(),
-		VerificationProgress: middleware.prometheusClient.VerificationProgress(),
-	}
-	return verificationProgress, nil
-}
-
-// demoCLightningRPC demonstrates a connection with lightnind. Currently it gets the lightningd alias and writes it into the SampleInfoResponse.
-func (middleware *Middleware) demoCLightningRPC() {
 	ln := &lightning.Client{
 		Path: middleware.environment.GetLightningRPCPath(),
 	}
@@ -88,17 +80,44 @@ func (middleware *Middleware) demoCLightningRPC() {
 	nodeinfo, err := ln.Call("getinfo")
 	if err != nil {
 		log.Println(err.Error() + " Lightningd getinfo called failed.")
-		return
+		return false
 	}
-	middleware.info.LightningAlias = nodeinfo.Get("alias").String()
+
+	updateInfo := rpcmessages.SampleInfoResponse{
+		Blocks:         blockCount,
+		Difficulty:     blockChainInfo.Difficulty,
+		LightningAlias: nodeinfo.Get("alias").String(),
+	}
+	if updateInfo != middleware.info {
+		middleware.info = updateInfo
+		return true
+	}
+	return false
+
 }
 
-//TODO rpcLoop just sends an event to the first client that catches it. In future, this information should properly fan out to all connected clients.
+func (middleware *Middleware) GetVerificationProgress() bool {
+	updateVerificationProgress := rpcmessages.VerificationProgressResponse{
+		Blocks:               middleware.prometheusClient.Blocks(),
+		Headers:              middleware.prometheusClient.Headers(),
+		VerificationProgress: middleware.prometheusClient.VerificationProgress(),
+	}
+	if updateVerificationProgress != middleware.verificationProgress {
+		middleware.verificationProgress = updateVerificationProgress
+		return true
+	}
+	return false
+}
+
+// rpcLoop gets new data from the various rpc connections of the middleware and emits events if new data is available
 func (middleware *Middleware) rpcLoop() {
 	for {
-		middleware.demoBitcoinRPC()
-		middleware.demoCLightningRPC()
-		middleware.events <- []byte(rpcmessages.OpUCanHasSampleInfo)
+		if middleware.GetSampleInfo() {
+			middleware.events <- []byte(rpcmessages.OpUCanHasSampleInfo)
+		}
+		if middleware.GetVerificationProgress() {
+			middleware.events <- []byte(rpcmessages.OpUCanHasVerificationProgress)
+		}
 		time.Sleep(5 * time.Second)
 	}
 }
@@ -130,12 +149,19 @@ func (middleware *Middleware) ResyncBitcoin(option rpcmessages.ResyncBitcoinArgs
 	return response, nil
 }
 
+// SystemEnv returns a new GetEnvResponse struct with the values as read from the environment
 func (middleware *Middleware) SystemEnv() (rpcmessages.GetEnvResponse, error) {
 	response := rpcmessages.GetEnvResponse{Network: middleware.environment.Network, ElectrsRPCPort: middleware.environment.ElectrsRPCPort}
 	log.Println(&response)
 	return response, nil
 }
 
-func (middleware *Middleware) SampleInfo() (rpcmessages.SampleInfoResponse, error) {
-	return middleware.info, nil
+// SampleInfo returns the chached SampleInfoResponse struct
+func (middleware *Middleware) SampleInfo() rpcmessages.SampleInfoResponse {
+	return middleware.info
+}
+
+// VerificationProgress returns the cached VerificationProgressResponse struct
+func (middleware *Middleware) VerificationProgress() rpcmessages.VerificationProgressResponse {
+	return middleware.verificationProgress
 }

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -20,11 +20,24 @@ func TestMiddleware(t *testing.T) {
 
 	middlewareInstance := middleware.NewMiddleware(argumentMap)
 
-	systemEnvResponse, err := middlewareInstance.SystemEnv()
-	require.NoError(t, err)
+	systemEnvResponse := middlewareInstance.SystemEnv()
 	require.Equal(t, systemEnvResponse.ElectrsRPCPort, "18442")
 	require.Equal(t, systemEnvResponse.Network, "testnet")
 	resyncBitcoinResponse, err := middlewareInstance.ResyncBitcoin(rpcmessages.Resync)
-	require.NoError(t, err)
 	require.Equal(t, resyncBitcoinResponse.Success, false)
+	require.NoError(t, err)
+	sampleInfo := middlewareInstance.SampleInfo()
+	emptySampleInfo := rpcmessages.SampleInfoResponse{
+		Blocks:         0,
+		Difficulty:     0.0,
+		LightningAlias: "disconnected",
+	}
+	require.Equal(t, sampleInfo, emptySampleInfo)
+	verificationProgress := middlewareInstance.VerificationProgress()
+	emptyVerificationProgress := rpcmessages.VerificationProgressResponse{
+		Blocks:               0,
+		Headers:              0,
+		VerificationProgress: 0.0,
+	}
+	require.Equal(t, verificationProgress, emptyVerificationProgress)
 }

--- a/middleware/src/prometheus/prometheus.go
+++ b/middleware/src/prometheus/prometheus.go
@@ -42,7 +42,7 @@ func (client *PromClient) query(endpoint string) (string, error) {
 	bodyString := string(body)
 	if !gjson.Valid(bodyString) {
 		log.Println("Received unvalid json from prometheus")
-		return "", errors.New("Received Invalid json from Prometheus")
+		return "", errors.New("received Invalid json from Prometheus")
 	}
 	if success != gjson.Get(bodyString, "status").String() {
 		log.Println("Failed")

--- a/middleware/src/prometheus/prometheus.go
+++ b/middleware/src/prometheus/prometheus.go
@@ -1,6 +1,7 @@
 package prometheus
 
 import (
+	"errors"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -23,31 +24,39 @@ func NewPromClient(address string) *PromClient {
 	}
 }
 
-func (client *PromClient) query(endpoint string) string {
+func (client *PromClient) query(endpoint string) (string, error) {
 	httpClient := http.Client{
 		Timeout: 5 * time.Second,
 	}
 	response, err := httpClient.Get(client.address + "/api/v1/query?query=" + endpoint)
 	if err != nil {
-		log.Printf("Some weird http error: %v", err)
+		log.Printf("HTTP Error")
+		return "", err
 	}
 	defer response.Body.Close()
 	body, err := ioutil.ReadAll(response.Body)
 	if err != nil {
 		log.Println("Could not read prometheus response body")
+		return "", err
 	}
 	bodyString := string(body)
 	if !gjson.Valid(bodyString) {
 		log.Println("Received unvalid json from prometheus")
+		return "", errors.New("Received Invalid json from Prometheus")
+	}
+	if success != gjson.Get(bodyString, "status").String() {
+		log.Println("Failed")
+		return "", nil
 	}
 
-	return bodyString
+	return bodyString, nil
 }
 
 func (client *PromClient) Headers() int64 {
-	response := client.query("bitcoin_headers")
-	if success != gjson.Get(response, "status").String() {
-		log.Println("Failed")
+	response, err := client.query("bitcoin_headers")
+	if err != nil {
+		log.Println(err.Error())
+		return 0
 	}
 	queryResult := gjson.Get(response, "data.result").Array()
 	firstResultValue := queryResult[0].Map()["value"].Array()
@@ -56,9 +65,10 @@ func (client *PromClient) Headers() int64 {
 }
 
 func (client *PromClient) Blocks() int64 {
-	response := client.query("bitcoin_blocks")
-	if success != gjson.Get(response, "status").String() {
-		log.Println("Failed")
+	response, err := client.query("bitcoin_blocks")
+	if err != nil {
+		log.Println(err.Error())
+		return 0
 	}
 	queryResult := gjson.Get(response, "data.result").Array()
 	firstResultValue := queryResult[0].Map()["value"].Array()
@@ -67,9 +77,10 @@ func (client *PromClient) Blocks() int64 {
 }
 
 func (client *PromClient) VerificationProgress() float64 {
-	response := client.query("bitcoin_verification_progress")
-	if success != gjson.Get(response, "status").String() {
-		log.Println("Failed")
+	response, err := client.query("bitcoin_verification_progress")
+	if err != nil {
+		log.Println(err.Error())
+		return 0.0
 	}
 	queryResult := gjson.Get(response, "data.result").Array()
 	firstResultValue := queryResult[0].Map()["value"].Array()

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -8,6 +8,8 @@ const (
 	OpRPCCall = "r"
 	// OpUCanHasSampleInfo notifies when new SampleInfo data is available.
 	OpUCanHasSampleInfo = "d"
+	// OpUCanHasVerificationProgress notifies when new VerificationProgress data is available.
+	OpUCanHasVerificationProgress = "v"
 )
 
 /*

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -51,8 +51,8 @@ func (conn *rpcConn) Close() error {
 type Middleware interface {
 	SystemEnv() (rpcmessages.GetEnvResponse, error)
 	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
-	SampleInfo() (rpcmessages.SampleInfoResponse, error)
-	VerificationProgress() (rpcmessages.VerificationProgressResponse, error)
+	SampleInfo() rpcmessages.SampleInfoResponse
+	VerificationProgress() rpcmessages.VerificationProgressResponse
 }
 
 // RPCServer provides rpc calls to the middleware
@@ -95,18 +95,16 @@ func (server *RPCServer) ResyncBitcoin(args *rpcmessages.ResyncBitcoinArgs, repl
 
 // GetSampleInfo sends the middleware's SampleInfoResponse over rpc
 func (server *RPCServer) GetSampleInfo(args int, reply *rpcmessages.SampleInfoResponse) error {
-	var err error
-	*reply, err = server.middleware.SampleInfo()
+	*reply = server.middleware.SampleInfo()
 	log.Printf("sent reply %v: ", reply)
-	return err
+	return nil
 }
 
 // GetVerificationProgress sends the middleware's VerificationProgressResponse over rpc
 func (server *RPCServer) GetVerificationProgress(args int, reply *rpcmessages.VerificationProgressResponse) error {
-	var err error
-	*reply, err = server.middleware.VerificationProgress()
+	*reply = server.middleware.VerificationProgress()
 	log.Printf("sent reply %v: ", reply)
-	return err
+	return nil
 }
 
 // Serve starts a gob rpc server

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -49,7 +49,7 @@ func (conn *rpcConn) Close() error {
 
 // Middleware provides an interface to the middleware package.
 type Middleware interface {
-	SystemEnv() (rpcmessages.GetEnvResponse, error)
+	SystemEnv() rpcmessages.GetEnvResponse
 	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
 	SampleInfo() rpcmessages.SampleInfoResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
@@ -79,10 +79,9 @@ func NewRPCServer(middleware Middleware) *RPCServer {
 
 // GetSystemEnv sends the middleware's GetEnvResponse over rpc
 func (server *RPCServer) GetSystemEnv(args int, reply *rpcmessages.GetEnvResponse) error {
-	var err error
-	*reply, err = server.middleware.SystemEnv()
+	*reply = server.middleware.SystemEnv()
 	log.Printf("sent reply %v: ", reply)
-	return err
+	return nil
 }
 
 // ResyncBitcoin sends the middleware's ResyncBitcoinResponse over rpc


### PR DESCRIPTION
The middleware polls its rpc connections to lightningd, bitcoind and prometheus every 5 seconds. If new data was received, the corresponding struct is updated and a notification that a new rpc call is sent to the connected wallet app.
 Add new tests for the rpc methods and update the Readme to the new rpc event loop.