### PR TITLE
Middleware: Add Tor RPCs

### DIFF
--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -33,6 +33,7 @@ type Middleware interface {
 	EnableTor(bool) rpcmessages.ErrorResponse
 	EnableTorMiddleware(bool) rpcmessages.ErrorResponse
 	EnableTorElectrs(bool) rpcmessages.ErrorResponse
+	EnableTorSSH(bool) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -34,6 +34,7 @@ type Middleware interface {
 	EnableTorMiddleware(bool) rpcmessages.ErrorResponse
 	EnableTorElectrs(bool) rpcmessages.ErrorResponse
 	EnableTorSSH(bool) rpcmessages.ErrorResponse
+	EnableClearnetIBD(bool) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -32,6 +32,7 @@ type Middleware interface {
 	RestoreHSMSecret() rpcmessages.ErrorResponse
 	EnableTor(bool) rpcmessages.ErrorResponse
 	EnableTorMiddleware(bool) rpcmessages.ErrorResponse
+	EnableTorElectrs(bool) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -31,6 +31,7 @@ type Middleware interface {
 	RestoreSysconfig() rpcmessages.ErrorResponse
 	RestoreHSMSecret() rpcmessages.ErrorResponse
 	EnableTor(bool) rpcmessages.ErrorResponse
+	EnableTorMiddleware(bool) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -30,6 +30,7 @@ type Middleware interface {
 	SetHostname(rpcmessages.SetHostnameArgs) rpcmessages.ErrorResponse
 	RestoreSysconfig() rpcmessages.ErrorResponse
 	RestoreHSMSecret() rpcmessages.ErrorResponse
+	EnableTor(bool) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -397,6 +397,25 @@ func (middleware *Middleware) EnableTorElectrs(enable bool) rpcmessages.ErrorRes
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
+// EnableTorSSH enables/disables the tor hidden service for ssh based on the passed boolean argument
+// and returns a ErrorResponse indicating if the call was successful.
+func (middleware *Middleware) EnableTorSSH(enable bool) rpcmessages.ErrorResponse {
+	var action string
+	if enable {
+		log.Println("Enabling Tor for ssh via the config script")
+		action = enableAction
+	} else {
+		log.Println("Disabling Tor for ssh via the config script")
+		action = disableAction
+	}
+
+	out, err := middleware.runBBBConfigScript(action, "tor_ssh", "")
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
+	}
+	return rpcmessages.ErrorResponse{Success: true}
+}
+
 // runBBBCmdScript runs the bbb-cmd.sh script.
 // The script executes commands like for example mounting a USB drive, doing a backup and copying files.
 func (middleware *Middleware) runBBBCmdScript(method string, arg1 string, arg2 string) (out []byte, err error) {

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -351,6 +351,25 @@ func (middleware *Middleware) EnableTor(enable bool) rpcmessages.ErrorResponse {
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
+// EnableTorMiddleware enables/disables the tor hidden service for the middleware based on the passed boolean argument
+// and returns a ErrorResponse indicating if the call was successful.
+func (middleware *Middleware) EnableTorMiddleware(enable bool) rpcmessages.ErrorResponse {
+	var action string
+	if enable {
+		log.Println("Enabling Tor for the middleware via the config script")
+		action = "enable"
+	} else {
+		log.Println("Disabling Tor for the middleware via the config script")
+		action = "disable"
+	}
+
+	out, err := middleware.runBBBConfigScript(action, "tor_bbbmiddleware", "")
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
+	}
+	return rpcmessages.ErrorResponse{Success: true}
+}
+
 // runBBBCmdScript runs the bbb-cmd.sh script.
 // The script executes commands like for example mounting a USB drive, doing a backup and copying files.
 func (middleware *Middleware) runBBBCmdScript(method string, arg1 string, arg2 string) (out []byte, err error) {

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -416,6 +416,25 @@ func (middleware *Middleware) EnableTorSSH(enable bool) rpcmessages.ErrorRespons
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
+// EnableClearnetIBD enables/disables initial block download over clearnet based on the passed boolean argument
+// and returns a ErrorResponse indicating if the call was successful.
+func (middleware *Middleware) EnableClearnetIBD(enable bool) rpcmessages.ErrorResponse {
+	var action string
+	if enable {
+		log.Println("Enabling clearnet IDB via the config script")
+		action = enableAction
+	} else {
+		log.Println("Disabling clearnet IDB via the config script")
+		action = disableAction
+	}
+
+	out, err := middleware.runBBBConfigScript(action, "bitcoin_ibd_clearnet", "")
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
+	}
+	return rpcmessages.ErrorResponse{Success: true}
+}
+
 // runBBBCmdScript runs the bbb-cmd.sh script.
 // The script executes commands like for example mounting a USB drive, doing a backup and copying files.
 func (middleware *Middleware) runBBBCmdScript(method string, arg1 string, arg2 string) (out []byte, err error) {

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -28,6 +28,14 @@ type Middleware struct {
 	dummyAdminPassword string
 }
 
+const (
+	// Since enable and disable are two often-used parameters passed to bbb-config
+	// and golangci-lint fails because of "string `disable` has 3 occurrences, make it a constant (goconst)"
+	// they are constants.
+	enableAction  string = "enable"
+	disableAction string = "disable"
+)
+
 // NewMiddleware returns a new instance of the middleware
 func NewMiddleware(argumentMap map[string]string) *Middleware {
 	middleware := &Middleware{
@@ -338,10 +346,10 @@ func (middleware *Middleware) EnableTor(enable bool) rpcmessages.ErrorResponse {
 	var action string
 	if enable {
 		log.Println("Enabling Tor via the config script")
-		action = "enable"
+		action = enableAction
 	} else {
 		log.Println("Disabling Tor via the config script")
-		action = "disable"
+		action = disableAction
 	}
 
 	out, err := middleware.runBBBConfigScript(action, "tor", "")
@@ -357,13 +365,32 @@ func (middleware *Middleware) EnableTorMiddleware(enable bool) rpcmessages.Error
 	var action string
 	if enable {
 		log.Println("Enabling Tor for the middleware via the config script")
-		action = "enable"
+		action = enableAction
 	} else {
 		log.Println("Disabling Tor for the middleware via the config script")
-		action = "disable"
+		action = disableAction
 	}
 
 	out, err := middleware.runBBBConfigScript(action, "tor_bbbmiddleware", "")
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
+	}
+	return rpcmessages.ErrorResponse{Success: true}
+}
+
+// EnableTorElectrs enables/disables the tor hidden service for electrs based on the passed boolean argument
+// and returns a ErrorResponse indicating if the call was successful.
+func (middleware *Middleware) EnableTorElectrs(enable bool) rpcmessages.ErrorResponse {
+	var action string
+	if enable {
+		log.Println("Enabling Tor for electrs via the config script")
+		action = enableAction
+	} else {
+		log.Println("Disabling Tor for electrs via the config script")
+		action = disableAction
+	}
+
+	out, err := middleware.runBBBConfigScript(action, "tor_electrs", "")
 	if err != nil {
 		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
 	}

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -332,6 +332,25 @@ func (middleware *Middleware) GetHostname() rpcmessages.GetHostnameResponse {
 	return rpcmessages.GetHostnameResponse{Hostname: hostname, ErrorResponse: rpcmessages.ErrorResponse{Success: true}}
 }
 
+// EnableTor enables/disables the tor.service and configures bitcoind and lightningd based on the passed boolean argument
+// and returns a ErrorResponse indicating if the call was successful.
+func (middleware *Middleware) EnableTor(enable bool) rpcmessages.ErrorResponse {
+	var action string
+	if enable {
+		log.Println("Enabling Tor via the config script")
+		action = "enable"
+	} else {
+		log.Println("Disabling Tor via the config script")
+		action = "disable"
+	}
+
+	out, err := middleware.runBBBConfigScript(action, "tor", "")
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
+	}
+	return rpcmessages.ErrorResponse{Success: true}
+}
+
 // runBBBCmdScript runs the bbb-cmd.sh script.
 // The script executes commands like for example mounting a USB drive, doing a backup and copying files.
 func (middleware *Middleware) runBBBCmdScript(method string, arg1 string, arg2 string) (out []byte, err error) {

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -150,6 +150,20 @@ func TestEnableTor(t *testing.T) {
 	require.Equal(t, responseDisable.Code, "")
 }
 
+func TestEnableTorMiddleware(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	responseEnable := testMiddleware.EnableTorMiddleware(true)
+	require.Equal(t, responseEnable.Success, true)
+	require.Equal(t, responseEnable.Message, "")
+	require.Equal(t, responseEnable.Code, "")
+
+	responseDisable := testMiddleware.EnableTorMiddleware(false)
+	require.Equal(t, responseDisable.Success, true)
+	require.Equal(t, responseDisable.Message, "")
+	require.Equal(t, responseDisable.Code, "")
+}
+
 func TestUserAuthenticate(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -136,6 +136,20 @@ func TestRestoreSysconfig(t *testing.T) {
 	require.Equal(t, response.Code, "")
 }
 
+func TestEnableTor(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	responseEnable := testMiddleware.EnableTor(true)
+	require.Equal(t, responseEnable.Success, true)
+	require.Equal(t, responseEnable.Message, "")
+	require.Equal(t, responseEnable.Code, "")
+
+	responseDisable := testMiddleware.EnableTor(false)
+	require.Equal(t, responseDisable.Success, true)
+	require.Equal(t, responseDisable.Message, "")
+	require.Equal(t, responseDisable.Code, "")
+}
+
 func TestUserAuthenticate(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -178,6 +178,20 @@ func TestEnableTorElectrs(t *testing.T) {
 	require.Equal(t, responseDisable.Code, "")
 }
 
+func TestEnableTorSSH(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	responseEnable := testMiddleware.EnableTorSSH(true)
+	require.Equal(t, responseEnable.Success, true)
+	require.Equal(t, responseEnable.Message, "")
+	require.Equal(t, responseEnable.Code, "")
+
+	responseDisable := testMiddleware.EnableTorSSH(false)
+	require.Equal(t, responseDisable.Success, true)
+	require.Equal(t, responseDisable.Message, "")
+	require.Equal(t, responseDisable.Code, "")
+}
+
 func TestUserAuthenticate(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -164,6 +164,20 @@ func TestEnableTorMiddleware(t *testing.T) {
 	require.Equal(t, responseDisable.Code, "")
 }
 
+func TestEnableTorElectrs(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	responseEnable := testMiddleware.EnableTorElectrs(true)
+	require.Equal(t, responseEnable.Success, true)
+	require.Equal(t, responseEnable.Message, "")
+	require.Equal(t, responseEnable.Code, "")
+
+	responseDisable := testMiddleware.EnableTorElectrs(false)
+	require.Equal(t, responseDisable.Success, true)
+	require.Equal(t, responseDisable.Message, "")
+	require.Equal(t, responseDisable.Code, "")
+}
+
 func TestUserAuthenticate(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -178,6 +178,20 @@ func TestEnableTorElectrs(t *testing.T) {
 	require.Equal(t, responseDisable.Code, "")
 }
 
+func TestEnableClearnetIBD(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	responseEnable := testMiddleware.EnableClearnetIBD(true)
+	require.Equal(t, responseEnable.Success, true)
+	require.Equal(t, responseEnable.Message, "")
+	require.Equal(t, responseEnable.Code, "")
+
+	responseDisable := testMiddleware.EnableClearnetIBD(false)
+	require.Equal(t, responseDisable.Success, true)
+	require.Equal(t, responseDisable.Message, "")
+	require.Equal(t, responseDisable.Code, "")
+}
+
 func TestEnableTorSSH(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -62,6 +62,7 @@ type Middleware interface {
 	RestoreHSMSecret() rpcmessages.ErrorResponse
 	SampleInfo() rpcmessages.SampleInfoResponse
 	EnableTor(bool) rpcmessages.ErrorResponse
+	EnableTorMiddleware(bool) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse
@@ -203,6 +204,15 @@ func (server *RPCServer) GetHostname(dummyArg bool, reply *rpcmessages.GetHostna
 // It sends the middleware's ErrorResponse over rpc.
 func (server *RPCServer) EnableTor(enable bool, reply *rpcmessages.ErrorResponse) error {
 	*reply = server.middleware.EnableTor(enable)
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// EnableTorMiddleware enables/disables the tor hidden service for the middleware.
+// The boolean argument passed is used to for enabling and disabling.
+// It sends the middleware's ErrorResponse over rpc.
+func (server *RPCServer) EnableTorMiddleware(enable bool, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableTorMiddleware(enable)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -64,6 +64,7 @@ type Middleware interface {
 	EnableTor(bool) rpcmessages.ErrorResponse
 	EnableTorMiddleware(bool) rpcmessages.ErrorResponse
 	EnableTorElectrs(bool) rpcmessages.ErrorResponse
+	EnableTorSSH(bool) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse
@@ -223,6 +224,15 @@ func (server *RPCServer) EnableTorMiddleware(enable bool, reply *rpcmessages.Err
 // It sends the middleware's ErrorResponse over rpc.
 func (server *RPCServer) EnableTorElectrs(enable bool, reply *rpcmessages.ErrorResponse) error {
 	*reply = server.middleware.EnableTorElectrs(enable)
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// EnableTorSSH enables/disables the tor hidden service for SSH.
+// The boolean argument passed is used to for enabling and disabling.
+// It sends the middleware's ErrorResponse over rpc.
+func (server *RPCServer) EnableTorSSH(enable bool, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableTorSSH(enable)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -63,6 +63,7 @@ type Middleware interface {
 	SampleInfo() rpcmessages.SampleInfoResponse
 	EnableTor(bool) rpcmessages.ErrorResponse
 	EnableTorMiddleware(bool) rpcmessages.ErrorResponse
+	EnableTorElectrs(bool) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse
@@ -213,6 +214,15 @@ func (server *RPCServer) EnableTor(enable bool, reply *rpcmessages.ErrorResponse
 // It sends the middleware's ErrorResponse over rpc.
 func (server *RPCServer) EnableTorMiddleware(enable bool, reply *rpcmessages.ErrorResponse) error {
 	*reply = server.middleware.EnableTorMiddleware(enable)
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// EnableTorElectrs enables/disables the tor hidden service for Electrs.
+// The boolean argument passed is used to for enabling and disabling.
+// It sends the middleware's ErrorResponse over rpc.
+func (server *RPCServer) EnableTorElectrs(enable bool, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableTorElectrs(enable)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -61,6 +61,7 @@ type Middleware interface {
 	RestoreSysconfig() rpcmessages.ErrorResponse
 	RestoreHSMSecret() rpcmessages.ErrorResponse
 	SampleInfo() rpcmessages.SampleInfoResponse
+	EnableTor(bool) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse
@@ -193,6 +194,15 @@ func (server *RPCServer) SetHostname(args *rpcmessages.SetHostnameArgs, reply *r
 // The GetHostnameResponse includes the current system hostname
 func (server *RPCServer) GetHostname(dummyArg bool, reply *rpcmessages.GetHostnameResponse) error {
 	*reply = server.middleware.GetHostname()
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// EnableTor enables/disables the tor.service and configures bitcoind and lightningd.
+// The boolean argument passed is used to for enabling and disabling.
+// It sends the middleware's ErrorResponse over rpc.
+func (server *RPCServer) EnableTor(enable bool, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableTor(enable)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -65,6 +65,7 @@ type Middleware interface {
 	EnableTorMiddleware(bool) rpcmessages.ErrorResponse
 	EnableTorElectrs(bool) rpcmessages.ErrorResponse
 	EnableTorSSH(bool) rpcmessages.ErrorResponse
+	EnableClearnetIBD(bool) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse
@@ -233,6 +234,15 @@ func (server *RPCServer) EnableTorElectrs(enable bool, reply *rpcmessages.ErrorR
 // It sends the middleware's ErrorResponse over rpc.
 func (server *RPCServer) EnableTorSSH(enable bool, reply *rpcmessages.ErrorResponse) error {
 	*reply = server.middleware.EnableTorSSH(enable)
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// EnableClearnetIBD enables/disables the tor hidden service for SSH.
+// The boolean argument passed is used to for enabling and disabling.
+// It sends the middleware's ErrorResponse over rpc.
+func (server *RPCServer) EnableClearnetIBD(enable bool, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableClearnetIBD(enable)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -172,6 +172,14 @@ func TestRPCServer(t *testing.T) {
 	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorElectrs", false, &disableTorElectrsReply)
 	require.Equal(t, true, disableTorElectrsReply.Success)
 
+	var enableTorSSHReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorSSH", true, &enableTorSSHReply)
+	require.Equal(t, true, enableTorSSHReply.Success)
+
+	var disableTorSSHReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorSSH", false, &disableTorSSHReply)
+	require.Equal(t, true, disableTorSSHReply.Success)
+
 	userAuthenticateArg := rpcmessages.UserAuthenticateArgs{Username: "admin", Password: "ICanHasPassword?"}
 	var userAuthenticateReply rpcmessages.ErrorResponse
 	testingRPCServer.RunRPCCall(t, "RPCServer.UserAuthenticate", userAuthenticateArg, &userAuthenticateReply)

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -148,6 +148,30 @@ func TestRPCServer(t *testing.T) {
 	testingRPCServer.RunRPCCall(t, "RPCServer.RestoreHSMSecret", dummyArg, &restoreHSMSecretReply)
 	require.Equal(t, true, restoreSysconfigReply.Success)
 
+	var enableTorReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTor", true, &enableTorReply)
+	require.Equal(t, true, enableTorReply.Success)
+
+	var disableTorReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTor", false, &disableTorReply)
+	require.Equal(t, true, disableTorReply.Success)
+
+	var enableTorMiddlewareReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorMiddleware", true, &enableTorMiddlewareReply)
+	require.Equal(t, true, enableTorMiddlewareReply.Success)
+
+	var disableTorMiddlewareReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorMiddleware", false, &disableTorMiddlewareReply)
+	require.Equal(t, true, disableTorMiddlewareReply.Success)
+
+	var enableTorElectrsReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorElectrs", true, &enableTorElectrsReply)
+	require.Equal(t, true, enableTorElectrsReply.Success)
+
+	var disableTorElectrsReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorElectrs", false, &disableTorElectrsReply)
+	require.Equal(t, true, disableTorElectrsReply.Success)
+
 	userAuthenticateArg := rpcmessages.UserAuthenticateArgs{Username: "admin", Password: "ICanHasPassword?"}
 	var userAuthenticateReply rpcmessages.ErrorResponse
 	testingRPCServer.RunRPCCall(t, "RPCServer.UserAuthenticate", userAuthenticateArg, &userAuthenticateReply)

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -180,6 +180,14 @@ func TestRPCServer(t *testing.T) {
 	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorSSH", false, &disableTorSSHReply)
 	require.Equal(t, true, disableTorSSHReply.Success)
 
+	var enableClearnetIBDReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableClearnetIBD", true, &enableClearnetIBDReply)
+	require.Equal(t, true, enableClearnetIBDReply.Success)
+
+	var disableClearnetIBDReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableClearnetIBD", false, &disableClearnetIBDReply)
+	require.Equal(t, true, disableClearnetIBDReply.Success)
+
 	userAuthenticateArg := rpcmessages.UserAuthenticateArgs{Username: "admin", Password: "ICanHasPassword?"}
 	var userAuthenticateReply rpcmessages.ErrorResponse
 	testingRPCServer.RunRPCCall(t, "RPCServer.UserAuthenticate", userAuthenticateArg, &userAuthenticateReply)


### PR DESCRIPTION
This PR adds RPCs to enable/disable various Tor settings.
 
| RPC                 	        | Input         	        | Output        	        |
|---------------------	        |---------------	        |---------------	        |
| EnableTor           	        | `enable bool` 	| ErrorResponse 	|
| EnableClearnetIBD   	| `enable bool` 	| ErrorResponse 	|
| EnableTorMiddleware 	| `enable bool` 	| ErrorResponse 	|
| EnableTorElectrs    	| `enable bool` 	| ErrorResponse 	|
| EnableTorSSH        	| `enable bool` 	| ErrorResponse 	|