### PR TITLE
Extend config scripts for middleware

### DIFF
--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -348,6 +348,7 @@ EOF
 
 ## make bbb scripts executable with sudo
 ln -sf /opt/shift/scripts/bbb-config.sh    /usr/local/sbin/bbb-config.sh
+ln -sf /opt/shift/scripts/bbb-cmd.sh       /usr/local/sbin/bbb-cmd.sh
 ln -sf /opt/shift/scripts/bbb-systemctl.sh /usr/local/sbin/bbb-systemctl.sh
 
 

--- a/armbian/base/scripts/bbb-cmd.sh
+++ b/armbian/base/scripts/bbb-cmd.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+set -eu
+
+# BitBox Base: system commands repository
+#
+
+# print usage information for script
+function usage() {
+  echo "BitBox Base: system commands repository
+usage: bbb-cmd.sh [--version] [--help] <command>
+
+possible commands:
+  bitcoin_reindex   wipes UTXO set and validates existing blocks
+  bitcoin_resync    re-download and validate all blocks
+
+  base_restart      restarts the node
+  base_shutdown     shuts down the node
+
+"
+}
+
+# ------------------------------------------------------------------------------
+
+# check script arguments
+if [[ ${#} -ne 1 ]] || [[ "${1}" == "-h" ]] || [[ "${1}" == "--help" ]]; then
+  usage
+  exit 0
+elif [[ "${1}" == "-v" ]] || [[ "${1}" == "--version" ]]; then
+  echo "bbb-cmd version 0.1"
+  exit 0
+fi
+
+if [[ ${UID} -ne 0 ]]; then
+  echo "${0}: needs to be run as superuser." >&2
+  exit 1
+fi
+
+COMMAND="${1^^}"
+
+case "${COMMAND}" in
+    BITCOIN_REINDEX|BITCOIN_RESYNC)
+        # stop systemd services
+        systemctl stop electrs
+        systemctl stop lightningd
+        systemctl stop bitcoind
+
+        if ! /bin/systemctl -q is-active bitcoind.service; then 
+            # deleting bitcoind chainstate in /mnt/ssd/bitcoin/.bitcoin/chainstate
+            rm -rf /mnt/ssd/bitcoin/.bitcoin/chainstate
+            rm -rf /mnt/ssd/electrs/db
+            rm -rf /data/triggers/bitcoind_fully_synced
+
+            # for RESYNC incl. download, delete `blocks` directory too
+            if [[ "${COMMAND}" == "BITCOIN_RESYNC" ]]; then
+                rm -rf /mnt/ssd/bitcoin/.bitcoin/blocks
+
+            # otherwise assume REINDEX (only validation, no download), set option reindex-chainstate
+            else
+                echo "reindex-chainstate=1" >> /etc/bitcoin/bitcoin.conf
+
+            fi
+
+            # restart bitcoind and remove option
+            systemctl start bitcoind
+            sleep 10
+            sed -i '/reindex/Id' /etc/bitcoin/bitcoin.conf
+
+        else
+            echo "bitcoind is still running, cannot delete chainstate"
+            exit 1
+        fi
+
+        echo "Command ${COMMAND} successfully executed."
+        ;;
+
+    BASE_RESTART)
+        reboot
+        ;;
+
+    BASE_SHUTDOWN)
+        shutdown now
+        ;;
+        
+    *)
+        echo "Invalid argument: command ${COMMAND} unknown."
+
+esac

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -343,6 +343,8 @@ case "${COMMAND}" in
         esac
         ;;
 
+    # EXEC section deprecated and moved to: bbb-cmd.sh script.
+    # remove once bbbmiddleware is adjusted.
     exec)
         case "${SETTING}" in
             BITCOIN_REINDEX|BITCOIN_RESYNC)

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -237,7 +237,6 @@ case "${COMMAND}" in
                         exit 1
                         ;;
                     *)
-                        # TODO(Stadicus): run in overlayroot-chroot for readonly rootfs
                         echo "${3}" > /etc/hostname
                         hostname -F /etc/hostname
                         echo "${SETTING}=${3}" > "${SYSCONFIG_PATH}/${SETTING}"

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -4,9 +4,7 @@ set -eu
 # BitBox Base: system configuration utility
 #
 
-SYSCONFIG_PATH="/data/sysconfig"
-mkdir -p "$SYSCONFIG_PATH"
-
+# print usage information for script
 function usage() {
   echo "BitBox Base: system configuration utility
 usage: bbb-config.sh [--version] [--help]
@@ -14,7 +12,7 @@ usage: bbb-config.sh [--version] [--help]
 
 possible commands:
   enable    <dashboard_hdmi|dashboard_web|wifi|autosetup_ssd|
-             tor_ssh|tor_electrum|overlayroot>
+             tor_ssh|tor_electrum|overlayroot|root_pwlogin>
 
   disable   any 'enable' argument
 
@@ -167,6 +165,16 @@ case "${COMMAND}" in
                     echo "${SETTING}=${ENABLE}" > "${SYSCONFIG_PATH}/${SETTING}"
                     echo "Overlay root filesystem will be disabled on next boot."
                 fi
+                ;;
+
+            ROOT_PWLOGIN)
+                # unlock/lock root user for password login
+                if [[ ${ENABLE} -eq 1 ]]; then
+                    exec_overlayroot both "passwd -u root"
+                else
+                    exec_overlayroot both "passwd -l root"
+                fi
+                echo "${SETTING}=${ENABLE}" > "${SYSCONFIG_PATH}/${SETTING}"
                 ;;
 
             *)


### PR DESCRIPTION
Extend `bbb-config.sh` with function to execute commands within `overlayroot-chroot`, e.g.
* `root_pw`: set root / base user password
* `root_pwlogin': enable / disable password login for 'root' user, both locally and for ssh

Add 'bbb-cmd.sh' as system commands repository, providing operating system-level commands to the command line and the middleware.
```
BitBox Base: system commands repository
usage: bbb-cmd.sh [--version] [--help] <command>

possible commands:
  bitcoin_reindex   wipes UTXO set and validates existing blocks
  bitcoin_resync    re-download and validate all blocks

  base_restart      restarts the node
  base_shutdown     shuts down the node
```