### PR TITLE
middleware: refactor and split up Backup and Restore RPCs

### DIFF
--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -24,7 +24,8 @@ type Middleware interface {
 	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error)
 	BackupSysconfig() rpcmessages.ErrorResponse
 	BackupHSMSecret() rpcmessages.ErrorResponse
-	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)
+	RestoreSysconfig() rpcmessages.ErrorResponse
+	RestoreHSMSecret() rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -22,7 +22,8 @@ type Middleware interface {
 	SampleInfo() rpcmessages.SampleInfoResponse
 	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
 	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error)
-	Backup(rpcmessages.BackupArgs) (rpcmessages.GenericResponse, error)
+	BackupSysconfig() rpcmessages.ErrorResponse
+	BackupHSMSecret() rpcmessages.ErrorResponse
 	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -219,29 +219,24 @@ func (middleware *Middleware) Flashdrive(args rpcmessages.FlashdriveArgs) (rpcme
 	}
 }
 
-// Backup returns a GenericResponse struct in response to a rpcserver request
-func (middleware *Middleware) Backup(method rpcmessages.BackupArgs) (rpcmessages.GenericResponse, error) {
-	switch method {
-	case rpcmessages.BackupSysConfig:
-		log.Println("Executing a backup of the system config via the cmd script")
-		out, err := middleware.runBBBCmdScript("backup", "sysconfig")
-		if err != nil {
-			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
-		}
-		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
-
-	case rpcmessages.BackupHSMSecret:
-		log.Println("Executing a backup of the c-lightning hsm_secret via the cmd script")
-		out, err := middleware.runBBBCmdScript("backup", "hsm_secret")
-		if err != nil {
-			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
-		}
-		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
-
-	default:
-		errorMessage := fmt.Sprintf("Method %d not supported for Backup().", method)
-		return rpcmessages.GenericResponse{Success: false, Message: errorMessage}, errors.New(errorMessage)
+// BackupSysconfig returns a ErrorResponse struct in response to a rpcserver request
+func (middleware *Middleware) BackupSysconfig() rpcmessages.ErrorResponse {
+	log.Println("Executing a backup of the system config via the cmd script")
+	out, err := middleware.runBBBCmdScript("backup", "sysconfig")
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
 	}
+	return rpcmessages.ErrorResponse{Success: true}
+}
+
+// BackupHSMSecret returns a ErrorResponse struct in response to a rpcserver request
+func (middleware *Middleware) BackupHSMSecret() rpcmessages.ErrorResponse {
+	log.Println("Executing a backup of the c-lightning hsm_secret via the cmd script")
+	out, err := middleware.runBBBCmdScript("backup", "hsm_secret")
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
+	}
+	return rpcmessages.ErrorResponse{Success: true}
 }
 
 // Restore returns a GenericResponse struct in response to a rpcserver request

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -239,29 +239,24 @@ func (middleware *Middleware) BackupHSMSecret() rpcmessages.ErrorResponse {
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
-// Restore returns a GenericResponse struct in response to a rpcserver request
-func (middleware *Middleware) Restore(method rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error) {
-	switch method {
-	case rpcmessages.RestoreSysConfig:
-		log.Println("Executing a restore of the system config via the cmd script")
-		out, err := middleware.runBBBCmdScript("restore", "sysconfig")
-		if err != nil {
-			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
-		}
-		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
-
-	case rpcmessages.RestoreHSMSecret:
-		log.Println("Executing a restore of the c-lightning hsm_secret via the cmd script")
-		out, err := middleware.runBBBCmdScript("restore", "hsm_secret")
-		if err != nil {
-			return rpcmessages.GenericResponse{Success: false, Message: string(out)}, err
-		}
-		return rpcmessages.GenericResponse{Success: true, Message: string(out)}, nil
-
-	default:
-		errorMessage := fmt.Sprintf("Method %d not supported for Restore().", method)
-		return rpcmessages.GenericResponse{Success: false, Message: errorMessage}, errors.New(errorMessage)
+// RestoreSysconfig returns a ErrorResponse struct in response to a rpcserver request
+func (middleware *Middleware) RestoreSysconfig() rpcmessages.ErrorResponse {
+	log.Println("Executing a restore of the system config via the cmd script")
+	out, err := middleware.runBBBCmdScript("restore", "sysconfig")
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
 	}
+	return rpcmessages.ErrorResponse{Success: true}
+}
+
+// RestoreHSMSecret returns a ErrorResponse struct in response to a rpcserver request
+func (middleware *Middleware) RestoreHSMSecret() rpcmessages.ErrorResponse {
+	log.Println("Executing a restore of the c-lightning hsm_secret via the cmd script")
+	out, err := middleware.runBBBCmdScript("restore", "hsm_secret")
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
+	}
+	return rpcmessages.ErrorResponse{Success: true}
 }
 
 // UserAuthenticate returns an ErrorResponse struct in response to a rpcserver request.

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -127,29 +127,22 @@ func TestFlashdrive(t *testing.T) {
 	require.Error(t, errUnknown)
 }
 
-func TestBackup(t *testing.T) {
+func TestBackupHSMSecret(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	/* --- test sysconfig arg for Backup() ---*/
-	backupSysconfig, errSysconfig := testMiddleware.Backup(rpcmessages.BackupSysConfig)
+	response := testMiddleware.BackupHSMSecret()
+	require.Equal(t, response.Success, true)
+	require.Equal(t, response.Message, "")
+	require.Equal(t, response.Code, "")
+}
 
-	require.Equal(t, backupSysconfig.Success, true)
-	require.Equal(t, backupSysconfig.Message, "backup sysconfig\n")
-	require.NoError(t, errSysconfig)
+func TestBackupSysconfig(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
 
-	/* --- test hsm secret arg for Backup() ---*/
-	backupHSMSecret, errHSMSecret := testMiddleware.Backup(rpcmessages.BackupHSMSecret)
-
-	require.Equal(t, backupHSMSecret.Success, true)
-	require.Equal(t, backupHSMSecret.Message, "backup hsm_secret\n")
-	require.NoError(t, errHSMSecret)
-
-	/* --- test an unknown arg for Backup() ---*/
-	backupUnknown, errUnknown := testMiddleware.Backup(-1)
-
-	require.Equal(t, backupUnknown.Success, false) // should fail, the method -1 is unknown
-	require.Equal(t, backupUnknown.Message, "Method -1 not supported for Backup().")
-	require.Error(t, errUnknown)
+	response := testMiddleware.BackupSysconfig()
+	require.Equal(t, response.Success, true)
+	require.Equal(t, response.Message, "")
+	require.Equal(t, response.Code, "")
 }
 
 // TestRestore only covers the 'script not found' case.

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -145,32 +145,22 @@ func TestBackupSysconfig(t *testing.T) {
 	require.Equal(t, response.Code, "")
 }
 
-// TestRestore only covers the 'script not found' case.
-// We can't know the absolute path of the script, because that depends
-// on the system the tests are executed. e.g. Travis path and local path differ.
-func TestRestore(t *testing.T) {
+func TestRestoreHSMSecret(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	/* --- test sysconfig arg for Restore() ---*/
-	restoreSysconfig, errSysconfig := testMiddleware.Restore(rpcmessages.RestoreSysConfig)
+	response := testMiddleware.RestoreHSMSecret()
+	require.Equal(t, response.Success, true)
+	require.Equal(t, response.Message, "")
+	require.Equal(t, response.Code, "")
+}
 
-	require.Equal(t, restoreSysconfig.Success, true)
-	require.Equal(t, restoreSysconfig.Message, "restore sysconfig\n")
-	require.NoError(t, errSysconfig)
+func TestRestoreSysconfig(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
 
-	/* --- test hsm secret arg for Restore() ---*/
-	restoreHSMSecret, errHSMSecret := testMiddleware.Restore(rpcmessages.RestoreHSMSecret)
-
-	require.Equal(t, restoreHSMSecret.Success, true)
-	require.Equal(t, restoreHSMSecret.Message, "restore hsm_secret\n")
-	require.NoError(t, errHSMSecret)
-
-	/* --- test an unknown arg for Restore() ---*/
-	restoreUnknown, errUnknown := testMiddleware.Restore(-1)
-
-	require.Equal(t, restoreUnknown.Success, false) // should fail, the method -1 is unknown
-	require.Equal(t, restoreUnknown.Message, "Method -1 not supported for Restore().")
-	require.Error(t, errUnknown)
+	response := testMiddleware.RestoreSysconfig()
+	require.Equal(t, response.Success, true)
+	require.Equal(t, response.Message, "")
+	require.Equal(t, response.Code, "")
 }
 
 func TestUserAuthenticate(t *testing.T) {

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -42,15 +42,6 @@ const (
 	Unmount
 )
 
-// BackupArgs is an iota that holds the method for the Backup RPC call
-type BackupArgs int
-
-// The BackupArgs has two methods. Backup the system config (sysconfig) or the hsm_secret by c-lightning
-const (
-	BackupSysConfig BackupArgs = iota
-	BackupHSMSecret
-)
-
 // RestoreArgs is an iota that holds the method for the Backup RPC call
 type RestoreArgs int
 

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -42,15 +42,6 @@ const (
 	Unmount
 )
 
-// RestoreArgs is an iota that holds the method for the Backup RPC call
-type RestoreArgs int
-
-// The RestoreArgs has two methods. Restore the system config (sysconfig) or the hsm_secret by c-lightning
-const (
-	RestoreSysConfig RestoreArgs = iota
-	RestoreHSMSecret
-)
-
 // UserAuthenticateArgs is an struct that holds the arguments for the UserAuthenticate RPC call
 type UserAuthenticateArgs struct {
 	Username string

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -54,7 +54,8 @@ type Middleware interface {
 	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error)
 	BackupSysconfig() rpcmessages.ErrorResponse
 	BackupHSMSecret() rpcmessages.ErrorResponse
-	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)
+	RestoreSysconfig() rpcmessages.ErrorResponse
+	RestoreHSMSecret() rpcmessages.ErrorResponse
 	SampleInfo() rpcmessages.SampleInfoResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
@@ -122,24 +123,31 @@ func (server *RPCServer) Flashdrive(args *rpcmessages.FlashdriveArgs, reply *rpc
 }
 
 // BackupSysconfig sends the middleware's ErrorResponse over rpc
-func (server *RPCServer) BackupSysconfig(reply *rpcmessages.ErrorResponse) {
+func (server *RPCServer) BackupSysconfig(dummyArg bool, reply *rpcmessages.ErrorResponse) error {
 	*reply = server.middleware.BackupSysconfig()
 	log.Printf("sent reply %v: ", reply)
+	return nil
 }
 
 // BackupHSMSecret sends the middleware's ErrorResponse over rpc
-func (server *RPCServer) BackupHSMSecret(reply *rpcmessages.ErrorResponse) {
+func (server *RPCServer) BackupHSMSecret(dummyArg bool, reply *rpcmessages.ErrorResponse) error {
 	*reply = server.middleware.BackupHSMSecret()
 	log.Printf("sent reply %v: ", reply)
+	return nil
 }
 
-// Restore sends the middleware's GenericResponse over rpc
-// Args given can specify e.g. a sysconfig restore or a hsm_secret restore
-func (server *RPCServer) Restore(args *rpcmessages.RestoreArgs, reply *rpcmessages.GenericResponse) error {
-	var err error
-	*reply, err = server.middleware.Restore(*args)
+// RestoreSysconfig sends the middleware's ErrorResponse over rpc
+func (server *RPCServer) RestoreSysconfig(dummyArg bool, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.RestoreSysconfig()
 	log.Printf("sent reply %v: ", reply)
-	return err
+	return nil
+}
+
+// RestoreHSMSecret sends the middleware's ErrorResponse over rpc
+func (server *RPCServer) RestoreHSMSecret(dummyArg bool, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.RestoreHSMSecret()
+	log.Printf("sent reply %v: ", reply)
+	return nil
 }
 
 // UserAuthenticate sends the middleware's ErrorResponse over rpc

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -52,7 +52,8 @@ type Middleware interface {
 	SystemEnv() rpcmessages.GetEnvResponse
 	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
 	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error)
-	Backup(rpcmessages.BackupArgs) (rpcmessages.GenericResponse, error)
+	BackupSysconfig() rpcmessages.ErrorResponse
+	BackupHSMSecret() rpcmessages.ErrorResponse
 	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)
 	SampleInfo() rpcmessages.SampleInfoResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
@@ -120,13 +121,16 @@ func (server *RPCServer) Flashdrive(args *rpcmessages.FlashdriveArgs, reply *rpc
 	return err
 }
 
-// Backup sends the middleware's GenericResponse over rpc
-// Args given can specify e.g. a sysconfig backup or a hsm_secret backup
-func (server *RPCServer) Backup(args *rpcmessages.BackupArgs, reply *rpcmessages.GenericResponse) error {
-	var err error
-	*reply, err = server.middleware.Backup(*args)
+// BackupSysconfig sends the middleware's ErrorResponse over rpc
+func (server *RPCServer) BackupSysconfig(reply *rpcmessages.ErrorResponse) {
+	*reply = server.middleware.BackupSysconfig()
 	log.Printf("sent reply %v: ", reply)
-	return err
+}
+
+// BackupHSMSecret sends the middleware's ErrorResponse over rpc
+func (server *RPCServer) BackupHSMSecret(reply *rpcmessages.ErrorResponse) {
+	*reply = server.middleware.BackupHSMSecret()
+	log.Printf("sent reply %v: ", reply)
 }
 
 // Restore sends the middleware's GenericResponse over rpc


### PR DESCRIPTION
This PR splits up the Backup and Restore RPCs into `BackupSysconfig()`, `BackupHSMSecret()` `RestoreSysconfig()` `RestoreHSMSecret()`. They now each return a `ErrorResponse` and do only take a dummy argument.