### PR TITLE
Middleware: Add Flashdrive, Backup and Restore RPCs

### DIFF
--- a/middleware/.golangci.yml
+++ b/middleware/.golangci.yml
@@ -60,7 +60,7 @@ linters-settings:
     suggest-new: true
   dupl:
     # tokens count to trigger issue, 150 by default
-    threshold: 150
+    threshold: 155
   goconst:
     # minimal length of string constant, 3 by default
     min-len: 3

--- a/middleware/cmd/middleware/main.go
+++ b/middleware/cmd/middleware/main.go
@@ -20,6 +20,7 @@ func main() {
 	dataDir := flag.String("datadir", ".base", "Directory where middleware persistent data like noise keys is stored")
 	network := flag.String("network", "testnet", "Indicate wether running bitcoin on testnet or mainnet")
 	bbbConfigScript := flag.String("bbbconfigscript", "/opt/shift/scripts/bbb-config.sh", "Path to the bbb-config file that allows setting system configuration")
+	bbbCmdScript := flag.String("bbbcmdscript", "/opt/shift/scripts/bbb-cmd.sh", "Path to the bbb-cmd file that allows executing system commands")
 	prometheusURL := flag.String("prometheusurl", "http://localhost:9090", "Url of the prometheus server in the form of 'http://localhost:9090'")
 	flag.Parse()
 
@@ -31,6 +32,7 @@ func main() {
 	argumentMap["electrsRPCPort"] = *electrsRPCPort
 	argumentMap["network"] = *network
 	argumentMap["bbbConfigScript"] = *bbbConfigScript
+	argumentMap["bbbCmdScript"] = *bbbCmdScript
 	argumentMap["prometheusURL"] = *prometheusURL
 
 	logBeforeExit := func() {

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -21,8 +21,9 @@ type Middleware interface {
 	SystemEnv() rpcmessages.GetEnvResponse
 	SampleInfo() rpcmessages.SampleInfoResponse
 	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
-	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.FlashdriveResponse, error)
-	Backup(rpcmessages.BackupArgs) (rpcmessages.BackupResponse, error)
+	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error)
+	Backup(rpcmessages.BackupArgs) (rpcmessages.GenericResponse, error)
+	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 }
 

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -22,6 +22,7 @@ type Middleware interface {
 	SampleInfo() rpcmessages.SampleInfoResponse
 	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
 	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.FlashdriveResponse, error)
+	Backup(rpcmessages.BackupArgs) (rpcmessages.BackupResponse, error)
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 }
 

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -21,6 +21,7 @@ type Middleware interface {
 	SystemEnv() rpcmessages.GetEnvResponse
 	SampleInfo() rpcmessages.SampleInfoResponse
 	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
+	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.FlashdriveResponse, error)
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 }
 

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -169,7 +169,7 @@ func (middleware *Middleware) VerificationProgress() rpcmessages.VerificationPro
 func (middleware *Middleware) Flashdrive(args rpcmessages.FlashdriveArgs) (rpcmessages.FlashdriveResponse, error) {
 	switch args.Method {
 	case rpcmessages.Check:
-		log.Println("executing a USB flashdrive check via the cmd script")
+		log.Println("Executing a USB flashdrive check via the cmd script")
 		out, err := middleware.runBBBCmdScript("usb_flashdrive", "check")
 		if err != nil {
 			return rpcmessages.FlashdriveResponse{Success: false, Message: string(out)}, nil
@@ -177,7 +177,7 @@ func (middleware *Middleware) Flashdrive(args rpcmessages.FlashdriveArgs) (rpcme
 		return rpcmessages.FlashdriveResponse{Success: true, Message: string(out)}, nil
 
 	case rpcmessages.Mount:
-		log.Println("executing a USB flashdrive mount via the cmd script")
+		log.Println("Executing a USB flashdrive mount via the cmd script")
 		out, err := middleware.runBBBCmdScript("usb_flashdrive", "mount"+" "+args.Path)
 		if err != nil {
 			return rpcmessages.FlashdriveResponse{Success: false, Message: string(out)}, nil
@@ -185,7 +185,7 @@ func (middleware *Middleware) Flashdrive(args rpcmessages.FlashdriveArgs) (rpcme
 		return rpcmessages.FlashdriveResponse{Success: true, Message: string(out)}, nil
 
 	case rpcmessages.Unmount:
-		log.Println("executing a USB flashdrive unmount via the cmd script")
+		log.Println("Executing a USB flashdrive unmount via the cmd script")
 		out, err := middleware.runBBBCmdScript("usb_flashdrive", "unmount")
 		if err != nil {
 			return rpcmessages.FlashdriveResponse{Success: false, Message: string(out)}, nil
@@ -193,7 +193,31 @@ func (middleware *Middleware) Flashdrive(args rpcmessages.FlashdriveArgs) (rpcme
 		return rpcmessages.FlashdriveResponse{Success: true, Message: string(out)}, nil
 
 	default:
-		return rpcmessages.FlashdriveResponse{Success: false, Message: "FlashdriveMethod not supported. (" + string(args.Method) + ")"}, nil
+		return rpcmessages.FlashdriveResponse{Success: false, Message: "Method " + string(args.Method) + " not supported for Flashdrive."}, nil
+	}
+}
+
+// Backup returns a BackupResponse struct in response to a rpcserver request
+func (middleware *Middleware) Backup(method rpcmessages.BackupArgs) (rpcmessages.BackupResponse, error) {
+	switch method {
+	case rpcmessages.SysConfig:
+		log.Println("Executing a backup of the system config via the cmd script")
+		out, err := middleware.runBBBCmdScript("backup", "sysconfig")
+		if err != nil {
+			return rpcmessages.BackupResponse{Success: false, Message: string(out)}, nil
+		}
+		return rpcmessages.BackupResponse{Success: true, Message: string(out)}, nil
+
+	case rpcmessages.HSMSecret:
+		log.Println("Executing a backup of the c-lightning hsm_secret via the cmd script")
+		out, err := middleware.runBBBCmdScript("backup", "hsm_secret")
+		if err != nil {
+			return rpcmessages.BackupResponse{Success: false, Message: string(out)}, nil
+		}
+		return rpcmessages.BackupResponse{Success: true, Message: string(out)}, nil
+
+	default:
+		return rpcmessages.BackupResponse{Success: false, Message: "Method " + string(method) + " not supported for Backup."}, nil
 	}
 }
 

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -136,10 +136,10 @@ func (middleware *Middleware) ResyncBitcoin(option rpcmessages.ResyncBitcoinArgs
 	switch option {
 	case rpcmessages.Resync:
 		log.Println("executing full bitcoin resync in config script")
-		cmd = exec.Command("."+middleware.environment.GetBBBConfigScript(), "exec", "bitcoin_resync")
+		cmd = exec.Command(middleware.environment.GetBBBConfigScript(), "exec", "bitcoin_resync")
 	case rpcmessages.Reindex:
 		log.Println("executing bitcoin reindex in config script")
-		cmd = exec.Command("."+middleware.environment.GetBBBConfigScript(), "exec", "bitcoin_reindex")
+		cmd = exec.Command(middleware.environment.GetBBBConfigScript(), "exec", "bitcoin_reindex")
 	default:
 	}
 	err := cmd.Run()
@@ -253,8 +253,8 @@ func (middleware *Middleware) Restore(method rpcmessages.RestoreArgs) (rpcmessag
 
 func (middleware *Middleware) runBBBCmdScript(method string, arg string) (out []byte, err error) {
 	script := middleware.environment.GetBBBCmdScript()
-	cmdAsString := "." + script + " " + method + " " + arg
-	out, err = exec.Command("."+script, method, "check").Output()
+	cmdAsString := script + " " + method + " " + arg
+	out, err = exec.Command(script, method, arg).Output()
 	if err != nil {
 		// no error handling here, only logging.
 		log.Printf("Error: The command '%s' exited with the output '%v' and error '%s'.\n", cmdAsString, string(out), err.Error())

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -2,6 +2,7 @@
 package middleware
 
 import (
+	"errors"
 	"log"
 	"os/exec"
 	"time"
@@ -165,59 +166,86 @@ func (middleware *Middleware) VerificationProgress() rpcmessages.VerificationPro
 	return middleware.verificationProgress
 }
 
-// Flashdrive returns a FlashdriveResponse struct in response to a rpcserver request
-func (middleware *Middleware) Flashdrive(args rpcmessages.FlashdriveArgs) (rpcmessages.FlashdriveResponse, error) {
+// Flashdrive returns a GenericResponse struct in response to a rpcserver request
+func (middleware *Middleware) Flashdrive(args rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error) {
 	switch args.Method {
 	case rpcmessages.Check:
 		log.Println("Executing a USB flashdrive check via the cmd script")
-		out, err := middleware.runBBBCmdScript("usb_flashdrive", "check")
+		out, err := middleware.runBBBCmdScript("flashdrive", "check")
 		if err != nil {
-			return rpcmessages.FlashdriveResponse{Success: false, Message: string(out)}, nil
+			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
 		}
-		return rpcmessages.FlashdriveResponse{Success: true, Message: string(out)}, nil
+		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
 
 	case rpcmessages.Mount:
 		log.Println("Executing a USB flashdrive mount via the cmd script")
-		out, err := middleware.runBBBCmdScript("usb_flashdrive", "mount"+" "+args.Path)
+		out, err := middleware.runBBBCmdScript("flashdrive", "mount"+" "+args.Path)
 		if err != nil {
-			return rpcmessages.FlashdriveResponse{Success: false, Message: string(out)}, nil
+			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
 		}
-		return rpcmessages.FlashdriveResponse{Success: true, Message: string(out)}, nil
+		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
 
 	case rpcmessages.Unmount:
 		log.Println("Executing a USB flashdrive unmount via the cmd script")
-		out, err := middleware.runBBBCmdScript("usb_flashdrive", "unmount")
+		out, err := middleware.runBBBCmdScript("flashdrive", "unmount")
 		if err != nil {
-			return rpcmessages.FlashdriveResponse{Success: false, Message: string(out)}, nil
+			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
 		}
-		return rpcmessages.FlashdriveResponse{Success: true, Message: string(out)}, nil
+		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
 
 	default:
-		return rpcmessages.FlashdriveResponse{Success: false, Message: "Method " + string(args.Method) + " not supported for Flashdrive."}, nil
+		errorMessage := "Method " + string(args.Method) + " not supported for Flashdrive()."
+		return rpcmessages.GenericResponse{Success: false, Message: errorMessage}, errors.New(errorMessage)
 	}
 }
 
-// Backup returns a BackupResponse struct in response to a rpcserver request
-func (middleware *Middleware) Backup(method rpcmessages.BackupArgs) (rpcmessages.BackupResponse, error) {
+// Backup returns a GenericResponse struct in response to a rpcserver request
+func (middleware *Middleware) Backup(method rpcmessages.BackupArgs) (rpcmessages.GenericResponse, error) {
 	switch method {
-	case rpcmessages.SysConfig:
+	case rpcmessages.BackupSysConfig:
 		log.Println("Executing a backup of the system config via the cmd script")
 		out, err := middleware.runBBBCmdScript("backup", "sysconfig")
 		if err != nil {
-			return rpcmessages.BackupResponse{Success: false, Message: string(out)}, nil
+			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
 		}
-		return rpcmessages.BackupResponse{Success: true, Message: string(out)}, nil
+		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
 
-	case rpcmessages.HSMSecret:
+	case rpcmessages.BackupHSMSecret:
 		log.Println("Executing a backup of the c-lightning hsm_secret via the cmd script")
 		out, err := middleware.runBBBCmdScript("backup", "hsm_secret")
 		if err != nil {
-			return rpcmessages.BackupResponse{Success: false, Message: string(out)}, nil
+			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
 		}
-		return rpcmessages.BackupResponse{Success: true, Message: string(out)}, nil
+		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
 
 	default:
-		return rpcmessages.BackupResponse{Success: false, Message: "Method " + string(method) + " not supported for Backup."}, nil
+		errorMessage := "Method " + string(method) + " not supported for Backup()."
+		return rpcmessages.GenericResponse{Success: false, Message: errorMessage}, errors.New(errorMessage)
+	}
+}
+
+// Restore returns a GenericResponse struct in response to a rpcserver request
+func (middleware *Middleware) Restore(method rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error) {
+	switch method {
+	case rpcmessages.RestoreSysConfig:
+		log.Println("Executing a restore of the system config via the cmd script")
+		out, err := middleware.runBBBCmdScript("restore", "sysconfig")
+		if err != nil {
+			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
+		}
+		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
+
+	case rpcmessages.RestoreHSMSecret:
+		log.Println("Executing a restore of the c-lightning hsm_secret via the cmd script")
+		out, err := middleware.runBBBCmdScript("restore", "hsm_secret")
+		if err != nil {
+			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
+		}
+		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
+
+	default:
+		errorMessage := "Method " + string(method) + " not supported for Restore()."
+		return rpcmessages.GenericResponse{Success: false, Message: errorMessage}, errors.New(errorMessage)
 	}
 }
 

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -142,11 +142,12 @@ func (middleware *Middleware) ResyncBitcoin(option rpcmessages.ResyncBitcoinArgs
 	default:
 	}
 	err := cmd.Run()
-	response := rpcmessages.ResyncBitcoinResponse{Success: true}
 	if err != nil {
 		log.Println(err.Error() + " failed to run resync command, script does not exist")
-		response = rpcmessages.ResyncBitcoinResponse{Success: false}
+		response := rpcmessages.ResyncBitcoinResponse{Success: false}
+		return response, err
 	}
+	response := rpcmessages.ResyncBitcoinResponse{Success: true}
 	return response, nil
 }
 

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -3,6 +3,7 @@ package middleware
 
 import (
 	"errors"
+	"fmt"
 	"log"
 	"os/exec"
 	"time"
@@ -195,7 +196,7 @@ func (middleware *Middleware) Flashdrive(args rpcmessages.FlashdriveArgs) (rpcme
 		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
 
 	default:
-		errorMessage := "Method " + string(args.Method) + " not supported for Flashdrive()."
+		errorMessage := fmt.Sprintf("Method %d not supported for Flashdrive().", args.Method)
 		return rpcmessages.GenericResponse{Success: false, Message: errorMessage}, errors.New(errorMessage)
 	}
 }
@@ -220,7 +221,7 @@ func (middleware *Middleware) Backup(method rpcmessages.BackupArgs) (rpcmessages
 		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
 
 	default:
-		errorMessage := "Method " + string(method) + " not supported for Backup()."
+		errorMessage := fmt.Sprintf("Method %d not supported for Backup().", method)
 		return rpcmessages.GenericResponse{Success: false, Message: errorMessage}, errors.New(errorMessage)
 	}
 }
@@ -245,7 +246,7 @@ func (middleware *Middleware) Restore(method rpcmessages.RestoreArgs) (rpcmessag
 		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
 
 	default:
-		errorMessage := "Method " + string(method) + " not supported for Restore()."
+		errorMessage := fmt.Sprintf("Method %d not supported for Restore().", method)
 		return rpcmessages.GenericResponse{Success: false, Message: errorMessage}, errors.New(errorMessage)
 	}
 }

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -16,7 +16,8 @@ func TestMiddleware(t *testing.T) {
 	argumentMap["lightningRPCPath"] = "/home/bitcoin/.lightning"
 	argumentMap["electrsRPCPort"] = "18442"
 	argumentMap["network"] = "testnet"
-	argumentMap["bbbConfigScript"] = "/home/bitcoin/script.sh"
+	argumentMap["bbbConfigScript"] = "/home/bitcoin/config-script.sh"
+	argumentMap["bbbCmdScript"] = "/home/bitcoin/cmd-script.sh"
 
 	middlewareInstance := middleware.NewMiddleware(argumentMap)
 

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -8,7 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMiddleware(t *testing.T) {
+// setupTestMiddleware middleware returns a middleware setup with testing arguments
+func setupTestMiddleware() *middleware.Middleware {
 	argumentMap := make(map[string]string)
 	argumentMap["bitcoinRPCUser"] = "user"
 	argumentMap["bitcoinRPCPassword"] = "password"
@@ -19,26 +20,51 @@ func TestMiddleware(t *testing.T) {
 	argumentMap["bbbConfigScript"] = "/home/bitcoin/config-script.sh"
 	argumentMap["bbbCmdScript"] = "/home/bitcoin/cmd-script.sh"
 
-	middlewareInstance := middleware.NewMiddleware(argumentMap)
+	testMiddleware := middleware.NewMiddleware(argumentMap)
 
-	systemEnvResponse := middlewareInstance.SystemEnv()
+	return testMiddleware
+}
+
+func TestSystemEnvResponse(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	systemEnvResponse := testMiddleware.SystemEnv()
+
 	require.Equal(t, systemEnvResponse.ElectrsRPCPort, "18442")
 	require.Equal(t, systemEnvResponse.Network, "testnet")
-	resyncBitcoinResponse, err := middlewareInstance.ResyncBitcoin(rpcmessages.Resync)
+}
+
+func TestResyncBitcoinResponse(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	resyncBitcoinResponse, err := testMiddleware.ResyncBitcoin(rpcmessages.Resync)
+
 	require.Equal(t, resyncBitcoinResponse.Success, false)
 	require.NoError(t, err)
-	sampleInfo := middlewareInstance.SampleInfo()
+}
+
+func TestSampleInfo(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	sampleInfo := testMiddleware.SampleInfo()
 	emptySampleInfo := rpcmessages.SampleInfoResponse{
 		Blocks:         0,
 		Difficulty:     0.0,
 		LightningAlias: "disconnected",
 	}
+
 	require.Equal(t, sampleInfo, emptySampleInfo)
-	verificationProgress := middlewareInstance.VerificationProgress()
+}
+
+func TestVerificationProgress(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	verificationProgress := testMiddleware.VerificationProgress()
 	emptyVerificationProgress := rpcmessages.VerificationProgressResponse{
 		Blocks:               0,
 		Headers:              0,
 		VerificationProgress: 0.0,
 	}
+
 	require.Equal(t, verificationProgress, emptyVerificationProgress)
 }

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -17,7 +17,7 @@ func setupTestMiddleware() *middleware.Middleware {
 	argumentMap["lightningRPCPath"] = "/home/bitcoin/.lightning"
 	argumentMap["electrsRPCPort"] = "18442"
 	argumentMap["network"] = "testnet"
-	argumentMap["bbbConfigScript"] = "/home/bitcoin/config-script.sh"
+	argumentMap["bbbConfigScript"] = "/home/bitcoin/bbb-cmd.sh"
 	argumentMap["bbbCmdScript"] = "/home/bitcoin/cmd-script.sh"
 
 	testMiddleware := middleware.NewMiddleware(argumentMap)
@@ -32,15 +32,6 @@ func TestSystemEnvResponse(t *testing.T) {
 
 	require.Equal(t, systemEnvResponse.ElectrsRPCPort, "18442")
 	require.Equal(t, systemEnvResponse.Network, "testnet")
-}
-
-func TestResyncBitcoinResponse(t *testing.T) {
-	testMiddleware := setupTestMiddleware()
-
-	resyncBitcoinResponse, err := testMiddleware.ResyncBitcoin(rpcmessages.Resync)
-
-	require.Equal(t, resyncBitcoinResponse.Success, false)
-	require.NoError(t, err)
 }
 
 func TestSampleInfo(t *testing.T) {
@@ -67,4 +58,127 @@ func TestVerificationProgress(t *testing.T) {
 	}
 
 	require.Equal(t, verificationProgress, emptyVerificationProgress)
+}
+
+// TestResyncBitcoin only covers the script not found case.
+// We can't know the absolute path of the script, because that depends
+// on the system the tests are executed. e.g. Travis path and local path differ.
+func TestResyncBitcoin(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	resyncBitcoinResponse, err := testMiddleware.ResyncBitcoin(rpcmessages.Resync)
+
+	require.Equal(t, resyncBitcoinResponse.Success, false)
+	require.Error(t, err)
+}
+
+// TestFlashdrive only covers the 'script not found' case.
+// We can't know the absolute path of the script, because that depends
+// on the system the tests are executed. e.g. Travis path and local path differ.
+func TestFlashdrive(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	/* --- test check arg for Flashdrive() ---*/
+	checkArgs := rpcmessages.FlashdriveArgs{
+		Method: rpcmessages.Check,
+		Path:   "", // not needed, only needed for mount
+	}
+
+	flashdriveCheck, errCheck := testMiddleware.Flashdrive(checkArgs)
+
+	require.Equal(t, flashdriveCheck.Success, false)
+	require.Empty(t, flashdriveCheck.Message) // should be empty, because the script should not be found and can't acctually return something
+	require.Error(t, errCheck)
+
+	/* --- test mount arg for Flashdrive() ---*/
+	mountArgs := rpcmessages.FlashdriveArgs{
+		Method: rpcmessages.Mount,
+		Path:   "/dev/sda",
+	}
+
+	flashdriveMount, errMount := testMiddleware.Flashdrive(mountArgs)
+
+	require.Equal(t, flashdriveMount.Success, false)
+	require.Empty(t, flashdriveMount.Message) // should be empty, because the script should not be found and can't acctually return something
+	require.Error(t, errMount)
+
+	/* --- test unmount arg for Flashdrive() ---*/
+	unmountArgs := rpcmessages.FlashdriveArgs{
+		Method: rpcmessages.Unmount,
+		Path:   "", // not needed, only needed for mount
+	}
+
+	flashdriveUnmount, errUnmount := testMiddleware.Flashdrive(unmountArgs)
+
+	require.Equal(t, flashdriveUnmount.Success, false)
+	require.Empty(t, flashdriveUnmount.Message) // should be empty, because the script should not be found and can't acctually return something
+	require.Error(t, errUnmount)
+
+	/* --- test an unkown arg for Flashdrive() ---*/
+	unkownArgs := rpcmessages.FlashdriveArgs{
+		Method: -1,
+		Path:   "",
+	}
+
+	flashdriveUnkown, errUnkown := testMiddleware.Flashdrive(unkownArgs)
+
+	require.Equal(t, flashdriveUnkown.Success, false) // should fail, the method -1 is unknown
+	require.Equal(t, flashdriveUnkown.Message, "Method -1 not supported for Flashdrive().")
+	require.Error(t, errUnkown)
+}
+
+// TestBackup only covers the 'script not found' case.
+// We can't know the absolute path of the script, because that depends
+// on the system the tests are executed. e.g. Travis path and local path differ.
+func TestBackup(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	/* --- test sysconfig arg for Backup() ---*/
+	backupSysconfig, errSysconfig := testMiddleware.Backup(rpcmessages.BackupSysConfig)
+
+	require.Equal(t, backupSysconfig.Success, false) // should fail, because the script location is invalid
+	require.Empty(t, backupSysconfig.Message)        // should be empty, because the script should not be found and can't acctually return something
+	require.Error(t, errSysconfig)
+
+	/* --- test hsm secret arg for Backup() ---*/
+	backupHSMSecret, errHSMSecret := testMiddleware.Backup(rpcmessages.BackupHSMSecret)
+
+	require.Equal(t, backupHSMSecret.Success, false) // should fail, because the script location is invalid
+	require.Empty(t, backupHSMSecret.Message)        // should be empty, because the script should not be found and can't acctually return something
+	require.Error(t, errHSMSecret)
+
+	/* --- test an unknown arg for Backup() ---*/
+	backupUnkown, errUnkown := testMiddleware.Backup(-1)
+
+	require.Equal(t, backupUnkown.Success, false) // should fail, the method -1 is unknown
+	require.Equal(t, backupUnkown.Message, "Method -1 not supported for Backup().")
+	require.Error(t, errUnkown)
+}
+
+// TestRestore only covers the 'script not found' case.
+// We can't know the absolute path of the script, because that depends
+// on the system the tests are executed. e.g. Travis path and local path differ.
+func TestRestore(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	/* --- test sysconfig arg for Restore() ---*/
+	restoreSysconfig, errSysconfig := testMiddleware.Restore(rpcmessages.RestoreSysConfig)
+
+	require.Equal(t, restoreSysconfig.Success, false) // should fail, because the script location is invalid
+	require.Empty(t, restoreSysconfig.Message)        // should be empty, because the script should not be found and can't acctually return something
+	require.Error(t, errSysconfig)
+
+	/* --- test hsm secret arg for Restore() ---*/
+	restoreHSMSecret, errHSMSecret := testMiddleware.Restore(rpcmessages.RestoreHSMSecret)
+
+	require.Equal(t, restoreHSMSecret.Success, false) // should fail, because the script location is invalid
+	require.Empty(t, restoreHSMSecret.Message)        // should be empty, because the script should not be found and can't acctually return something
+	require.Error(t, errHSMSecret)
+
+	/* --- test an unknown arg for Restore() ---*/
+	restoreUnkown, errUnkown := testMiddleware.Restore(-1)
+
+	require.Equal(t, restoreUnkown.Success, false) // should fail, the method -1 is unknown
+	require.Equal(t, restoreUnkown.Message, "Method -1 not supported for Restore().")
+	require.Error(t, errUnkown)
 }

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -25,6 +25,23 @@ const (
 	Reindex
 )
 
+// FlashdriveArgs is an struct that holds the arguments for the Flashdrive RPC call
+type FlashdriveArgs struct {
+	Method FlashdriveMethod // the method called
+	Path   string           // the method 'mount' needs a path. If not calling 'mount' this path should be empty.
+}
+
+// FlashdriveMethod is an iota that holds the methods for the Flashdrive RPC call
+type FlashdriveMethod int
+
+// FlashdriveMethod can be one of three possible methods.
+// Either check for an existing flashdrive, mount a flash drive or unmount a mounted drive.
+const (
+	Check FlashdriveMethod = iota
+	Mount
+	Unmount
+)
+
 /*
 Put Response structs below this line. They should have the format of 'RPC Method Name' + 'Response'.
 */
@@ -52,4 +69,10 @@ type VerificationProgressResponse struct {
 	Blocks               int64   `json:"blocks"`
 	Headers              int64   `json:"headers"`
 	VerificationProgress float64 `json:"verificationProgress"`
+}
+
+// FlashdriveResponse is the struct that gets sent by the rpc server during a Flashdrive call
+type FlashdriveResponse struct {
+	Success bool
+	Message string
 }

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -47,8 +47,17 @@ type BackupArgs int
 
 // The BackupArgs has two methods. Backup the system config (sysconfig) or the hsm_secret by c-lightning
 const (
-	SysConfig BackupArgs = iota
-	HSMSecret
+	BackupSysConfig BackupArgs = iota
+	BackupHSMSecret
+)
+
+// RestoreArgs is an iota that holds the method for the Backup RPC call
+type RestoreArgs int
+
+// The RestoreArgs has two methods. Restore the system config (sysconfig) or the hsm_secret by c-lightning
+const (
+	RestoreSysConfig RestoreArgs = iota
+	RestoreHSMSecret
 )
 
 /*
@@ -80,14 +89,9 @@ type VerificationProgressResponse struct {
 	VerificationProgress float64 `json:"verificationProgress"`
 }
 
-// FlashdriveResponse is the struct that gets sent by the rpc server during a Flashdrive call
-type FlashdriveResponse struct {
-	Success bool
-	Message string
-}
-
-// BackupResponse is the struct that gets sent by the rpc server during a Backup call
-type BackupResponse struct {
+// GenericResponse is a struct that for example gets sent by the RPC server during a Flashdrive, Backup or Restore call.
+// Since it simply includes a success boolean and a message it can be used for other/future RPCs as well.
+type GenericResponse struct {
 	Success bool
 	Message string
 }

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -31,7 +31,7 @@ type FlashdriveArgs struct {
 	Path   string           // the method 'mount' needs a path. If not calling 'mount' this path should be empty.
 }
 
-// FlashdriveMethod is an iota that holds the methods for the Flashdrive RPC call
+// FlashdriveMethod is an iota that holds the method for the Flashdrive RPC call
 type FlashdriveMethod int
 
 // FlashdriveMethod can be one of three possible methods.
@@ -40,6 +40,15 @@ const (
 	Check FlashdriveMethod = iota
 	Mount
 	Unmount
+)
+
+// BackupArgs is an iota that holds the method for the Backup RPC call
+type BackupArgs int
+
+// The BackupArgs has two methods. Backup the system config (sysconfig) or the hsm_secret by c-lightning
+const (
+	SysConfig BackupArgs = iota
+	HSMSecret
 )
 
 /*
@@ -73,6 +82,12 @@ type VerificationProgressResponse struct {
 
 // FlashdriveResponse is the struct that gets sent by the rpc server during a Flashdrive call
 type FlashdriveResponse struct {
+	Success bool
+	Message string
+}
+
+// BackupResponse is the struct that gets sent by the rpc server during a Backup call
+type BackupResponse struct {
 	Success bool
 	Message string
 }

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -51,8 +51,9 @@ func (conn *rpcConn) Close() error {
 type Middleware interface {
 	SystemEnv() rpcmessages.GetEnvResponse
 	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
-	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.FlashdriveResponse, error)
-	Backup(rpcmessages.BackupArgs) (rpcmessages.BackupResponse, error)
+	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error)
+	Backup(rpcmessages.BackupArgs) (rpcmessages.GenericResponse, error)
+	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)
 	SampleInfo() rpcmessages.SampleInfoResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 }
@@ -108,20 +109,29 @@ func (server *RPCServer) GetVerificationProgress(args int, reply *rpcmessages.Ve
 	return nil
 }
 
-// Flashdrive sends the middleware's FlashdriveResponse over rpc
+// Flashdrive sends the middleware's GenericResponse over rpc
 // Args given can specify e.g. a flashdrive check, mount or unmount
-func (server *RPCServer) Flashdrive(args *rpcmessages.FlashdriveArgs, reply *rpcmessages.FlashdriveResponse) error {
+func (server *RPCServer) Flashdrive(args *rpcmessages.FlashdriveArgs, reply *rpcmessages.GenericResponse) error {
 	var err error
 	*reply, err = server.middleware.Flashdrive(*args)
 	log.Printf("sent reply %v: ", reply)
 	return err
 }
 
-// Backup sends the middleware's BackupResponse over rpc
+// Backup sends the middleware's GenericResponse over rpc
 // Args given can specify e.g. a sysconfig backup or a hsm_secret backup
-func (server *RPCServer) Backup(args *rpcmessages.BackupArgs, reply *rpcmessages.BackupResponse) error {
+func (server *RPCServer) Backup(args *rpcmessages.BackupArgs, reply *rpcmessages.GenericResponse) error {
 	var err error
 	*reply, err = server.middleware.Backup(*args)
+	log.Printf("sent reply %v: ", reply)
+	return err
+}
+
+// Restore sends the middleware's GenericResponse over rpc
+// Args given can specify e.g. a sysconfig restore or a hsm_secret restore
+func (server *RPCServer) Restore(args *rpcmessages.RestoreArgs, reply *rpcmessages.GenericResponse) error {
+	var err error
+	*reply, err = server.middleware.Restore(*args)
 	log.Printf("sent reply %v: ", reply)
 	return err
 }

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -51,6 +51,7 @@ func (conn *rpcConn) Close() error {
 type Middleware interface {
 	SystemEnv() rpcmessages.GetEnvResponse
 	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
+	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.FlashdriveResponse, error)
 	SampleInfo() rpcmessages.SampleInfoResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 }
@@ -104,6 +105,15 @@ func (server *RPCServer) GetVerificationProgress(args int, reply *rpcmessages.Ve
 	*reply = server.middleware.VerificationProgress()
 	log.Printf("sent reply %v: ", reply)
 	return nil
+}
+
+// Flashdrive sends the middleware's FlashdriveResponse over rpc
+// Args given can specify e.g. a flashdrive check, mount or unmount
+func (server *RPCServer) Flashdrive(args *rpcmessages.FlashdriveArgs, reply *rpcmessages.FlashdriveResponse) error {
+	var err error
+	*reply, err = server.middleware.Flashdrive(*args)
+	log.Printf("sent reply %v: ", reply)
+	return err
 }
 
 // Serve starts a gob rpc server

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -52,6 +52,7 @@ type Middleware interface {
 	SystemEnv() rpcmessages.GetEnvResponse
 	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
 	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.FlashdriveResponse, error)
+	Backup(rpcmessages.BackupArgs) (rpcmessages.BackupResponse, error)
 	SampleInfo() rpcmessages.SampleInfoResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 }
@@ -112,6 +113,15 @@ func (server *RPCServer) GetVerificationProgress(args int, reply *rpcmessages.Ve
 func (server *RPCServer) Flashdrive(args *rpcmessages.FlashdriveArgs, reply *rpcmessages.FlashdriveResponse) error {
 	var err error
 	*reply, err = server.middleware.Flashdrive(*args)
+	log.Printf("sent reply %v: ", reply)
+	return err
+}
+
+// Backup sends the middleware's BackupResponse over rpc
+// Args given can specify e.g. a sysconfig backup or a hsm_secret backup
+func (server *RPCServer) Backup(args *rpcmessages.BackupArgs, reply *rpcmessages.BackupResponse) error {
+	var err error
+	*reply, err = server.middleware.Backup(*args)
 	log.Printf("sent reply %v: ", reply)
 	return err
 }

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -51,7 +51,15 @@ func NewTestingRPCServer() TestingRPCServer {
 	argumentMap["lightningRPCPath"] = "/home/bitcoin/.lightning"
 	argumentMap["electrsRPCPort"] = "18442"
 	argumentMap["network"] = "testnet"
-	argumentMap["bbbConfigScript"] = "/home/bitcoin/script.sh"
+
+	/* The config and cmd script are mocked with /bin/echo which just returns
+	the passed arguments. The real scripts can't be used here, because
+	- the absolute location of those is different on each host this is run on
+	- the relative location is differen depending here the tests are run from
+	*/
+	argumentMap["bbbConfigScript"] = "/bin/echo"
+	argumentMap["bbbCmdScript"] = "/bin/echo"
+
 	middlewareInstance := middleware.NewMiddleware(argumentMap)
 
 	testingRPCServer.rpcServer = rpcserver.NewRPCServer(middlewareInstance)

--- a/middleware/src/system/system.go
+++ b/middleware/src/system/system.go
@@ -10,6 +10,7 @@ type Environment struct {
 	bitcoinRPCPort     string
 	lightningRPCPath   string
 	bbbConfigScript    string
+	bbbCmdScript       string
 	prometheusURL      string
 }
 
@@ -25,6 +26,7 @@ func NewEnvironment(argumentMap map[string]string) Environment {
 		ElectrsRPCPort:     argumentMap["electrsRPCPort"],
 		Network:            argumentMap["network"],
 		bbbConfigScript:    argumentMap["bbbConfigScript"],
+		bbbCmdScript:       argumentMap["bbbCmdScript"],
 		prometheusURL:      argumentMap["prometheusURL"],
 	}
 	return environment
@@ -53,6 +55,11 @@ func (environment *Environment) GetLightningRPCPath() string {
 // GetBBBConfigScript is a getter for the location of the bbb config script
 func (environment *Environment) GetBBBConfigScript() string {
 	return environment.bbbConfigScript
+}
+
+// GetBBBCmdScript is a getter for the location of the bbb cmd script
+func (environment *Environment) GetBBBCmdScript() string {
+	return environment.bbbCmdScript
 }
 
 // GetPrometheusURL is a getter for the url the prometheus server is reachable on

--- a/middleware/src/system/system_test.go
+++ b/middleware/src/system/system_test.go
@@ -15,7 +15,8 @@ func TestSystem(t *testing.T) {
 	argumentMap["lightningRPCPath"] = "/home/bitcoin/.lightning"
 	argumentMap["electrsRPCPort"] = "18442"
 	argumentMap["network"] = "testnet"
-	argumentMap["bbbConfigScript"] = "/home/bitcoin/script.sh"
+	argumentMap["bbbConfigScript"] = "/home/bitcoin/config-script.sh"
+	argumentMap["bbbCmdScript"] = "/home/bitcoin/cmd-script.sh"
 	argumentMap["prometheusURL"] = "http://localhost:9090"
 
 	environmentInstance := system.NewEnvironment(argumentMap)
@@ -23,7 +24,8 @@ func TestSystem(t *testing.T) {
 	require.Equal(t, environmentInstance.GetBitcoinRPCUser(), "user")
 	require.Equal(t, environmentInstance.GetBitcoinRPCPassword(), "password")
 	require.Equal(t, environmentInstance.GetLightningRPCPath(), "/home/bitcoin/.lightning")
-	require.Equal(t, environmentInstance.GetBBBConfigScript(), "/home/bitcoin/script.sh")
+	require.Equal(t, environmentInstance.GetBBBConfigScript(), "/home/bitcoin/config-script.sh")
+	require.Equal(t, environmentInstance.GetBBBCmdScript(), "/home/bitcoin/cmd-script.sh")
 	require.Equal(t, environmentInstance.Network, "testnet")
 	require.Equal(t, environmentInstance.ElectrsRPCPort, "18442")
 	require.Equal(t, environmentInstance.GetPrometheusURL(), "http://localhost:9090")


### PR DESCRIPTION
**WIP**: First version to gather feedback. Code builds, but I have no BBBase to run it yet.

This PR adds 
- [x]  `Flashdrive` RPC that which handles the args `check`, `mount` and `unmount` 
- [x]  `Backup` RPC that handles the args `sysconfig` and `hsm_secret` 
- [x]  `Restore` RPC that handles the args `sysconfig` and `hsm_secret` 
- [x] rename `usb_flashdrive` to `flashdrive` https://github.com/digitalbitbox/bitbox-base/pull/155#issuecomment-523628270
- [x] Test that the RPCs are callable via the RPC Client in the App  

