### PR TITLE
Add ErrorResponse

### DIFF
--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -95,3 +95,12 @@ type GenericResponse struct {
 	Success bool
 	Message string
 }
+
+// ErrorResponse is a generic RPC response indicating if a RPC call was successful or not.
+// It can be embedded into other RPC responses that return values.
+// In any case the ErrorResponse should be checked first, so that, if an error is returned, we ignore everything else in the response.
+type ErrorResponse struct {
+	Success bool
+	Code    string
+	Message string
+}


### PR DESCRIPTION
This adds an ErrorResponse struct used to idicate if an RPC call was successful or not. It can be embedded into other RPC responses that return values. In any case the ErrorResponse should be checked first, so that, if an error is returned, we ignore everything else in the response.