### PR TITLE
middleware: split up ResyncBitcoin RPC into two RPCs

### DIFF
--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -20,7 +20,8 @@ type Middleware interface {
 	Start() <-chan []byte
 	SystemEnv() rpcmessages.GetEnvResponse
 	SampleInfo() rpcmessages.SampleInfoResponse
-	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
+	ResyncBitcoin() rpcmessages.ErrorResponse
+	ReindexBitcoin() rpcmessages.ErrorResponse
 	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error)
 	Backup(rpcmessages.BackupArgs) (rpcmessages.GenericResponse, error)
 	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -24,6 +24,8 @@ type Middleware interface {
 	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error)
 	Backup(rpcmessages.BackupArgs) (rpcmessages.GenericResponse, error)
 	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)
+	GetHostname() rpcmessages.GetHostnameResponse
+	SetHostname(rpcmessages.SetHostnameArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -138,26 +138,24 @@ func (middleware *Middleware) Start() <-chan []byte {
 	return middleware.events
 }
 
-// ResyncBitcoin returns a ResyncBitcoinResponse struct in response to a rpcserver request
-func (middleware *Middleware) ResyncBitcoin(option rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error) {
-	var cmd *exec.Cmd
-	switch option {
-	case rpcmessages.Resync:
-		log.Println("executing full bitcoin resync in config script")
-		cmd = exec.Command(middleware.environment.GetBBBConfigScript(), "exec", "bitcoin_resync")
-	case rpcmessages.Reindex:
-		log.Println("executing bitcoin reindex in config script")
-		cmd = exec.Command(middleware.environment.GetBBBConfigScript(), "exec", "bitcoin_reindex")
-	default:
-	}
-	err := cmd.Run()
+// ResyncBitcoin returns a ErrorResponse struct in response to a rpcserver request
+func (middleware *Middleware) ResyncBitcoin() rpcmessages.ErrorResponse {
+	log.Println("executing full bitcoin resync via the config script")
+	out, err := middleware.runBBBConfigScript("exec", "bitcoin_resync", "")
 	if err != nil {
-		log.Println(err.Error() + " failed to run resync command, script does not exist")
-		response := rpcmessages.ResyncBitcoinResponse{Success: false}
-		return response, err
+		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
 	}
-	response := rpcmessages.ResyncBitcoinResponse{Success: true}
-	return response, nil
+	return rpcmessages.ErrorResponse{Success: true}
+}
+
+// ReindexBitcoin returns a ErrorResponse struct in response to a rpcserver request
+func (middleware *Middleware) ReindexBitcoin() rpcmessages.ErrorResponse {
+	log.Println("executing full bitcoin resync via the config script")
+	out, err := middleware.runBBBConfigScript("exec", "bitcoin_reindex", "")
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
+	}
+	return rpcmessages.ErrorResponse{Success: true}
 }
 
 // SystemEnv returns a new GetEnvResponse struct with the values as read from the environment

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -69,10 +69,19 @@ func TestVerificationProgress(t *testing.T) {
 func TestResyncBitcoin(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	resyncBitcoinResponse, err := testMiddleware.ResyncBitcoin(rpcmessages.Resync)
+	response := testMiddleware.ResyncBitcoin()
+	require.Equal(t, response.Success, true)
+	require.Equal(t, response.Message, "")
+	require.Equal(t, response.Code, "")
+}
 
-	require.Equal(t, resyncBitcoinResponse.Success, true)
-	require.NoError(t, err)
+func TestReindexBitcoin(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	response := testMiddleware.ReindexBitcoin()
+	require.Equal(t, response.Success, true)
+	require.Equal(t, response.Message, "")
+	require.Equal(t, response.Code, "")
 }
 
 func TestFlashdrive(t *testing.T) {

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -16,15 +16,6 @@ const (
 Put Incoming Args below this line. They should have the format of 'RPC Method Name' + 'Args'.
 */
 
-// ResyncBitcoinArgs is an iota that holds the options for the ResyncBitcoin rpc call
-type ResyncBitcoinArgs int
-
-// The ResyncBitcoinArgs has two options. Other resync bitcon from scratch with an IBD, or delete the chainstate and reindex.
-const (
-	Resync ResyncBitcoinArgs = iota
-	Reindex
-)
-
 // FlashdriveArgs is an struct that holds the arguments for the Flashdrive RPC call
 type FlashdriveArgs struct {
 	Method FlashdriveMethod // the method called
@@ -85,11 +76,6 @@ Put Response structs below this line. They should have the format of 'RPC Method
 type GetEnvResponse struct {
 	Network        string
 	ElectrsRPCPort string
-}
-
-// ResyncBitcoinResponse is the struct that gets sent by the rpc server during a ResyncBitcoin call
-type ResyncBitcoinResponse struct {
-	Success bool
 }
 
 // SampleInfoResponse holds sample information from c-lightning and bitcoind. It is temporary for testing purposes

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -72,6 +72,11 @@ type UserChangePasswordArgs struct {
 	NewPassword string
 }
 
+// SetHostnameArgs is a struct that holds the to be set hostname
+type SetHostnameArgs struct {
+	Hostname string
+}
+
 /*
 Put Response structs below this line. They should have the format of 'RPC Method Name' + 'Response'.
 */
@@ -99,6 +104,12 @@ type VerificationProgressResponse struct {
 	Blocks               int64   `json:"blocks"`
 	Headers              int64   `json:"headers"`
 	VerificationProgress float64 `json:"verificationProgress"`
+}
+
+// GetHostnameResponse is the struct that get sent by the rpc server during a GetHostname rpc call
+type GetHostnameResponse struct {
+	ErrorResponse
+	Hostname string
 }
 
 // GenericResponse is a struct that for example gets sent by the RPC server during a Flashdrive, Backup or Restore call.

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -54,6 +54,8 @@ type Middleware interface {
 	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error)
 	Backup(rpcmessages.BackupArgs) (rpcmessages.GenericResponse, error)
 	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)
+	GetHostname() rpcmessages.GetHostnameResponse
+	SetHostname(rpcmessages.SetHostnameArgs) rpcmessages.ErrorResponse
 	SampleInfo() rpcmessages.SampleInfoResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
@@ -150,6 +152,22 @@ func (server *RPCServer) UserAuthenticate(args *rpcmessages.UserAuthenticateArgs
 func (server *RPCServer) UserChangePassword(args *rpcmessages.UserChangePasswordArgs, reply *rpcmessages.ErrorResponse) {
 	*reply = server.middleware.UserChangePassword(*args)
 	log.Printf("sent reply %v: ", reply)
+}
+
+// SetHostname sends the middleware's ErrorResponse over rpc
+// The argument given specifys the hostname to be set
+func (server *RPCServer) SetHostname(args *rpcmessages.SetHostnameArgs, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.SetHostname(*args)
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// GetHostname sends the middleware's GetHostnameResponse over rpc
+// The GetHostnameResponse includes the current system hostname
+func (server *RPCServer) GetHostname(dummyArg bool, reply *rpcmessages.GetHostnameResponse) error {
+	*reply = server.middleware.GetHostname()
+	log.Printf("sent reply %v: ", reply)
+	return nil
 }
 
 // Serve starts a gob rpc server

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -50,7 +50,8 @@ func (conn *rpcConn) Close() error {
 // Middleware provides an interface to the middleware package.
 type Middleware interface {
 	SystemEnv() rpcmessages.GetEnvResponse
-	ResyncBitcoin(rpcmessages.ResyncBitcoinArgs) (rpcmessages.ResyncBitcoinResponse, error)
+	ResyncBitcoin() rpcmessages.ErrorResponse
+	ReindexBitcoin() rpcmessages.ErrorResponse
 	Flashdrive(rpcmessages.FlashdriveArgs) (rpcmessages.GenericResponse, error)
 	Backup(rpcmessages.BackupArgs) (rpcmessages.GenericResponse, error)
 	Restore(rpcmessages.RestoreArgs) (rpcmessages.GenericResponse, error)
@@ -91,12 +92,18 @@ func (server *RPCServer) GetSystemEnv(args int, reply *rpcmessages.GetEnvRespons
 	return nil
 }
 
-// ResyncBitcoin sends the middleware's ResyncBitcoinResponse over rpc
-func (server *RPCServer) ResyncBitcoin(args *rpcmessages.ResyncBitcoinArgs, reply *rpcmessages.ResyncBitcoinResponse) error {
-	var err error
-	*reply, err = server.middleware.ResyncBitcoin(*args)
+// ReindexBitcoin sends the middleware's ErrorResponse over rpc
+func (server *RPCServer) ReindexBitcoin(dummyArg bool, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.ReindexBitcoin()
 	log.Printf("sent reply %v: ", reply)
-	return err
+	return nil
+}
+
+// ResyncBitcoin sends the middleware's ErrorResponse over rpc
+func (server *RPCServer) ResyncBitcoin(dummyArg bool, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.ResyncBitcoin()
+	log.Printf("sent reply %v: ", reply)
+	return nil
 }
 
 // GetSampleInfo sends the middleware's SampleInfoResponse over rpc

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -97,8 +97,13 @@ func TestRPCServer(t *testing.T) {
 	var systemEnvReply rpcmessages.GetEnvResponse
 	testingRPCServer.RunRPCCall(t, "RPCServer.GetSystemEnv", request, &systemEnvReply)
 
-	var resyncReply rpcmessages.ResyncBitcoinResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.ResyncBitcoin", request, &resyncReply)
+	var reindexBitcoinReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.ReindexBitcoin", true /* dummy Arg */, &reindexBitcoinReply)
+	require.Equal(t, true, reindexBitcoinReply.Success)
+
+	var resyncBitcoinReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.ResyncBitcoin", true /* dummy Arg */, &resyncBitcoinReply)
+	require.Equal(t, true, resyncBitcoinReply.Success)
 
 	var sampleInfoReply rpcmessages.SampleInfoResponse
 	testingRPCServer.RunRPCCall(t, "RPCServer.GetSampleInfo", request, &sampleInfoReply)


### PR DESCRIPTION
The ResyncBitcoin RPC is split up into the ResyncBitcoin and ReindexBitcoin RPC.
This builds on top of work done in 35013917cbb7aa5512a4f4373dd355d143db555c. Will rebase on master once https://github.com/digitalbitbox/bitbox-base/pull/163 is merged.