### PR TITLE
Fix Armbian Docker build

### DIFF
--- a/armbian/armbian-build.sh
+++ b/armbian/armbian-build.sh
@@ -5,7 +5,7 @@
 # Script to automate the build process of the customized Armbian base image for the BitBox Base.
 # Additional information: https://digitalbitbox.github.io/bitbox-base
 #
-set -eux
+set -eu
 
 function usage() {
 	echo "Build customized Armbian base image for BitBox Base"
@@ -45,15 +45,23 @@ case ${ACTION} in
 		cp -aR ../bin/go/* armbian-build/userpatches/overlay/bin/go			# copy additional software binaries to overlay
 
 		BOARD=${BOARD:-rockpro64}
-		BUILD_ARGS="docker BOARD=${BOARD} KERNEL_ONLY=no KERNEL_CONFIGURE=no RELEASE=bionic BRANCH=default BUILD_DESKTOP=no WIREGUARD=no"
-		if ! [ "${ACTION}" == "build" ]; then
-			BUILD_ARGS="${BUILD_ARGS} CLEAN_LEVEL=oldcache PROGRESS_LOG_TO_FILE=yes"
+		BUILD_ARGS="docker BOARD=${BOARD} KERNEL_ONLY=no KERNEL_CONFIGURE=no BUILD_MINIMAL=yes BUILD_DESKTOP=no RELEASE=bionic BRANCH=default WIREGUARD=no PROGRESS_LOG_TO_FILE=yes"
+		if [ "${ACTION}" == "update" ]; then
+			BUILD_ARGS="${BUILD_ARGS} CLEAN_LEVEL=oldcache"
 		fi
 		time armbian-build/compile.sh ${BUILD_ARGS}
 
 		# move compiled Armbian image to binaries directory
-		# TODO(Stadicus): verify that only one file is present
-		mv -v armbian-build/output/images/Armbian_*.img ../bin/img-armbian/BitBoxBase_Armbian_RockPro64.img
+		IMG_COUNT=find armbian-build/output/images/Armbian_*.img | grep -c ^armbian
+		echo $IMG_COUNT
+
+		if [[ ${IMG_COUNT} -eq 1 ]]; then
+			mv -v armbian-build/output/images/Armbian_*.img ../bin/img-armbian/BitBoxBase_Armbian_RockPro64.img
+		else
+			echo "ERR: one image file expected in armbian-build/output/images/, ${IMG_COUNT} files found."
+			find armbian-build/output/images/Armbian_*.img
+			exit 1
+		fi
 		;;
 
 	ondevice)

--- a/armbian/armbian-build.sh
+++ b/armbian/armbian-build.sh
@@ -24,7 +24,7 @@ fi
 
 case ${ACTION} in
 	build|update)
-		if ! which git >/dev/null 2>&1 || ! which docker >/dev/null 2>&1; then
+		if ! command -v git >/dev/null 2>&1 || ! command -v docker >/dev/null 2>&1; then
 			echo
 			echo "Build environment not set up, please check documentation at"
 			echo "https://digitalbitbox.github.io/bitbox-base"
@@ -49,11 +49,11 @@ case ${ACTION} in
 		if [ "${ACTION}" == "update" ]; then
 			BUILD_ARGS="${BUILD_ARGS} CLEAN_LEVEL=oldcache"
 		fi
+		# shellcheck disable=SC2086
 		time armbian-build/compile.sh ${BUILD_ARGS}
 
 		# move compiled Armbian image to binaries directory
-		IMG_COUNT=find armbian-build/output/images/Armbian_*.img | grep -c ^armbian
-		echo $IMG_COUNT
+		IMG_COUNT=$(find armbian-build/output/images/Armbian_*.img | grep -c ^armbian)
 
 		if [[ ${IMG_COUNT} -eq 1 ]]; then
 			mv -v armbian-build/output/images/Armbian_*.img ../bin/img-armbian/BitBoxBase_Armbian_RockPro64.img

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -207,7 +207,7 @@ fi
 
 ## install dependecies
 apt install -y --no-install-recommends \
-  git openssl network-manager net-tools fio libnss-mdns avahi-daemon avahi-discover avahi-utils fail2ban acl rsync smartmontools
+  git openssl network-manager net-tools fio libnss-mdns avahi-daemon avahi-discover avahi-utils fail2ban acl rsync smartmontools curl
 apt install -y --no-install-recommends ifmetric
 
 # debug

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -81,11 +81,15 @@ COMMAND="${1}"
 SETTING="${2^^}"
 
 # check if overlayroot is enabled
-source /etc/overlayroot.local.conf
-if [[ "${overlayroot:0:5}" == "tmpfs" ]]; then
-    OVERLAYROOT_ENABLED=true;
-else
-    OVERLAYROOT_ENABLED=false;
+OVERLAYROOT_ENABLED=false;
+
+if [ -f /etc/overlayroot.local.conf ]; then
+    overlayroot=""
+    # shellcheck disable=SC1091
+    source /etc/overlayroot.local.conf
+    if [[ "${overlayroot:0:5}" == "tmpfs" ]]; then
+        OVERLAYROOT_ENABLED=true;
+    fi
 fi
 
 # parse COMMAND: enable, disable, get, set
@@ -277,7 +281,7 @@ case "${COMMAND}" in
 
             HOSTNAME)
                 case "${3}" in
-                    [^0-9A-Za-z]*|*[^\-0-9A-Z_a-z]*|*[^0-9A-Za-z]|*-_*|*_-*)
+                    [^0-9A-Za-z]*|*[^-0-9A-Z_a-z]*|*[^0-9A-Za-z]|*-_*|*_-*)
                         echo "Invalid argument: '${3}' is not a valid hostname."
                         exit 1
                         ;;


### PR DESCRIPTION
Due to recent changes in Armbian Docker build process, this pull-request 
* add the `BUILD_MINIMAL=yes` argument
* installs `curl` for the BitBox Base image

Before moving the final disk image, the number of images available in the target directory is checked and expected to equal 1.