### PR TITLE
Adjust Docker Go build for ./bin/go destination

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 armbian/armbian-build/
 armbian/mender*
-provisioning/
+bin/
 _site/
+middleware/integration_test/volumes/

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     make \
     ca-certificates
 WORKDIR /go/src/github.com/digitalbitbox/bitbox-base
-RUN mkdir build
+RUN mkdir -p bin/go/
 
 # Build the middleware
 FROM bitbox-base as middleware-builder
@@ -33,5 +33,5 @@ RUN make -C "tools"
 # Final
 FROM golang:1.12.5-stretch as final
 
-COPY --from=middleware-builder /go/src/github.com/digitalbitbox/bitbox-base/build/. /opt/build/.
-COPY --from=middleware-tools /go/src/github.com/digitalbitbox/bitbox-base/build/. /opt/build/.
+COPY --from=middleware-builder /go/src/github.com/digitalbitbox/bitbox-base/bin/go/. /opt/build/.
+COPY --from=middleware-tools /go/src/github.com/digitalbitbox/bitbox-base/bin/go/. /opt/build/.

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ docker-build-go: dockerinit
 	docker run \
 	       --rm \
 	       --tty \
-	       -v $(REPO_ROOT)/build:/opt/build_host \
+	       -v $(REPO_ROOT)/bin/go:/opt/build_host \
 	  digitalbitbox/bitbox-base bash -c "cp -f /opt/build/* /opt/build_host"
 
 # build Armbian disk image

--- a/middleware/Makefile
+++ b/middleware/Makefile
@@ -27,7 +27,7 @@ build:
 
 aarch64: check-go-env fetch-deps ci
 	GOARCH=arm64 go install $(REPO_ROOT)/middleware/cmd/middleware
-	cp ${GOPATH}/bin/linux_arm64/middleware $(REPO_ROOT)/build/bbbmiddleware
+	cp ${GOPATH}/bin/linux_arm64/middleware $(REPO_ROOT)/bin/go/bbbmiddleware
 
 regtest-up:
 	cd $(REPO_ROOT)/middleware/integration_test ;\

--- a/tools/bbbfancontrol/Makefile
+++ b/tools/bbbfancontrol/Makefile
@@ -10,7 +10,7 @@ native: check-go-env copy-service
 
 aarch64: check-go-env copy-service
 	GOARCH=arm64 go install $(REPO_ROOT)/tools/bbbfancontrol
-	cp ${GOPATH}/bin/linux_arm64/bbbfancontrol $(REPO_ROOT)/build/
+	cp ${GOPATH}/bin/linux_arm64/bbbfancontrol $(REPO_ROOT)/bin/go/
 
 copy-service:
-	cp bbbfancontrol.service $(REPO_ROOT)/build/
+	cp bbbfancontrol.service $(REPO_ROOT)/bin/go/

--- a/tools/bbbsupervisor/Makefile
+++ b/tools/bbbsupervisor/Makefile
@@ -10,7 +10,7 @@ native: check-go-env copy-service
 
 aarch64: check-go-env copy-service
 	GOARCH=arm64 go install $(REPO_ROOT)/tools/bbbsupervisor
-	cp ${GOPATH}/bin/linux_arm64/bbbsupervisor $(REPO_ROOT)/build/
+	cp ${GOPATH}/bin/linux_arm64/bbbsupervisor $(REPO_ROOT)/bin/go/
 
 copy-service:
-	cp bbbsupervisor.service $(REPO_ROOT)/build/
+	cp bbbsupervisor.service $(REPO_ROOT)/bin/go/


### PR DESCRIPTION
Restructuring of repo directories, especially combining `/build` and `/provisioning` into the various `/bin/*` directories, broke the build process. Fixed by this pull request.