### PR TITLE
bitcoind-rpcauth: script and service configuration

### DIFF
--- a/armbian/Makefile
+++ b/armbian/Makefile
@@ -14,9 +14,7 @@ mender-artefacts:
 	bash $(MAKE_PATH)/mender-convert.sh
 
 # update Armbian image and create new Mender.io artefacts in one go
-update-mender:
-	bash $(MAKE_PATH)/armbian-build.sh update
-	bash $(MAKE_PATH)/mender-convert.sh
+update-mender: update mender-artefacts
 
 # execute configuration script directly on the device, starting 
 # with a stock Armbian image

--- a/armbian/Makefile
+++ b/armbian/Makefile
@@ -1,17 +1,28 @@
 .DEFAULT_GOAL := build
 MAKE_PATH=$(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 
+# build Armbian image from scratch, not using cached binaries
 build:
 	bash $(MAKE_PATH)/armbian-build.sh build
 
+# update Armbian image with cached binaries
 update:
 	bash $(MAKE_PATH)/armbian-build.sh update
 
+# create Mender.io artefacts from the latest Armbian image
 mender-artefacts:
 	bash $(MAKE_PATH)/mender-convert.sh
 
+# update Armbian image and create new Mender.io artefacts in one go
+update-mender:
+	bash $(MAKE_PATH)/armbian-build.sh update
+	bash $(MAKE_PATH)/mender-convert.sh
+
+# execute configuration script directly on the device, starting 
+# with a stock Armbian image
 build-ondevice:
 	bash $(MAKE_PATH)/armbian-build.sh ondevice
 
+# clean up build repositories and cached data
 clean:
 	rm -rf $(MAKE_PATH)/armbian/armbian-build

--- a/armbian/base/config/redis/factorysettings.txt
+++ b/armbian/base/config/redis/factorysettings.txt
@@ -23,8 +23,10 @@ SET bitcoind:listen 1
 SET bitcoind:txindex 0
 SET bitcoind:prune 0
 SET bitcoind:disablewallet 1
-SET bitcoind:rpccookiefile /mnt/ssd/bitcoin/.bitcoin/.cookie
-SET bitcoind:sysparms 1
+SET bitcoind:refresh-rpcauth 1
+SET bitcoind:rpcauth xxx
+SET bitcoind:rpcuser xxx
+SET bitcoind:rpcpassword xxx
 SET bitcoind:printtoconsole 1
 SET bitcoind:onlynet ipv4
 SET bitcoind:rpcconnect 127.0.0.1

--- a/armbian/base/config/templates/bashrc-custom.template
+++ b/armbian/base/config/templates/bashrc-custom.template
@@ -4,7 +4,7 @@ alias l='ls $LS_OPTIONS -l'
 alias ll='ls $LS_OPTIONS -la'
 
 # Bitcoin
-alias bcli='bitcoin-cli -conf=/etc/bitcoin/bitcoin.conf'
+alias bcli='bitcoin-cli -conf=/etc/bitcoin/bitcoin.conf -rpcuser=base -rpcpassword={{ bitcoind:rpcpassword }}'
 alias blog='sudo journalctl -f -u bitcoind'
 
 # Lightning

--- a/armbian/base/config/templates/bbbmiddleware.conf.template
+++ b/armbian/base/config/templates/bbbmiddleware.conf.template
@@ -1,4 +1,5 @@
 {{ #output: /etc/bbbmiddleware/bbbmiddleware.conf }}
-BITCOIN_RPCUSER={{      bbbmiddleware:bitcoin-rpcuser   #default: __cookie__ }}
+BITCOIN_RPCUSER={{      bitcoind:rpcuser                #default: base }}
+BITCOIN_RPCPASSWORD={{  bitcoind:rpcpassword            #rmLine }}
 BITCOIN_RPCPORT={{      bitcoind:rpcport                #default: 8332 }}
-LIGHTNING_RPCPATH={{    lightningd:lightning-dir        #default: /mnt/ssd/bitcoin/.lightning }}
+LIGHTNING_RPCPATH={{    lightningd:lightning-dir        #default: /mnt/ssd/bitcoin/.lightning }}/lightning-rpc

--- a/armbian/base/config/templates/bitcoin.conf.template
+++ b/armbian/base/config/templates/bitcoin.conf.template
@@ -10,8 +10,6 @@ listenonion={{      tor:base:enabled            #default: 1 }}              {{ t
 txindex={{          bitcoind:txindex            #default: 0 }}
 prune={{            bitcoind:prune              #default: 0 }}
 disablewallet={{    bitcoind:disablewallet      #default: 1 }}
-rpccookiefile={{    bitcoind:rpccookiefile      #default: /mnt/ssd/bitcoin/.bitcoin/.cookie }}
-sysparms={{         bitcoind:sysparms           #default: 1 }}
 printtoconsole={{   bitcoind:printtoconsole     #default: 1 }}
 onlynet={{          bitcoind:onlynet            #default: ipv4 }}           {{ tor:base:enabled #rmLineTrue }}
 onlynet={{          bitcoind:onlynet            #default: ipv4 }}           {{ tor:base:enabled #rmLineFalse }} {{ bitcoind:ibd-clearnet #rmLineFalse }}
@@ -19,6 +17,7 @@ onlynet={{          bitcoind:onlynet            #default: ipv4 }}           {{ t
 # rpc
 rpcconnect={{       bitcoind:rpcconnect         #default: 127.0.0.1 }}
 rpcport={{          bitcoind:rpcport            #default: 8332 }}
+rpcauth={{          bitcoind:rpcauth            #rmLine }}
 
 # performance
 dbcache={{          bitcoind:dbcache            #default: 300 }}

--- a/armbian/base/config/templates/electrs.conf.template
+++ b/armbian/base/config/templates/electrs.conf.template
@@ -7,3 +7,5 @@ DAEMON_DIR={{       electrs:daemon_dir      #default: /mnt/ssd/bitcoin/.bitcoin 
 MONITORING_ADDR={{  electrs:monitoring_addr #default: 127.0.0.1:4224 }}
 VERBOSITY={{        electrs:verbosity       #default: vvvv }}
 RUST_BACKTRACE={{   electrs:rust_backtrace  #default: 1 }}
+RPCUSER={{          bitcoind:rpcuser        #default: base }}
+RPCPASSWORD={{      bitcoind:rpcpassword    #rmLine }}

--- a/armbian/base/config/templates/lightningd.conf.template
+++ b/armbian/base/config/templates/lightningd.conf.template
@@ -1,6 +1,8 @@
 {{ #output: /etc/lightningd/lightningd.conf }}
 {{                      bitcoind:network            #default: mainnet }}
 bitcoin-cli={{          lightningd:bitcoin-cli      #default: /usr/bin/bitcoin-cli }}
+bitcoin-rpcuser={{      bitcoind:rpcuser            #default: base }}
+bitcoin-rpcpassword={{  bitcoind:rpcpassword        #rmLine }}
 bitcoin-rpcconnect={{   bitcoind:rpcconnect         #default: 127.0.0.1 }}
 bitcoin-rpcport={{      bitcoind:rpcport            #default: 8332 }}
 lightning-dir={{        lightningd:lightning-dir    #default: /mnt/ssd/bitcoin/.lightning }}

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -207,8 +207,7 @@ else
   echo "No SSH keys file found (base/authorized_keys), password login only."
 fi
 chown -R base:bitcoin /home/base/
-chmod 700 /home/base/.ssh/
-chmod 600 /home/base/.ssh/*
+chmod -R u+rw,g-rwx,o-rwx /home/base/.ssh
 
 # disable password login for SSH (authorized ssh keys only)
 if [ "$BASE_SSH_PASSWORD_LOGIN" != "true" ]; then
@@ -244,7 +243,7 @@ chsh -s /bin/bash hdmi
 # also revoke direct write access for service users to local directory
 if ! mountpoint /mnt/ssd -q; then 
   rm -rf /mnt/ssd/bitcoin/
-  chmod 700 /mnt/ssd
+  chmod u+rwx,g-rwx,o-rwx /mnt/ssd
 fi
 
 
@@ -413,7 +412,7 @@ mkdir -p /mnt/ssd/
 ## add bash shortcuts
 generateConfig bashrc-custom.template # -->  /home/base/.bashrc-custom
 chown base:bitcoin /home/base/.bashrc-custom
-chmod 600 /home/base/.bashrc-custom
+chmod u+rw,g-rwx,o-rwx /home/base/.bashrc-custom
 echo "source /home/base/.bashrc-custom" >> /home/base/.bashrc
 # shellcheck disable=SC1091
 source /home/base/.bashrc-custom
@@ -466,15 +465,12 @@ tar --strip-components 1 -xzf bitcoin-${BITCOIN_VERSION}-aarch64-linux-gnu.tar.g
 install -m 0755 -o root -g root -t /usr/bin bin/*
 
 mkdir -p /etc/bitcoin/
-chmod 750 /etc/bitcoin/
 generateConfig "bitcoin.conf.template" # --> /etc/bitcoin/bitcoin.conf
-chown -R bitcoin:bitcoin /etc/bitcoin
-chmod 640 /etc/bitcoin/*
+chown -R root:bitcoin /etc/bitcoin
+chmod -R u+rw,g+r,g-w,o-rwx /etc/bitcoin
 importFile "/etc/systemd/system/bitcoind.service"
 systemctl enable bitcoind.service
 
-######## XXX
-cat /etc/bitcoin/bitcoin.conf
 
 # LIGHTNING --------------------------------------------------------------------
 BIN_DEPS_TAG="v0.0.1-alpha"
@@ -515,10 +511,9 @@ else
 fi
 
 mkdir -p /etc/lightningd/
-chmod -R 750 /etc/lightningd/
 generateConfig "lightningd.conf.template" # --> /etc/lightningd/lightningd.conf
-chown -R bitcoin:bitcoin /etc/lightningd
-chmod 640 /etc/lightningd/*
+chown -R root:bitcoin /etc/lightningd
+chmod -R u+rw,g+r,g-w,o-rwx /etc/lightningd
 importFile "/etc/systemd/system/lightningd.service"
 systemctl enable lightningd.service
 
@@ -539,10 +534,9 @@ tar -xzf electrs-${ELECTRS_VERSION}-aarch64-linux-gnu.tar.gz -C /usr/bin
 chmod +x /usr/bin/electrs
 
 mkdir -p /etc/electrs/
-chmod 750 /etc/electrs/
 generateConfig "electrs.conf.template" # --> /etc/electrs/electrs.conf
-chown -R electrs:bitcoin /etc/electrs
-chmod 640 /etc/electrs/*
+chown -R root:bitcoin /etc/electrs
+chmod -R u+rw,g+r,g-w,o-rwx /etc/electrs
 importFile "/etc/systemd/system/electrs.service"
 systemctl enable electrs.service
 
@@ -585,9 +579,8 @@ fi
 if [ -f /opt/shift/bin/go/bbbmiddleware ]; then
   cp /opt/shift/bin/go/bbbmiddleware /usr/local/sbin/
   mkdir -p /etc/bbbmiddleware/
-  chmod 750 /etc/bbbmiddleware/
   generateConfig "bbbmiddleware.conf.template" # --> /etc/bbbmiddleware/bbbmiddleware.conf
-  chmod 640 /etc/bbbmiddleware/*
+  chmod -R u+rw,g+r,g-w,o-rwx /etc/bbbmiddleware
   importFile "/etc/systemd/system/bbbmiddleware.service"
   systemctl enable bbbmiddleware.service
 else

--- a/armbian/base/rootfs/etc/systemd/system/bbbmiddleware.service
+++ b/armbian/base/rootfs/etc/systemd/system/bbbmiddleware.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=BitBox Base Middleware
-After=multi-user.target
+After=multi-user.target bitcoind.service
 
 [Service]
 
@@ -8,10 +8,10 @@ After=multi-user.target
 ###################
 
 EnvironmentFile=/etc/bbbmiddleware/bbbmiddleware.conf
-EnvironmentFile=/mnt/ssd/bitcoin/.bitcoin/.cookie.env
+ExecStartPre=/opt/shift/scripts/systemd-bbbmiddleware-startpre.sh
 ExecStart=/usr/local/sbin/bbbmiddleware \
     -rpcuser=${BITCOIN_RPCUSER} \
-    -rpcpassword=${RPCPASSWORD} \
+    -rpcpassword=${BITCOIN_RPCPASSWORD} \
     -rpcport=${BITCOIN_RPCPORT} \
     -lightning-rpc-path=${LIGHTNING_RPCPATH} \
     -datadir=/data/bbbmiddleware

--- a/armbian/base/rootfs/etc/systemd/system/bitcoind.service
+++ b/armbian/base/rootfs/etc/systemd/system/bitcoind.service
@@ -1,6 +1,6 @@
 [Unit]
 Description=Bitcoin daemon
-After=multi-user.target
+After=multi-user.target redis.service
 Requires=startup-checks.service
 
 [Service]
@@ -8,7 +8,9 @@ Requires=startup-checks.service
 # Service execution
 ###################
 
-ExecStartPre=/opt/shift/scripts/systemd-bitcoind-startpre.sh
+# run startpre script as root (with =+ )
+ExecStartPre=+/opt/shift/scripts/systemd-bitcoind-startpre.sh
+
 ExecStart=/usr/bin/bitcoind \
     -conf=/etc/bitcoin/bitcoin.conf \
     -pid=/run/bitcoind/bitcoind.pid
@@ -20,7 +22,7 @@ ExecStartPost=/opt/shift/scripts/systemd-bitcoind-startpost.sh
 Type=simple
 PIDFile=/run/bitcoind/bitcoind.pid
 Restart=always
-RestartSec=30
+RestartSec=10
 TimeoutSec=300
 
 

--- a/armbian/base/rootfs/etc/systemd/system/electrs.service
+++ b/armbian/base/rootfs/etc/systemd/system/electrs.service
@@ -8,13 +8,12 @@ After=multi-user.target bitcoind.service
 ###################
 
 EnvironmentFile=/etc/electrs/electrs.conf
-EnvironmentFile=/mnt/ssd/bitcoin/.bitcoin/.cookie.env
 ExecStartPre=+/opt/shift/scripts/systemd-electrs-startpre.sh
 ExecStart=/usr/bin/electrs \
     --network ${NETWORK} \
     --db-dir ${DB_DIR} \
     --daemon-dir ${DAEMON_DIR} \
-    --cookie "__cookie__:${RPCPASSWORD}" \
+    --cookie "${RPCUSER}:${RPCPASSWORD}" \
     --monitoring-addr ${MONITORING_ADDR} \
     -${VERBOSITY}
 

--- a/armbian/base/scripts/bitcoind-rpcauth.py
+++ b/armbian/base/scripts/bitcoind-rpcauth.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+# Copyright (c) 2015-2018 The Bitcoin Core developers
+# Distributed under the MIT software license, see the accompanying
+# file COPYING or http://www.opensource.org/licenses/mit-license.php.
+# 
+# Original script
+# https://github.com/bitcoin/bitcoin/tree/master/share/rpcauth
+# ------------------------------------------------------------------------------
+# Extendet script, by Shift Cryptosecurity AG, Switzerland
+# implementing direct Redis support to store rpcauth, rpcuser and rpcpassword
+# 
+# https://github.com/digitalbitbox/bitbox-base
+# ------------------------------------------------------------------------------
+
+from argparse import ArgumentParser
+from base64 import urlsafe_b64encode
+from binascii import hexlify
+from getpass import getpass
+from os import urandom
+import redis
+import sys
+
+import hmac
+
+def generate_salt(size):
+    """Create size byte hex salt"""
+    return hexlify(urandom(size)).decode()
+
+def generate_password():
+    """Create 32 byte b64 password"""
+    return urlsafe_b64encode(urandom(32)).decode('utf-8')
+
+def password_to_hmac(salt, password):
+    m = hmac.new(bytearray(salt, 'utf-8'), bytearray(password, 'utf-8'), 'SHA256')
+    return m.hexdigest()
+
+def main():
+    parser = ArgumentParser(description='Create login credentials for a JSON-RPC user')
+    parser.add_argument('username', help='the username for authentication')
+    parser.add_argument('password', help='leave empty to generate a random password or specify "-" to prompt for password', nargs='?')
+    args = parser.parse_args()
+
+    if not args.password:
+        args.password = generate_password()
+    elif args.password == '-':
+        args.password = getpass()
+
+    # Create 16 byte hex salt
+    salt = generate_salt(16)
+    password_hmac = password_to_hmac(salt, args.password)
+
+    print('String to be appended to bitcoin.conf:')
+    print('rpcauth={0}:{1}${2}'.format(args.username, salt, password_hmac))
+    print('Your password:\n{0}'.format(args.password))
+
+    # Extension by Shift Cryptosecurity AG, Switzerland 
+    # ▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼▼
+
+    try:
+        r = redis.Redis(
+            host='127.0.0.1',
+            port=6379,
+        )
+
+        if r.ping():
+            r.set('bitcoind:rpcauth', '{0}:{1}${2}'.format(args.username, salt, password_hmac))
+            r.set('bitcoind:rpcuser', args.username)
+            r.set('bitcoind:rpcpassword', args.password)
+            r.save()
+        else:
+            sys.exit('ERR: Redis not available.')
+
+    except:
+        sys.exit('ERR: Redis not available.')
+
+    # ▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲▲
+
+if __name__ == '__main__':
+    main()

--- a/armbian/base/scripts/include/redis.sh.inc
+++ b/armbian/base/scripts/include/redis.sh.inc
@@ -2,23 +2,33 @@
 #
 redis_set() {
     # usage: redis_set "key" "value"
-    ok=$(redis-cli -h localhost -p 6379 -n 0 SET "${1}" "${2}")
+    ok=$(redis-cli -h localhost -p 6379 -n 0 SET "${1}" "${2}") || true
     if [[ "${ok}"  != "OK" ]]; then
-        echo "ERR: could not SET key ${1}"
-        # exit 1
+        echo "ERR: Redis could not SET key ${1}"
     else
         echo "INFO: set Redis key '${1}' to '${2}'"
     fi
 
-    ok=$(redis-cli -h localhost -p 6379 -n 0 SAVE)
+    ok=$(redis-cli -h localhost -p 6379 -n 0 SAVE) || true
     if [[ "${ok}"  != "OK" ]]; then
-        echo "ERR: could not SAVE to disk"
-        # exit 1
+        echo "ERR: Redis could not SAVE to disk"
     fi
 }
 
 redis_get() {
     # usage: str=$(redis_get "key")
-    ok=$(redis-cli -h localhost -p 6379 -n 0 GET "${1}")
+    ok=$(redis-cli -h localhost -p 6379 -n 0 GET "${1}") || true
     echo "${ok}"
+}
+
+redis_require() {
+    # checks if Redis is available, or aborts
+    # usage: redis_require
+    ok=$(redis-cli -h localhost -p 6379 -n 0 PING) || true
+    if [[ "${ok}"  != "PONG" ]]; then
+        echo "ERR: Redis not available, aborting"
+        exit 1
+    else
+        echo "INFO: Redis available"
+    fi
 }

--- a/armbian/base/scripts/systemd-bbbmiddleware-startpre.sh
+++ b/armbian/base/scripts/systemd-bbbmiddleware-startpre.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+#
+# This script is run by systemd using the ExecStartPre option
+# before starting bbbmiddleware.service.
+#
+set -eu
+
+# include functions redis_set() and redis_get()
+# shellcheck disable=SC1091
+source /opt/shift/scripts/include/redis.sh.inc
+
+# ------------------------------------------------------------------------------
+
+REFRESH_RPCAUTH="$(redis_get 'bitcoind:refresh-rpcauth')"
+if [ "${REFRESH_RPCAUTH}" -ne 0 ]; then
+    # either Redis not ready yet or new credentials requested
+    echo "INFO: bitcoind:refresh-rpcauth not 0, holding off bbbmiddleware start for bitcoind to warm up"
+    sleep 15
+
+else
+    echo "INFO: bitcoind:refresh-rpcauth equals 0, starting bbbmiddleware immediately"
+fi

--- a/armbian/base/scripts/systemd-bitcoind-startpost.sh
+++ b/armbian/base/scripts/systemd-bitcoind-startpost.sh
@@ -3,23 +3,3 @@
 # This script is run by systemd using the ExecStartPost option 
 # after starting bitcoind.service (Bitcoin Core).
 set -eu
-
-# We set rpccookiefile=/mnt/ssd/bitcoin/.bitcoin/.cookie, but there seems to be
-# no way to specify where to expect the bitcoin cookie for c-lightning, so let's
-# create a symlink at the expected testnet location.
-mkdir -p /mnt/ssd/bitcoin/.bitcoin/testnet3/
-ln -fs /mnt/ssd/bitcoin/.bitcoin/.cookie /mnt/ssd/bitcoin/.bitcoin/testnet3/.cookie
-echo "${0}: symlink from file .bitcoin/.cookie -> .bitcoin/testnet3/.cookie created."
-
-# wait a few seconds before providing cookie authentication 
-# as .env file for electrs and bbbmiddleware 
-sleep 10
-echo -n 'RPCPASSWORD=' > /mnt/ssd/bitcoin/.bitcoin/.cookie.env
-tail -c +12 /mnt/ssd/bitcoin/.bitcoin/.cookie >> /mnt/ssd/bitcoin/.bitcoin/.cookie.env
-echo "${0}: file /mnt/ssd/bitcoin/.bitcoin/.cookie.env updated."
-
-# log bitcoind restarts including auth information
-echo "`date +%Y-%m-%d-%H:%M` systemd-bitcoind-post.sh `cat /mnt/ssd/bitcoin/.bitcoin/.cookie`" >> /mnt/ssd/bitcoin/.bitcoin/restarts.log
-
-# hold off next services for a bit
-sleep 10

--- a/armbian/base/scripts/systemd-bitcoind-startpre.sh
+++ b/armbian/base/scripts/systemd-bitcoind-startpre.sh
@@ -5,6 +5,26 @@
 #
 set -eu
 
+# include functions redis_set() and redis_get()
+# shellcheck disable=SC1091
+source /opt/shift/scripts/include/redis.sh.inc
+
+# ------------------------------------------------------------------------------
+
+# Redis must be available
+redis_require
+
+# check if rpcauth credentials exist, or create new ones
+RPCAUTH="$(redis_get 'bitcoind:rpcauth')"
+REFRESH_RPCAUTH="$(redis_get 'bitcoind:refresh-rpcauth')"
+
+if [ ${#RPCAUTH} -lt 90 ] || [ "${REFRESH_RPCAUTH}" -eq 1 ]; then
+    echo "INFO: creating new bitcoind rpc credentials"
+    /opt/shift/scripts/bbb-cmd.sh bitcoind refresh_rpcauth
+else
+    echo "INFO: found bitcoind rpc credentials, no action taken"
+fi
+
 # check if SSD is already available to avoid failure
 BITCOIN_DIR="/mnt/ssd/bitcoin/.bitcoin"
 if [ ! -d "${BITCOIN_DIR}" ] || [ ! -x "${BITCOIN_DIR}" ]; then

--- a/armbian/base/scripts/systemd-bitcoind-startpre.sh
+++ b/armbian/base/scripts/systemd-bitcoind-startpre.sh
@@ -3,6 +3,8 @@
 # This script is run by systemd using the ExecStartPre option
 # before starting bitcoind.service (Bitcoin Core).
 #
+# Must be run as 'root' with ExecStartPre=+
+#
 set -eu
 
 # include functions redis_set() and redis_get()
@@ -20,6 +22,8 @@ REFRESH_RPCAUTH="$(redis_get 'bitcoind:refresh-rpcauth')"
 
 if [ ${#RPCAUTH} -lt 90 ] || [ "${REFRESH_RPCAUTH}" -eq 1 ]; then
     echo "INFO: creating new bitcoind rpc credentials"
+    echo "INFO: old bitcoind:rpcauth was ${RPCAUTH}"
+    echo "INFO: bitcoind:refresh-rpcauth is ${REFRESH_RPCAUTH}"
     /opt/shift/scripts/bbb-cmd.sh bitcoind refresh_rpcauth
 else
     echo "INFO: found bitcoind rpc credentials, no action taken"

--- a/armbian/base/scripts/systemd-electrs-startpre.sh
+++ b/armbian/base/scripts/systemd-electrs-startpre.sh
@@ -27,14 +27,3 @@ if [ $BITCOIN_IBD -eq 1 ]; then
     echo "ERR: bitcoind.service is in IBD mode. Not starting electrs.service."
     exit 1
 fi
-
-if [ -f /mnt/ssd/bitcoin/.bitcoin/.cookie ]; then
-    sleep 3
-    echo -n 'RPCPASSWORD=' > /mnt/ssd/bitcoin/.bitcoin/.cookie.env
-    tail -c +12 /mnt/ssd/bitcoin/.bitcoin/.cookie >> /mnt/ssd/bitcoin/.bitcoin/.cookie.env
-    chown bitcoin:bitcoin /mnt/ssd/bitcoin/.bitcoin/.cookie.env
-    echo "INFO: file /mnt/ssd/bitcoin/.bitcoin/.cookie.env updated."
-else
-    echo "ERR: authentication file /mnt/ssd/bitcoin/.bitcoin/.cookie not present. Not starting electrs.service."
-    exit 1
-fi

--- a/armbian/base/scripts/systemd-lightningd-startpre.sh
+++ b/armbian/base/scripts/systemd-lightningd-startpre.sh
@@ -27,13 +27,3 @@ if [ $BITCOIN_IBD -eq 1 ]; then
     echo "ERR: bitcoind.service is in IBD mode. Not starting lightningd.service."
     exit 1
 fi
-
-if [ -f /mnt/ssd/bitcoin/.bitcoin/.cookie ]; then
-    echo -n 'RPCPASSWORD=' > /mnt/ssd/bitcoin/.bitcoin/.cookie.env
-    tail -c +12 /mnt/ssd/bitcoin/.bitcoin/.cookie >> /mnt/ssd/bitcoin/.bitcoin/.cookie.env
-    chown bitcoin:bitcoin /mnt/ssd/bitcoin/.bitcoin/.cookie.env
-    echo "INFO: file /mnt/ssd/bitcoin/.bitcoin/.cookie.env updated."
-else
-    echo "ERR: authentication file /mnt/ssd/bitcoin/.bitcoin/.cookie not present. Not starting lightningd.service."
-    exit 1
-fi

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -114,12 +114,6 @@ mkdir -p /mnt/ssd/system/journal/
 rm -rf /var/log/journal
 ln -sfn /mnt/ssd/system/journal /var/log/journal
 
-## We set rpccookiefile=/mnt/ssd/bitcoin/.bitcoin/.cookie, but there seems to be
-## no way to specify where to expect the bitcoin cookie for c-lightning, so let's
-## create a symlink at the expected testnet location.
-mkdir -p /mnt/ssd/bitcoin/.bitcoin/testnet3/
-ln -fs /mnt/ssd/bitcoin/.bitcoin/.cookie /mnt/ssd/bitcoin/.bitcoin/testnet3/.cookie
-
 
 # Configuration Management
 # ------------------------------------------------------------------------------

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -97,14 +97,14 @@ chown bitcoin:system /mnt/ssd/
 ## bitcoin data storage
 mkdir -p /mnt/ssd/bitcoin/.bitcoin/testnet3
 chown -R bitcoin:bitcoin /mnt/ssd/bitcoin/
-chmod -R 750 /mnt/ssd/bitcoin/
+chmod -R u+rw,g+r,g-w,o-rwx /mnt/ssd/bitcoin/
 setfacl -dR -m g::rx /mnt/ssd/bitcoin/.bitcoin/
 setfacl -dR -m o::- /mnt/ssd/bitcoin/.bitcoin/
 
 ## electrs data storage
 mkdir -p /mnt/ssd/electrs/
 chown -R electrs:bitcoin /mnt/ssd/electrs/
-chmod -R 750 /mnt/ssd/electrs/
+chmod -R u+rw,g+r,g-w,o-rwx /mnt/ssd/electrs/
 
 ## system folders
 mkdir -p /mnt/ssd/prometheus
@@ -160,7 +160,7 @@ if [ ! -f /mnt/ssd/swapfile ]; then
         echo "Creating /mnt/ssd/swapfile."
         fallocate --length 2GiB /mnt/ssd/swapfile
         mkswap /mnt/ssd/swapfile
-        chmod 600 /mnt/ssd/swapfile
+        chmod u+rw,g-rwx,o-rwx /mnt/ssd/swapfile
     else
         echo "ERR: No swapfile found, but SSD not mounted."
     fi


### PR DESCRIPTION
This pull requests adds the recommended **rpcauth** methods for services to authenticate when using the bitcoind JSON RPC interface.

From the bitcoind help:
> `Username and HMAC-SHA-256 hashed password for JSON-RPC connections. The field <userpw> comes in the format: <USERNAME>:<SALT>$<HASH>. A canonical python script is included in share/rpcauth. The client then connects normally using the rpcuser=<USERNAME>/rpcpassword=<PASSWORD> pair of arguments. This option can be specified multiple times`

The rpcauth.py script from bitcoin repository to generate unique but persistent rpcauth credentials for bitcoind is added and extended to store the credentials directly in Redis.

To ensure unique credentials, the bitcoind-startpre script calls the command 'bbb-cmd.sh bitcoind refresh_rpcauth' if no valid rpcauth value is found in Redis (min length of 90 characters), or bitcoind:refresh-rpcauth is set to 1.

Configuration of bitcoind, lightningd, elects and bbbmiddleware is adjusted to use new authentication method:
* bitcoind.conf contains rpcauth setting: rpcuser plus salted/hashed password
* other services use rpcuser/rpcpassword to authenticate themselves

File access to config files containing rpcpassword is restricted to service user and group bitcoin. Two improvements should still be considered:
* storing the credentials in unsecured Redis db is not optimal
* Electrs should support rpcuser/rpcpassword without passing them through the command line (password visible in ps output)

As bitcoind does not manage funds, local rpcaccess (available only if system is already compromised) is not really critical and this solution good enough for an MVP.

The `redis.sh.inc` includes a new method `redis_require` while other methods like `redis_get` and `redis_set` don't fail the whole script if Redis is not available.