### PR TITLE
Add dummy RPCs to Authenticate and ChangePassword

### DIFF
--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -25,6 +25,8 @@ type Middleware interface {
 	Backup(rpcmessages.BackupArgs) (rpcmessages.GenericResponse, error)
 	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)
 	VerificationProgress() rpcmessages.VerificationProgressResponse
+	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
+	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse
 }
 
 // Handlers provides a web api

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -179,3 +179,102 @@ func TestRestore(t *testing.T) {
 	require.Equal(t, restoreUnknown.Message, "Method -1 not supported for Restore().")
 	require.Error(t, errUnknown)
 }
+
+func TestUserAuthenticate(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	/* test login should fail for every user/password, when dummyIsBaseSetup == false */
+	notInitalizedArgs := rpcmessages.UserAuthenticateArgs{Username: "dev", Password: "dev"}
+	authenticateNotInitalized := testMiddleware.UserAuthenticate(notInitalizedArgs)
+
+	require.Equal(t, false, authenticateNotInitalized.Success)
+	require.Equal(t, "authentication unsuccessful", authenticateNotInitalized.Message)
+	require.Equal(t, false, testMiddleware.DummyIsBaseSetup())
+
+	/* test initial admin login with dummyAdminPassword. Should fail because dummyIsBaseSetup == false  */
+	adminDummyPWArgs := rpcmessages.UserAuthenticateArgs{Username: "admin", Password: testMiddleware.DummyAdminPassword()}
+	authenticateAdminDummyPW := testMiddleware.UserAuthenticate(adminDummyPWArgs)
+
+	require.Equal(t, false, authenticateAdminDummyPW.Success)
+	require.Equal(t, "authentication unsuccessful", authenticateAdminDummyPW.Message)
+	require.Equal(t, false, testMiddleware.DummyIsBaseSetup())
+
+	/* test initial admin login, should succeed because dummyIsBaseSetup == false  */
+	adminArgs := rpcmessages.UserAuthenticateArgs{Username: "admin", Password: "ICanHasPassword?"}
+	authenticateAdmin := testMiddleware.UserAuthenticate(adminArgs)
+
+	require.Equal(t, true, authenticateAdmin.Success)
+	require.Equal(t, false, testMiddleware.DummyIsBaseSetup())
+
+	// change admin password to "abc123def", which sets dummyIsBaseSetup = true
+	response := testMiddleware.UserChangePassword(rpcmessages.UserChangePasswordArgs{Username: "admin", NewPassword: "abc123def"})
+	require.Equal(t, true, response.Success)
+
+	/* test login dev/dev should succeed now, because dummyIsBaseSetup == true */
+	devArgs := rpcmessages.UserAuthenticateArgs{Username: "dev", Password: "dev"}
+	authenticateDev := testMiddleware.UserAuthenticate(devArgs)
+
+	require.Equal(t, true, authenticateDev.Success)
+	require.Equal(t, true, testMiddleware.DummyIsBaseSetup())
+
+	/* test initial admin login, should fail now because dummyIsBaseSetup == true  */
+	authenticateAdmin2 := testMiddleware.UserAuthenticate(adminArgs)
+
+	require.Equal(t, false, authenticateAdmin2.Success, false)
+	require.Equal(t, "authentication unsuccessful", authenticateAdmin2.Message)
+	require.Equal(t, true, testMiddleware.DummyIsBaseSetup(), true)
+
+	/* test initial admin login with dummyAdminPassword. Should succeed now, because dummyIsBaseSetup == true  */
+	adminDummyPW2Args := rpcmessages.UserAuthenticateArgs{Username: "admin", Password: testMiddleware.DummyAdminPassword()}
+	authenticateAdminDummyPW2 := testMiddleware.UserAuthenticate(adminDummyPW2Args)
+
+	require.Equal(t, true, authenticateAdminDummyPW2.Success)
+	require.Equal(t, true, testMiddleware.DummyIsBaseSetup())
+
+	/* test invalid login (with a invalid username) */
+	invalidNameArgs := rpcmessages.UserAuthenticateArgs{Username: "InvalidUserName", Password: ""}
+	authenticateInvalidName := testMiddleware.UserAuthenticate(invalidNameArgs)
+
+	require.Equal(t, false, authenticateInvalidName.Success)
+	require.Equal(t, "authentication unsuccessful", authenticateInvalidName.Message)
+
+	/* test invalid login (empty username and password) */
+	emptyArgs := rpcmessages.UserAuthenticateArgs{Username: "", Password: ""}
+	authenticateEmpty := testMiddleware.UserAuthenticate(emptyArgs)
+
+	require.Equal(t, false, authenticateEmpty.Success)
+	require.Equal(t, "authentication unsuccessful", authenticateEmpty.Message)
+}
+
+func TestUserChangePassword(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	/* test valid password change */
+	validArgs := rpcmessages.UserChangePasswordArgs{Username: "notAdmin", NewPassword: "12345678"}
+	changepasswordValid := testMiddleware.UserChangePassword(validArgs)
+
+	require.Equal(t, true, changepasswordValid.Success)
+	require.Equal(t, false, testMiddleware.DummyIsBaseSetup())
+
+	/* test admin password change, this should set dummyIsBaseSetup == true */
+	newPassword := "123qwert567"
+	adminChangeArgs := rpcmessages.UserChangePasswordArgs{Username: "admin", NewPassword: newPassword}
+	changepasswordAdminChange := testMiddleware.UserChangePassword(adminChangeArgs)
+
+	require.Equal(t, true, changepasswordAdminChange.Success)
+	require.Equal(t, true, testMiddleware.DummyIsBaseSetup())
+
+	/* test invalid password change (to short, needs to be 7 chars) */
+	invalidArgs := rpcmessages.UserChangePasswordArgs{NewPassword: "1234567"}
+	changepasswordInvalid := testMiddleware.UserChangePassword(invalidArgs)
+
+	require.Equal(t, false, changepasswordInvalid.Success)
+	require.Equal(t, "password change unsuccessful (too short)", changepasswordInvalid.Message)
+
+	/* test empty password change */
+	emptyArgs := rpcmessages.UserChangePasswordArgs{}
+	changepasswordEmpty := testMiddleware.UserChangePassword(emptyArgs)
+
+	require.Equal(t, false, changepasswordEmpty.Success)
+	require.Equal(t, "password change unsuccessful (too short)", changepasswordEmpty.Message)
+}

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -60,6 +60,18 @@ const (
 	RestoreHSMSecret
 )
 
