### PR TITLE
middleware: Add Error() to ErrorResponse

### DIFF
--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -328,7 +328,7 @@ func (middleware *Middleware) GetHostname() rpcmessages.GetHostnameResponse {
 	out, err := middleware.runBBBConfigScript("get", "hostname", "")
 	if err != nil {
 		return rpcmessages.GetHostnameResponse{
-			ErrorResponse: rpcmessages.ErrorResponse{
+			ErrorResponse: &rpcmessages.ErrorResponse{
 				Success: false,
 				Message: string(out),
 				Code:    err.Error(),
@@ -337,7 +337,12 @@ func (middleware *Middleware) GetHostname() rpcmessages.GetHostnameResponse {
 	}
 
 	hostname := strings.TrimSuffix(string(out), "\n")
-	return rpcmessages.GetHostnameResponse{Hostname: hostname, ErrorResponse: rpcmessages.ErrorResponse{Success: true}}
+	return rpcmessages.GetHostnameResponse{
+		Hostname: hostname,
+		ErrorResponse: &rpcmessages.ErrorResponse{
+			Success: true,
+		},
+	}
 }
 
 // EnableTor enables/disables the tor.service and configures bitcoind and lightningd based on the passed boolean argument

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -308,7 +308,7 @@ func TestGetHostname(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 	response := testMiddleware.GetHostname()
 
-	require.Equal(t, true, response.Success)
+	require.Equal(t, true, response.ErrorResponse.Success)
 	require.Equal(t, "get hostname ", response.Hostname)
 }
 

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -1,5 +1,7 @@
 package rpcmessages
 
+import "fmt"
+
 /*
 Put notification constants here. Notifications for new rpc data should have the format 'OpUCanHas' + 'RPC Method Name'.
 */
@@ -59,8 +61,8 @@ type VerificationProgressResponse struct {
 
 // GetHostnameResponse is the struct that get sent by the rpc server during a GetHostname rpc call
 type GetHostnameResponse struct {
-	ErrorResponse
-	Hostname string
+	ErrorResponse *ErrorResponse
+	Hostname      string
 }
 
 // ErrorResponse is a generic RPC response indicating if a RPC call was successful or not.
@@ -70,4 +72,8 @@ type ErrorResponse struct {
 	Success bool
 	Code    string
 	Message string
+}
+
+func (err *ErrorResponse) Error() string {
+	return fmt.Sprintf("bbBaseError: Code: %s | Message: %s", err.Code, err.Message)
 }

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -119,7 +119,7 @@ func TestRPCServer(t *testing.T) {
 
 	var getHostnameReply rpcmessages.GetHostnameResponse
 	testingRPCServer.RunRPCCall(t, "RPCServer.GetHostname", dummyArg, &getHostnameReply)
-	require.Equal(t, true, getHostnameReply.Success)
+	require.Equal(t, true, getHostnameReply.ErrorResponse.Success)
 
 	var verificationProgressReply rpcmessages.VerificationProgressResponse
 	testingRPCServer.RunRPCCall(t, "RPCServer.GetVerificationProgress", dummyArg, &verificationProgressReply)


### PR DESCRIPTION
To be in sync with the rpcmessages.go in the bitbox-wallet-app a
Error() string method is added to the ErrorResponse. Additionally the
ErrorResponse in GetHostnameResponse is unembedded to separate
namespaces more clearly.

https://github.com/digitalbitbox/bitbox-wallet-app/pull/506/commits/788e92fed16b7f157597829e2f2f1c0f6a4ba839