### PR TITLE
add mock shell scripts for integration test

### DIFF
--- a/armbian/base/scripts/bbb-cmd.sh
+++ b/armbian/base/scripts/bbb-cmd.sh
@@ -10,7 +10,7 @@ usage() {
 usage: bbb-cmd.sh [--version] [--help] <command>
 
 possible commands:
-  setup         <datadir|hostname_link>
+  setup         <datadir>
   base          <restart|shutdown>
   bitcoind      <reindex|resync>
   flashdrive    <check|mount|umount>

--- a/middleware/integration_test/bbb-cmd.sh
+++ b/middleware/integration_test/bbb-cmd.sh
@@ -13,7 +13,7 @@ usage() {
 usage: bbb-cmd.sh [--version] [--help] <command>
 
 possible commands:
-  setup         <datadir|hostname_link>
+  setup         <datadir>
   base          <restart|shutdown>
   bitcoind      <reindex|resync>
   flashdrive    <check|mount|umount>

--- a/middleware/integration_test/bbb-cmd.sh
+++ b/middleware/integration_test/bbb-cmd.sh
@@ -1,0 +1,115 @@
+#!/bin/bash
+set -eu
+
+# MOCK DEV SCRIPT
+# always return without doing anything
+
+# BitBox Base: system commands repository
+#
+
+# print usage information for script
+usage() {
+  echo "BitBox Base: system commands repository
+usage: bbb-cmd.sh [--version] [--help] <command>
+
+possible commands:
+  setup         <datadir|hostname_link>
+  base          <restart|shutdown>
+  bitcoind      <reindex|resync>
+  flashdrive    <check|mount|umount>
+  backup        <sysconfig|hsm_secret>
+  restore       <sysconfig|hsm_secret>
+
+"
+}
+
+# ------------------------------------------------------------------------------
+
+# check script arguments
+if [[ ${#} == 0 ]] || [[ "${1}" == "-h" ]] || [[ "${1}" == "--help" ]]; then
+    usage
+    exit 0
+elif [[ "${1}" == "-v" ]] || [[ "${1}" == "--version" ]]; then
+    echo "bbb-cmd version 0.1"
+    exit 0
+fi
+
+MODULE="${1:-''}"
+COMMAND="${2:-''}"
+ARG="${3:-''}"
+
+MODULE="${MODULE^^}"
+COMMAND="${COMMAND^^}"
+
+case "${MODULE}" in
+    SETUP)
+        case "${COMMAND}" in
+            DATADIR)
+                echo "OK: ${MODULE} -- ${COMMAND}"
+                ;;
+
+            *)
+                echo "Invalid argument for module ${MODULE}: command ${COMMAND} unknown."
+                exit 1
+        esac
+        ;;
+
+    BITCOIND)
+        case "${COMMAND}" in
+            RESYNC|REINDEX)
+                echo "OK: ${MODULE} -- ${COMMAND}"
+                ;;
+            *)
+                echo "Invalid argument for module ${MODULE}: command ${COMMAND} unknown."
+                exit 1
+        esac
+        ;;
+        
+
+    BASE)
+        case "${COMMAND}" in
+            RESTART|SHUTDOWN)
+                echo "OK: ${MODULE} -- ${COMMAND}"
+                ;;
+            *)
+                echo "Invalid argument for module ${MODULE}: command ${COMMAND} unknown."
+                exit 1
+        esac
+        ;;
+
+    FLASHDRIVE)
+        # sanitize device name
+        ARG="${ARG//[^a-zA-Z0-9_\/]/}"
+
+        case "${COMMAND}" in
+            CHECK)
+                echo "/dev/sdb1"
+                ;;
+
+            MOUNT|UNMOUNT)
+                echo "OK: ${MODULE} -- ${COMMAND}"
+                ;;
+
+            *)
+                echo "Invalid argument for module ${MODULE}: command ${COMMAND} unknown."
+                exit 1
+        esac
+        ;;        
+    
+    BACKUP|RESTORE)
+        case "${COMMAND}" in
+            # backup system configuration to mounted usb flashdrive
+            SYSCONFIG|HSM_SECRET)
+                echo "OK: ${MODULE} -- ${COMMAND}"
+                ;;
+
+            *)
+                echo "Invalid argument for module ${MODULE}: command ${COMMAND} unknown."
+                exit 1
+        esac
+        ;;    
+
+    *)
+        echo "Invalid argument: module ${MODULE} unknown."
+        exit 1
+esac

