### PR TITLE
bbb-cmd.sh: check / mount / unmount USB drive for backup

### DIFF
--- a/armbian/base/scripts/bbb-cmd.sh
+++ b/armbian/base/scripts/bbb-cmd.sh
@@ -10,11 +10,14 @@ function usage() {
 usage: bbb-cmd.sh [--version] [--help] <command>
 
 possible commands:
-  bitcoin_reindex   wipes UTXO set and validates existing blocks
-  bitcoin_resync    re-download and validate all blocks
+  bitcoind reindex   wipes UTXO set and validates existing blocks
+  bitcoind resync    re-download and validate all blocks
 
-  base_restart      restarts the node
-  base_shutdown     shuts down the node
+  base restart      restarts the node
+  base shutdown     shuts down the node
+  
+  usb_thumbdrive    <check|mount|umount>
+  usb_backup
 
 "
 }
@@ -22,23 +25,28 @@ possible commands:
 # ------------------------------------------------------------------------------
 
 # check script arguments
-if [[ ${#} -ne 1 ]] || [[ "${1}" == "-h" ]] || [[ "${1}" == "--help" ]]; then
-  usage
-  exit 0
+if [[ ${#} == 0 ]] || [[ "${1}" == "-h" ]] || [[ "${1}" == "--help" ]]; then
+    usage
+    exit 0
 elif [[ "${1}" == "-v" ]] || [[ "${1}" == "--version" ]]; then
-  echo "bbb-cmd version 0.1"
-  exit 0
+    echo "bbb-cmd version 0.1"
+    exit 0
 fi
 
 if [[ ${UID} -ne 0 ]]; then
-  echo "${0}: needs to be run as superuser." >&2
-  exit 1
+    echo "${0}: needs to be run as superuser." >&2
+    exit 1
 fi
 
-COMMAND="${1^^}"
+MODULE="${1:-''}"
+COMMAND="${2:-''}"
+ARG="${3:-''}"
 
-case "${COMMAND}" in
-    BITCOIN_REINDEX|BITCOIN_RESYNC)
+MODULE="${MODULE^^}"
+COMMAND="${COMMAND^^}"
+
+case "${MODULE}" in
+    BITCOIND)
         # stop systemd services
         systemctl stop electrs
         systemctl stop lightningd
@@ -51,7 +59,7 @@ case "${COMMAND}" in
             rm -rf /data/triggers/bitcoind_fully_synced
 
             # for RESYNC incl. download, delete `blocks` directory too
-            if [[ "${COMMAND}" == "BITCOIN_RESYNC" ]]; then
+            if [[ "${COMMAND}" == "RESYNC" ]]; then
                 rm -rf /mnt/ssd/bitcoin/.bitcoin/blocks
 
             # otherwise assume REINDEX (only validation, no download), set option reindex-chainstate
@@ -70,18 +78,104 @@ case "${COMMAND}" in
             exit 1
         fi
 
-        echo "Command ${COMMAND} successfully executed."
+        echo "Command ${MODULE} ${COMMAND} successfully executed."
         ;;
 
-    BASE_RESTART)
-        reboot
+    BASE)
+        case "${COMMAND}" in
+            RESTART)
+                reboot
+                ;;
+            SHUTDOWN)
+                shutdown now
+                ;;
+            *)
+                echo "Invalid argument for module ${MODULE}: command ${COMMAND} unknown."
+        esac
         ;;
 
