### PR TITLE
middleware: add hostname RPC with set and get functionality

### DIFF
--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -24,6 +24,8 @@ type Middleware interface {
 	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error)
 	Backup(rpcmessages.BackupArgs) (rpcmessages.GenericResponse, error)
 	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)
+	GetHostname() rpcmessages.GetHostnameResponse
+	SetHostname(rpcmessages.SetHostnameArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -72,6 +72,11 @@ type UserChangePasswordArgs struct {
 	NewPassword string
 }
 
+// SetHostnameArgs is a struct that holds the to be set hostname
+type SetHostnameArgs struct {
+	Hostname string
+}
+
 /*
 Put Response structs below this line. They should have the format of 'RPC Method Name' + 'Response'.
 */
@@ -99,6 +104,12 @@ type VerificationProgressResponse struct {
 	Blocks               int64   `json:"blocks"`
 	Headers              int64   `json:"headers"`
 	VerificationProgress float64 `json:"verificationProgress"`
+}
+
+// GetHostnameResponse is the struct that get sent by the rpc server during a GetHostname rpc call
+type GetHostnameResponse struct {
+	ErrorResponse
+	Hostname string
 }
 
 // GenericResponse is a struct that for example gets sent by the RPC server during a Flashdrive, Backup or Restore call.

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -54,6 +54,8 @@ type Middleware interface {
 	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error)
 	Backup(rpcmessages.BackupArgs) (rpcmessages.GenericResponse, error)
 	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)
+	GetHostname() rpcmessages.GetHostnameResponse
+	SetHostname(rpcmessages.SetHostnameArgs) rpcmessages.ErrorResponse
 	SampleInfo() rpcmessages.SampleInfoResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
@@ -150,6 +152,22 @@ func (server *RPCServer) UserAuthenticate(args *rpcmessages.UserAuthenticateArgs
 func (server *RPCServer) UserChangePassword(args *rpcmessages.UserChangePasswordArgs, reply *rpcmessages.ErrorResponse) {
 	*reply = server.middleware.UserChangePassword(*args)
 	log.Printf("sent reply %v: ", reply)
+}
+
+// SetHostname sends the middleware's ErrorResponse over rpc
+// The argument given specifys the hostname to be set
+func (server *RPCServer) SetHostname(args *rpcmessages.SetHostnameArgs, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.SetHostname(*args)
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// GetHostname sends the middleware's GetHostnameResponse over rpc
+// The GetHostnameResponse includes the current system hostname
+func (server *RPCServer) GetHostname(dummyArg bool, reply *rpcmessages.GetHostnameResponse) error {
+	*reply = server.middleware.GetHostname()
+	log.Printf("sent reply %v: ", reply)
+	return nil
 }
 
 // Serve starts a gob rpc server


### PR DESCRIPTION
This PR adds a `Hostname()` RPC to the middleware. The hostname can either be `set` or `get`.

<s>This PR builds on top of the work done in #155 (only adds a9f5f2f and 17177ea). As soon as that one is merged into master I'll rebase this to master. I'll leave this marked as WIP in the meanwhile. </s>