--- a/middleware/integration_test/bbb-config.sh
+++ b/middleware/integration_test/bbb-config.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+set -eu
+
+# MOCK DEV SCRIPT
+# always return without doing anything
+
+# BitBox Base: system configuration utility
+#
+
+# print usage information for script
+usage() {
+  echo "BitBox Base: system configuration utility
+usage: bbb-config.sh [--version] [--help]
+                     <command> [<args>]
+
+assumes Redis database running to be used with 'redis-cli'
+
+possible commands:
+  enable    <dashboard_hdmi|dashboard_web|wifi|autosetup_ssd|
+             tor|tor_ssh|tor_electrum|overlayroot|root_pwlogin>
+
+  disable   any 'enable' argument
+
+  set       <bitcoin_network|hostname|root_pw|wifi_ssid|wifi_pw>
+            bitcoin_network     <mainnet|testnet>
+            bitcoin_ibd         <true|false>
+            bitcoin_dbcache     int (MB)
+            other arguments     string
+
+  get       <tor_ssh_onion|tor_electrum_onion>
+
+  apply     no argument, applies all configuration settings to the system 
+            [not yet implemented]
+
+"
+}
+
+# ------------------------------------------------------------------------------
+
+# check script arguments
+if [[ ${#} -eq 0 ]] || [[ "${1}" == "-h" ]] || [[ "${1}" == "--help" ]]; then
+  usage
+  exit 0
+elif [[ "${1}" == "-v" ]] || [[ "${1}" == "--version" ]]; then
+  echo "bbb-config version 0.1"
+  exit 0
+elif [[ ${#} -eq 1 ]]; then
+  usage
+  exit 0
+fi
+
+COMMAND="${1}"
+SETTING="${2^^}"
+
+# parse COMMAND: enable, disable, get, set
+case "${COMMAND}" in
+    enable|disable)
+        if [[ "${COMMAND}" == "enable" ]]; then
+            ENABLE=1
+        else
+            ENABLE=0
+        fi
+
+        case "${SETTING}" in
+            DASHBOARD_HDMI|DASHBOARD_WEB|WIFI|AUTOSETUP_SSD|TOR|TOR_SSH|TOR_ELECTRUM|OVERLAYROOT|ROOT_PWLOGIN)
+                echo "OK: ${COMMAND} -- ${SETTING}"
+                ;;
+
+            *)
+                echo "Invalid argument: setting ${SETTING} unknown."
+                exit 1
+        esac
+        ;;
+
+    set)
+        if [[ ${#} -lt 3 ]]; then
+            echo "Missing argument: command 'set' needs two arguments."
+            exit 1
+        fi
+
+        case "${SETTING}" in
+            BITCOIN_NETWORK)
+                case "${3}" in
+                    mainnet|testnet)
+                        echo "OK: ${COMMAND} -- ${SETTING} ${3}"
+                        ;;
+
+                    *)
+                        echo "Invalid argument: ${SETTING} can only be set to 'mainnet' or 'testnet'."
+                        exit 1
+                esac
+                ;;
+
+            BITCOIN_IBD)
+                case "${3}" in
+                    true|false)
+                        echo "OK: ${COMMAND} -- ${SETTING} ${3}"
+                        ;;
+                    *)
+                        echo "Invalid argument: '${3}' must be either 'true' or 'false'."
+                        exit 1
+                esac
+                ;;
+
+            BITCOIN_DBCACHE)
+                if [[ "${3}" -ge 50 ]] && [[ "${3}" -le 3000 ]]; then
+                    echo "OK: ${COMMAND} -- ${SETTING} ${3}"
+                else
+                    echo "Invalid argument: '${3}' must be an integer in MB between 50 and 3000."
+                    exit 1
+                fi
+                ;;
+
+            HOSTNAME)
+                case "${3}" in
+                    [^0-9A-Za-z]*|*[^-0-9A-Z_a-z]*|*[^0-9A-Za-z]|*-_*|*_-*)
+                        echo "Invalid argument: '${3}' is not a valid hostname."
+                        exit 1
+                        ;;
+                    *)
+                        echo "OK: ${COMMAND} -- ${SETTING} ${3}"
+                esac
+                ;;
+
+            ROOT_PW|WIFI_SSID|WIFI_PW)
+                echo "OK: ${COMMAND} -- ${SETTING} ${3}"
+                ;;
+
+            *)
+                echo "Invalid argument: setting ${SETTING} unknown."
+
+        esac
+        ;;
+
+    get)
+        case "${SETTING}" in
+            TOR_SSH_ONION)
+                echo "${SETTING}=torssh-onioneiynxxxxxxxxxxxaicxqgb3xxxxxxxxxabxegcjznhyd.onion"
+                ;;
+
+            TOR_ELECTRUM_ONION)
+                echo "${SETTING}=torelectrumneiynxxxxxxxxxxxaicxqgb3xxxxxxxxxabxegcjznhyd.onion"
+                ;;
+
+            *)
+                echo "Invalid argument: setting ${SETTING} unknown."
+        esac
+        ;;
+
+    *)
+        echo "Invalid argument: command ${COMMAND} unknown."
+        exit 1
+esac


### PR DESCRIPTION
Add mock `bbb-cmd.sh` and `bbb-config.sh` scripts in `/middleware/integration_test` to enable the Middleware to call these scripts in a development environment, without actually doing anything to the system.

All validation checks have been preserved.