-    BASE_SHUTDOWN)
-        shutdown now
-        ;;
-        
+    USB_THUMBDRIVE)
+        # sanitize device name
+        ARG="${ARG//[^a-zA-Z0-9_\/]/}"
+
+        case "${COMMAND}" in
+            CHECK)
+                usb_thumbdrive_count=0
+                while read scsidev; do
+                    name=$( echo "${scsidev}" | cut -f 1 -d " " )
+                    size=$( echo "${scsidev}" | cut -f 2 -d " " )
+                    type=$( echo "${scsidev}" | cut -f 3 -d " " )
+
+                    # search drives that have partition and are <= 64GB
+                    if [[ "${type}" == "part" ]] && [[ size -lt 64000000000 ]]; then
+                        usb_thumbdrive_count=$((usb_thumbdrive_count + 1))
+                        usb_thumbdrive_name="${name}"
+                    fi
+                done <<< "$(lsblk -o NAME,SIZE,TYPE -abrnp -I 8)"
+
+                # only 1 drive must be present, otherwise abort
+                if [[ usb_thumbdrive_count -eq 1 ]]; then
+                    echo "${usb_thumbdrive_name}"
+
+                elif [[ usb_thumbdrive_count -eq 0 ]]; then
+                    echo "USB_THUMBDRIVE CHECK: no target found"
+                    exit 1
+
+                else
+                    echo "USB_THUMBDRIVE CHECK: too many targets found (${usb_thumbdrive_count} in total)"
+                    exit 1
+                fi               
+                ;;
+
+            MOUNT)
+                # check if ARG is valid USB thumbdrive
+                if ! lsblk "${ARG}" > /dev/null 2>&1; then
+                    echo "USB_THUMBDRIVE MOUNT: device ${ARG} not found."
+                    exit 1
+
+                elif [ `lsblk -o NAME,SIZE,TYPE -abrnp -I 8 ${ARG} | wc -l` -ne 1 ]; then
+                    echo "USB_THUMBDRIVE MOUNT: device ${ARG} is not unique and/or has partitions."
+                    exit 1
+
+                else
+                    scsidev=`lsblk -o NAME,SIZE,TYPE -abrnp -I 8 ${ARG}`
+                    size=$( echo "${scsidev}" | cut -f 2 -d " " )
+                    type=$( echo "${scsidev}" | cut -f 3 -d " " )
+
+                    if [[ "${type}" != "part" ]] || [[ size -gt 64000000000 ]]; then
+                        echo "USB_THUMBDRIVE MOUNT: device ${scsidev} is either bigger than 64GB (${size}) or not a partition (type ${type})."
+                        exit 1
+
+                    # all checks passed
+                    else
+                        # mount USB device with the following options:
+                        #   rw:         read/write
+                        #   nosuid:     cannot contain set userid files, prevents root escalation
+                        #   nodev:      cannot contain special devices
+                        #   noexec:     cannot contain executable binaries
+                        #   noatime:    no update of file access time
+                        #   nodiratime: no update of directory access time
+                        #   sync:       synchronous write, flushed to disk immediatly
+                        mount "${ARG}" -o rw,nosuid,nodev,noexec,noatime,nodiratime,sync /mnt/backup
+                        echo "USB_THUMBDRIVE MOUNT: mounted ${scsidev}} to /mnt/backup"
+                    fi
+
+                fi
+                ;;
+
+            UNMOUNT)
+                if ! mountpoint /mnt/backup -q; then
+                    echo "USB_THUMBDRIVE UNMOUNT: no drive mounted at /mnt/backup"
+                else
+                    echo "USB_THUMBDRIVE UNMOUNT: /mnt/backup unmounted."
+                    umount /mnt/backup
+                fi
+                ;;
+            *)
+                echo "Invalid argument for module ${MODULE}: command ${COMMAND} unknown."
+        esac
+        ;;        
     *)
-        echo "Invalid argument: command ${COMMAND} unknown."
+        echo "Invalid argument: module ${MODULE} unknown."
 
 esac


### PR DESCRIPTION
Builds on top of pr https://github.com/digitalbitbox/bitbox-base/pull/141 and adds the commands mount a USB thumbdrive on `/mnt/backup`.

Thumbdrive detection uses several checks (e.g. must be <= 64GB) and drive is mounted with safe constraints (e.g. don't allow executable binaries or `suid` flags on the drive). 

```console
$ ./bbb-cmd.sh usb_thumbdrive check
/dev/sda1

$ ./bbb-cmd.sh usb_thumbdrive mount /dev/sda1
USB_THUMBDRIVE MOUNT: mounted /dev/sda1 to /mnt/backup

$ ./bbb-cmd.sh usb_thumbdrive mount /dev/sda1
mount: /mnt/backup: /dev/sda1 already mounted on /mnt/backup.

$ ./bbb-cmd.sh usb_thumbdrive unmount
USB_THUMBDRIVE UNMOUNT: /mnt/backup unmounted.

$ ./bbb-cmd.sh usb_thumbdrive unmount
USB_THUMBDRIVE UNMOUNT: no drive mounted at /mnt/backup
```