+// UserAuthenticateArgs is an struct that holds the arguments for the UserAuthenticate RPC call
+type UserAuthenticateArgs struct {
+	Username string
+	Password string
+}
+
+// UserChangePasswordArgs is an struct that holds the arguments for the UserChangePassword RPC call
+type UserChangePasswordArgs struct {
+	Username    string
+	NewPassword string
+}
+
 /*
 Put Response structs below this line. They should have the format of 'RPC Method Name' + 'Response'.
 */

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -56,6 +56,8 @@ type Middleware interface {
 	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)
 	SampleInfo() rpcmessages.SampleInfoResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
+	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
+	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse
 }
 
 // RPCServer provides rpc calls to the middleware
@@ -134,6 +136,20 @@ func (server *RPCServer) Restore(args *rpcmessages.RestoreArgs, reply *rpcmessag
 	*reply, err = server.middleware.Restore(*args)
 	log.Printf("sent reply %v: ", reply)
 	return err
+}
+
+// UserAuthenticate sends the middleware's ErrorResponse over rpc
+// Args given specify the username and the password
+func (server *RPCServer) UserAuthenticate(args *rpcmessages.UserAuthenticateArgs, reply *rpcmessages.ErrorResponse) {
+	*reply = server.middleware.UserAuthenticate(*args)
+	log.Printf("sent reply %v: ", reply)
+}
+
+// UserChangePassword sends the middleware's ErrorResponse over rpc
+// The Arg given specify the username and the new password
+func (server *RPCServer) UserChangePassword(args *rpcmessages.UserChangePasswordArgs, reply *rpcmessages.ErrorResponse) {
+	*reply = server.middleware.UserChangePassword(*args)
+	log.Printf("sent reply %v: ", reply)
 }
 
 // Serve starts a gob rpc server


### PR DESCRIPTION
This PR adds two dummy RPCs to authenticate and change the password. This shall only be used for testing and development. 

See https://github.com/digitalbitbox/bitbox-base/pull/164#issuecomment-526148566 for current behavior. 