### PR TITLE
Add Redis for configuration management

### DIFF
--- a/armbian/base/config/redis/factorysettings.txt
+++ b/armbian/base/config/redis/factorysettings.txt
@@ -1,0 +1,52 @@
+SET bitcoind:testnet 0
+SET bitcoind:mainnet 1
+SET bitcoind:server 1
+SET bitcoind:listen 1
+SET bitcoind:listenonion 1
+SET bitcoind:txindex 0
+SET bitcoind:prune 0
+SET bitcoind:disablewallet 1
+SET bitcoind:rpccookiefile /mnt/ssd/bitcoin/.bitcoin/.cookie
+SET bitcoind:sysparms 1
+SET bitcoind:printtoconsole 1
+SET bitcoind:rpcconnect 127.0.0.1
+SET bitcoind:dbcache 300
+SET bitcoind:maxconnections 40
+SET bitcoind:maxuploadtarget 5000
+SET bitcoind:proxy 127.0.0.1:9050
+SET bitcoind:seednode:1 nkf5e6b7pl4jfd4a.onion
+SET bitcoind:seednode:2 xqzfakpeuvrobvpj.onion
+SET bitcoind:seednode:3 tsyvzsqwa2kkf6b2.onion
+
+SET lightningd:bitcoin-cli /usr/bin/bitcoin-cli
+SET lightningd:bitcoin-rpcconnect 127.0.0.1
+SET lightningd:bitcoin-rpcport 8332
+SET lightningd:network mainnet
+SET lightningd:lightning-dir /mnt/ssd/bitcoin/.lightning
+SET lightningd:bind-addr 127.0.0.1:9735
+SET lightningd:proxy 127.0.0.1:9050
+SET lightningd:log-level debug
+SET lightningd:plugin:1 /opt/shift/scripts/prometheus-lightningd.py
+
+SET electrs:network mainnet
+SET electrs:rpcconnect 127.0.0.1
+SET electrs:rpcport 8332
+SET electrs:db_dir /mnt/ssd/electrs/db
+SET electrs:daemon_dir /mnt/ssd/bitcoin/.bitcoin
+SET electrs:monitoring_addr 127.0.0.1:4224
+SET electrs:verbosity vvvv
+SET electrs:rust_backtrace 1
+
+SET bbbmiddleware:bitcoin_rpcuser __cookie__
+SET bbbmiddleware:bitcoin_rpcport 8332
+SET bbbmiddleware:lightning_rpcpath /mnt/ssd/bitcoin/.lightning/lightning-rpc
+
+SET grafana:server:http_addr 127.0.0.1                 
+SET grafana:server:root_url http://127.0.0.1:3000/info/ 
+SET grafana:analytics:reporting_enabled false         
+SET grafana:analytics:check_for_updates false           
+SET grafana:users:allow_sign_up false                   
+SET grafana:users:disable_login_form false
+SET grafana:auth.anonymous:enabled true
+
+SAVE

--- a/armbian/base/config/redis/redis-local.conf
+++ b/armbian/base/config/redis/redis-local.conf
@@ -1,0 +1,18 @@
+# accept connections only from clients running into the same computer
+bind 127.0.0.1
+port 6379
+
+# run as a systemd unit
+supervised systemd
+daemonize yes
+
+# loglevel: debug, verbose, notice or warning
+loglevel notice
+
+# database configuration
+databases 1
+dbfilename bitboxbase.rdb
+dir /data/redis/
+
+# various
+always-show-logo no

--- a/armbian/base/config/redis/redis.service
+++ b/armbian/base/config/redis/redis.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Redis In-Memory Data Store
+After=network.target
+# original config in /lib/systemd/system/redis-server.service
+
+[Service]
+Type=forking
+ExecStart=/usr/bin/redis-server /etc/redis/redis.conf
+ExecStop=/bin/kill -s TERM $MAINPID
+User=redis
+Group=redis
+Restart=always
+
+[Install]
+WantedBy=multi-user.target

--- a/armbian/base/scripts/redis-pipe.sh
+++ b/armbian/base/scripts/redis-pipe.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# BitBox Base: mass import key/value pairs into Redis
+# 
+# Pipe a text file with Redis commands (one per line) to this script to
+# convert it to the Redis protocol for mass insertion.
+# https://redis.io/topics/mass-insert
+#
+# Example: cat redis-commands.txt | sh redis-pipe.sh | redis-cli --pipe
+
+while read -r CMD; do
+  # each command begins with *{number arguments in command}\r\n
+  XS="${CMD}"
+  # shellcheck disable=SC2086
+  set -- ${XS}
+  printf "*%s\r\n" "${#}"
+  # for each argument, we append ${length}\r\n{argument}\r\n
+  for X in $CMD; do
+    printf "\$%s\r\n%s\r\n" "${#X}" "${X}"
+  done
+done


### PR DESCRIPTION
Add Redis to the Armbian build process. It is installed, configured and set up as a systemd unit. Initial configuration is mass-imported from factorysettings.txt

This is the prerequisite to move the configuration management consistently into Redis, which is not yet implemented.