### PR TITLE
Refactor and split up Flashdrive RPC 

### DIFF
--- a/middleware/.golangci.yml
+++ b/middleware/.golangci.yml
@@ -60,7 +60,7 @@ linters-settings:
     suggest-new: true
   dupl:
     # tokens count to trigger issue, 150 by default
-    threshold: 155
+    threshold: 160
   goconst:
     # minimal length of string constant, 3 by default
     min-len: 3

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -21,7 +21,8 @@ type Middleware interface {
 	SystemEnv() rpcmessages.GetEnvResponse
 	SampleInfo() rpcmessages.SampleInfoResponse
 	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
-	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error)
+	MountFlashdrive() rpcmessages.ErrorResponse
+	UnmountFlashdrive() rpcmessages.ErrorResponse
 	Backup(rpcmessages.BackupArgs) (rpcmessages.GenericResponse, error)
 	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)
 	VerificationProgress() rpcmessages.VerificationProgressResponse

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -187,36 +187,31 @@ func (middleware *Middleware) DummyAdminPassword() string {
 	return middleware.dummyAdminPassword
 }
 
-// Flashdrive returns a GenericResponse struct in response to a rpcserver request
-func (middleware *Middleware) Flashdrive(args rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error) {
-	switch args.Method {
-	case rpcmessages.Mount:
-		log.Println("Executing a USB flashdrive check via the cmd script")
-		outCheck, errCheck := middleware.runBBBCmdScript("flashdrive", "check", "")
-		if errCheck != nil {
-			return rpcmessages.GenericResponse{Success: false, Message: string(outCheck)}, errCheck
-		}
-		flashDriveName := strings.TrimSuffix(string(outCheck), "\n")
-
-		log.Println("Executing a USB flashdrive mount via the cmd script")
-		outMount, errMount := middleware.runBBBCmdScript("flashdrive", "mount", flashDriveName)
-		if errMount != nil {
-			return rpcmessages.GenericResponse{Success: false, Message: string(outMount)}, errMount
-		}
-		return rpcmessages.GenericResponse{Success: true, Message: string(outMount)}, nil
-
-	case rpcmessages.Unmount:
-		log.Println("Executing a USB flashdrive unmount via the cmd script")
-		out, err := middleware.runBBBCmdScript("flashdrive", "unmount", "")
-		if err != nil {
-			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
-		}
-		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
-
-	default:
-		errorMessage := fmt.Sprintf("Method %d not supported for Flashdrive().", args.Method)
-		return rpcmessages.GenericResponse{Success: false, Message: errorMessage}, errors.New(errorMessage)
+// MountFlashdrive returns an ErrorResponse struct in a response to a rpcserver request
+func (middleware *Middleware) MountFlashdrive() rpcmessages.ErrorResponse {
+	log.Println("Executing a USB flashdrive check via the cmd script")
+	outCheck, err := middleware.runBBBCmdScript("flashdrive", "check", "")
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(outCheck), Code: err.Error()}
 	}
+	flashDriveName := strings.TrimSuffix(string(outCheck), "\n")
+
+	log.Println("Executing a USB flashdrive mount via the cmd script")
+	outMount, err := middleware.runBBBCmdScript("flashdrive", "mount", flashDriveName)
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(outMount), Code: err.Error()}
+	}
+	return rpcmessages.ErrorResponse{Success: true}
+}
+
+// UnmountFlashdrive returns an ErrorResponse struct in a response to a rpcserver request
+func (middleware *Middleware) UnmountFlashdrive() rpcmessages.ErrorResponse {
+	log.Println("Executing a USB flashdrive unmount via the cmd script")
+	out, err := middleware.runBBBCmdScript("flashdrive", "unmount", "")
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
+	}
+	return rpcmessages.ErrorResponse{Success: true}
 }
 
 // Backup returns a GenericResponse struct in response to a rpcserver request

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/btcsuite/btcd/rpcclient"
@@ -191,7 +192,7 @@ func (middleware *Middleware) Flashdrive(args rpcmessages.FlashdriveArgs) (rpcme
 	switch args.Method {
 	case rpcmessages.Check:
 		log.Println("Executing a USB flashdrive check via the cmd script")
-		out, err := middleware.runBBBCmdScript("flashdrive", "check")
+		out, err := middleware.runBBBCmdScript("flashdrive", "check", "")
 		if err != nil {
 			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
 		}
@@ -199,7 +200,7 @@ func (middleware *Middleware) Flashdrive(args rpcmessages.FlashdriveArgs) (rpcme
 
 	case rpcmessages.Mount:
 		log.Println("Executing a USB flashdrive mount via the cmd script")
-		out, err := middleware.runBBBCmdScript("flashdrive", "mount"+" "+args.Path)
+		out, err := middleware.runBBBCmdScript("flashdrive", "mount", args.Path)
 		if err != nil {
 			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
 		}
@@ -207,7 +208,7 @@ func (middleware *Middleware) Flashdrive(args rpcmessages.FlashdriveArgs) (rpcme
 
 	case rpcmessages.Unmount:
 		log.Println("Executing a USB flashdrive unmount via the cmd script")
-		out, err := middleware.runBBBCmdScript("flashdrive", "unmount")
+		out, err := middleware.runBBBCmdScript("flashdrive", "unmount", "")
 		if err != nil {
 			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
 		}
@@ -224,7 +225,7 @@ func (middleware *Middleware) Backup(method rpcmessages.BackupArgs) (rpcmessages
 	switch method {
 	case rpcmessages.BackupSysConfig:
 		log.Println("Executing a backup of the system config via the cmd script")
-		out, err := middleware.runBBBCmdScript("backup", "sysconfig")
+		out, err := middleware.runBBBCmdScript("backup", "sysconfig", "")
 		if err != nil {
 			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
 		}
@@ -232,7 +233,7 @@ func (middleware *Middleware) Backup(method rpcmessages.BackupArgs) (rpcmessages
 
 	case rpcmessages.BackupHSMSecret:
 		log.Println("Executing a backup of the c-lightning hsm_secret via the cmd script")
-		out, err := middleware.runBBBCmdScript("backup", "hsm_secret")
+		out, err := middleware.runBBBCmdScript("backup", "hsm_secret", "")
 		if err != nil {
 			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
 		}
@@ -249,7 +250,7 @@ func (middleware *Middleware) Restore(method rpcmessages.RestoreArgs) (rpcmessag
 	switch method {
 	case rpcmessages.RestoreSysConfig:
 		log.Println("Executing a restore of the system config via the cmd script")
-		out, err := middleware.runBBBCmdScript("restore", "sysconfig")
+		out, err := middleware.runBBBCmdScript("restore", "sysconfig", "")
 		if err != nil {
 			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
 		}
@@ -257,7 +258,7 @@ func (middleware *Middleware) Restore(method rpcmessages.RestoreArgs) (rpcmessag
 
 	case rpcmessages.RestoreHSMSecret:
 		log.Println("Executing a restore of the c-lightning hsm_secret via the cmd script")
-		out, err := middleware.runBBBCmdScript("restore", "hsm_secret")
+		out, err := middleware.runBBBCmdScript("restore", "hsm_secret", "")
 		if err != nil {
 			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
 		}
@@ -316,10 +317,10 @@ func (middleware *Middleware) UserChangePassword(args rpcmessages.UserChangePass
 	return rpcmessages.ErrorResponse{Success: false, Message: "password change unsuccessful (too short)"}
 }
 
-func (middleware *Middleware) runBBBCmdScript(method string, arg string) (out []byte, err error) {
+func (middleware *Middleware) runBBBCmdScript(method string, arg1 string, arg2 string) (out []byte, err error) {
 	script := middleware.environment.GetBBBCmdScript()
-	cmdAsString := script + " " + method + " " + arg
-	out, err = exec.Command(script, method, arg).Output()
+	cmdAsString := strings.Join([]string{script, method, arg1, arg2}, " ")
+	out, err = exec.Command(script, method, arg1, arg2).Output()
 	if err != nil {
 		// no error handling here, only logging.
 		log.Printf("Error: The command '%s' exited with the output '%v' and error '%s'.\n", cmdAsString, string(out), err.Error())

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -190,21 +190,20 @@ func (middleware *Middleware) DummyAdminPassword() string {
 // Flashdrive returns a GenericResponse struct in response to a rpcserver request
 func (middleware *Middleware) Flashdrive(args rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error) {
 	switch args.Method {
-	case rpcmessages.Check:
-		log.Println("Executing a USB flashdrive check via the cmd script")
-		out, err := middleware.runBBBCmdScript("flashdrive", "check", "")
-		if err != nil {
-			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
-		}
-		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
-
 	case rpcmessages.Mount:
-		log.Println("Executing a USB flashdrive mount via the cmd script")
-		out, err := middleware.runBBBCmdScript("flashdrive", "mount", args.Path)
-		if err != nil {
-			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
+		log.Println("Executing a USB flashdrive check via the cmd script")
+		outCheck, errCheck := middleware.runBBBCmdScript("flashdrive", "check", "")
+		if errCheck != nil {
+			return rpcmessages.GenericResponse{Success: false, Message: string(outCheck)}, errCheck
 		}
-		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
+		flashDriveName := strings.TrimSuffix(string(outCheck), "\n")
+
+		log.Println("Executing a USB flashdrive mount via the cmd script")
+		outMount, errMount := middleware.runBBBCmdScript("flashdrive", "mount", flashDriveName)
+		if errMount != nil {
+			return rpcmessages.GenericResponse{Success: false, Message: string(outMount)}, errMount
+		}
+		return rpcmessages.GenericResponse{Success: true, Message: string(outMount)}, nil
 
 	case rpcmessages.Unmount:
 		log.Println("Executing a USB flashdrive unmount via the cmd script")

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -87,7 +87,7 @@ func TestFlashdrive(t *testing.T) {
 	flashdriveCheck, errCheck := testMiddleware.Flashdrive(checkArgs)
 
 	require.Equal(t, flashdriveCheck.Success, true)
-	require.Equal(t, flashdriveCheck.Message, "flashdrive check\n")
+	require.Equal(t, flashdriveCheck.Message, "flashdrive check \n")
 	require.NoError(t, errCheck)
 
 	/* --- test mount arg for Flashdrive() ---*/
@@ -111,7 +111,7 @@ func TestFlashdrive(t *testing.T) {
 	flashdriveUnmount, errUnmount := testMiddleware.Flashdrive(unmountArgs)
 
 	require.Equal(t, flashdriveUnmount.Success, true)
-	require.Equal(t, flashdriveUnmount.Message, "flashdrive unmount\n")
+	require.Equal(t, flashdriveUnmount.Message, "flashdrive unmount \n")
 	require.NoError(t, errUnmount)
 
 	/* --- test an unknown arg for Flashdrive() ---*/
@@ -134,14 +134,14 @@ func TestBackup(t *testing.T) {
 	backupSysconfig, errSysconfig := testMiddleware.Backup(rpcmessages.BackupSysConfig)
 
 	require.Equal(t, backupSysconfig.Success, true)
-	require.Equal(t, backupSysconfig.Message, "backup sysconfig\n")
+	require.Equal(t, backupSysconfig.Message, "backup sysconfig \n")
 	require.NoError(t, errSysconfig)
 
 	/* --- test hsm secret arg for Backup() ---*/
 	backupHSMSecret, errHSMSecret := testMiddleware.Backup(rpcmessages.BackupHSMSecret)
 
 	require.Equal(t, backupHSMSecret.Success, true)
-	require.Equal(t, backupHSMSecret.Message, "backup hsm_secret\n")
+	require.Equal(t, backupHSMSecret.Message, "backup hsm_secret \n")
 	require.NoError(t, errHSMSecret)
 
 	/* --- test an unknown arg for Backup() ---*/
@@ -162,14 +162,14 @@ func TestRestore(t *testing.T) {
 	restoreSysconfig, errSysconfig := testMiddleware.Restore(rpcmessages.RestoreSysConfig)
 
 	require.Equal(t, restoreSysconfig.Success, true)
-	require.Equal(t, restoreSysconfig.Message, "restore sysconfig\n")
+	require.Equal(t, restoreSysconfig.Message, "restore sysconfig \n")
 	require.NoError(t, errSysconfig)
 
 	/* --- test hsm secret arg for Restore() ---*/
 	restoreHSMSecret, errHSMSecret := testMiddleware.Restore(rpcmessages.RestoreHSMSecret)
 
 	require.Equal(t, restoreHSMSecret.Success, true)
-	require.Equal(t, restoreHSMSecret.Message, "restore hsm_secret\n")
+	require.Equal(t, restoreHSMSecret.Message, "restore hsm_secret \n")
 	require.NoError(t, errHSMSecret)
 
 	/* --- test an unknown arg for Restore() ---*/

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -78,35 +78,19 @@ func TestResyncBitcoin(t *testing.T) {
 func TestFlashdrive(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	/* --- test check arg for Flashdrive() ---*/
-	checkArgs := rpcmessages.FlashdriveArgs{
-		Method: rpcmessages.Check,
-		Path:   "", // not needed, only needed for mount
-	}
-
-	flashdriveCheck, errCheck := testMiddleware.Flashdrive(checkArgs)
-
-	require.Equal(t, flashdriveCheck.Success, true)
-	require.Equal(t, flashdriveCheck.Message, "flashdrive check \n")
-	require.NoError(t, errCheck)
-
 	/* --- test mount arg for Flashdrive() ---*/
-	mountArgs := rpcmessages.FlashdriveArgs{
-		Method: rpcmessages.Mount,
-		Path:   "/dev/sda",
-	}
+	mountArgs := rpcmessages.FlashdriveArgs{Method: rpcmessages.Mount}
 
 	flashdriveMount, errMount := testMiddleware.Flashdrive(mountArgs)
 
 	require.Equal(t, flashdriveMount.Success, true)
-	require.Equal(t, flashdriveMount.Message, "flashdrive mount /dev/sda\n")
+	// We end up wit this, because the output of `/bin/echo flashdrive check `
+	// is passed to `/echo/bin flashdrive mount flashdrive check `
+	require.Equal(t, flashdriveMount.Message, "flashdrive mount flashdrive check \n")
 	require.NoError(t, errMount)
 
 	/* --- test unmount arg for Flashdrive() ---*/
-	unmountArgs := rpcmessages.FlashdriveArgs{
-		Method: rpcmessages.Unmount,
-		Path:   "", // not needed, only needed for mount
-	}
+	unmountArgs := rpcmessages.FlashdriveArgs{Method: rpcmessages.Unmount}
 
 	flashdriveUnmount, errUnmount := testMiddleware.Flashdrive(unmountArgs)
 
@@ -115,10 +99,7 @@ func TestFlashdrive(t *testing.T) {
 	require.NoError(t, errUnmount)
 
 	/* --- test an unknown arg for Flashdrive() ---*/
-	unknownArgs := rpcmessages.FlashdriveArgs{
-		Method: -1,
-		Path:   "",
-	}
+	unknownArgs := rpcmessages.FlashdriveArgs{Method: -1}
 
 	flashdriveUnknown, errUnknown := testMiddleware.Flashdrive(unknownArgs)
 

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -75,37 +75,20 @@ func TestResyncBitcoin(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestFlashdrive(t *testing.T) {
+func TestMountFlashdrive(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
+	response := testMiddleware.MountFlashdrive()
+	require.Equal(t, true, response.Success)
+	require.Equal(t, "", response.Message)
+	require.Equal(t, "", response.Code)
+}
 
-	/* --- test mount arg for Flashdrive() ---*/
-	mountArgs := rpcmessages.FlashdriveArgs{Method: rpcmessages.Mount}
-
-	flashdriveMount, errMount := testMiddleware.Flashdrive(mountArgs)
-
-	require.Equal(t, flashdriveMount.Success, true)
-	// We end up wit this, because the output of `/bin/echo flashdrive check `
-	// is passed to `/echo/bin flashdrive mount flashdrive check `
-	require.Equal(t, flashdriveMount.Message, "flashdrive mount flashdrive check \n")
-	require.NoError(t, errMount)
-
-	/* --- test unmount arg for Flashdrive() ---*/
-	unmountArgs := rpcmessages.FlashdriveArgs{Method: rpcmessages.Unmount}
-
-	flashdriveUnmount, errUnmount := testMiddleware.Flashdrive(unmountArgs)
-
-	require.Equal(t, flashdriveUnmount.Success, true)
-	require.Equal(t, flashdriveUnmount.Message, "flashdrive unmount \n")
-	require.NoError(t, errUnmount)
-
-	/* --- test an unknown arg for Flashdrive() ---*/
-	unknownArgs := rpcmessages.FlashdriveArgs{Method: -1}
-
-	flashdriveUnknown, errUnknown := testMiddleware.Flashdrive(unknownArgs)
-
-	require.Equal(t, flashdriveUnknown.Success, false) // should fail, the method -1 is unknown
-	require.Equal(t, flashdriveUnknown.Message, "Method -1 not supported for Flashdrive().")
-	require.Error(t, errUnknown)
+func TestUnmountFlashdrive(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+	response := testMiddleware.UnmountFlashdrive()
+	require.Equal(t, true, response.Success)
+	require.Equal(t, "", response.Message)
+	require.Equal(t, "", response.Code)
 }
 
 func TestBackup(t *testing.T) {

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -28,7 +28,6 @@ const (
 // FlashdriveArgs is an struct that holds the arguments for the Flashdrive RPC call
 type FlashdriveArgs struct {
 	Method FlashdriveMethod // the method called
-	Path   string           // the method 'mount' needs a path. If not calling 'mount' this path should be empty.
 }
 
 // FlashdriveMethod is an iota that holds the method for the Flashdrive RPC call
@@ -37,8 +36,7 @@ type FlashdriveMethod int
 // FlashdriveMethod can be one of three possible methods.
 // Either check for an existing flashdrive, mount a flash drive or unmount a mounted drive.
 const (
-	Check FlashdriveMethod = iota
-	Mount
+	Mount FlashdriveMethod = iota
 	Unmount
 )
 

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -25,21 +25,6 @@ const (
 	Reindex
 )
 
-// FlashdriveArgs is an struct that holds the arguments for the Flashdrive RPC call
-type FlashdriveArgs struct {
-	Method FlashdriveMethod // the method called
-}
-
-// FlashdriveMethod is an iota that holds the method for the Flashdrive RPC call
-type FlashdriveMethod int
-
-// FlashdriveMethod can be one of three possible methods.
-// Either check for an existing flashdrive, mount a flash drive or unmount a mounted drive.
-const (
-	Mount FlashdriveMethod = iota
-	Unmount
-)
-
 // BackupArgs is an iota that holds the method for the Backup RPC call
 type BackupArgs int
 

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -51,7 +51,8 @@ func (conn *rpcConn) Close() error {
 type Middleware interface {
 	SystemEnv() rpcmessages.GetEnvResponse
 	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
-	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error)
+	MountFlashdrive() rpcmessages.ErrorResponse
+	UnmountFlashdrive() rpcmessages.ErrorResponse
 	Backup(rpcmessages.BackupArgs) (rpcmessages.GenericResponse, error)
 	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)
 	SampleInfo() rpcmessages.SampleInfoResponse
@@ -111,13 +112,18 @@ func (server *RPCServer) GetVerificationProgress(args int, reply *rpcmessages.Ve
 	return nil
 }
 
-// Flashdrive sends the middleware's GenericResponse over rpc
-// Args given can specify e.g. a flashdrive check, mount or unmount
-func (server *RPCServer) Flashdrive(args *rpcmessages.FlashdriveArgs, reply *rpcmessages.GenericResponse) error {
-	var err error
-	*reply, err = server.middleware.Flashdrive(*args)
+// MountFlashdrive sends the middleware's ErrorResponse over RPC.
+func (server *RPCServer) MountFlashdrive(dummyArg bool, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.MountFlashdrive()
 	log.Printf("sent reply %v: ", reply)
-	return err
+	return nil
+}
+
+// UnmountFlashdrive sends the middleware's ErrorResponse over RPC.
+func (server *RPCServer) UnmountFlashdrive(dummyArg bool, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.UnmountFlashdrive()
+	log.Printf("sent reply %v: ", reply)
+	return nil
 }
 
 // Backup sends the middleware's GenericResponse over rpc


### PR DESCRIPTION
Edit: This PR now addresses two things.

- [x] The Flashdrive RPC calls `bbb-cmd.sh` script with the `check` parameter only internally in `mount`. 
- [x] Split up the Flashdrive RPC into two: `MountFlashdrive` and `UnmountFlashdrive`.

_edit end_


Traffic between the base and the app should be kept minimal. This PR refactors the Flashdrive RPC to only use the `bbb-cmd.sh flashdrive check` output internally when calling the Flashdrive `mount` method. 

The changes make unit testing the RPCs even uglier/more complex. We might need to think about mocking the `bbb-cmd.sh` script in some other way in the future. 