### PR TITLE
Cleanup loop devices during build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@
 # Ignore the generated file holding current git commit for Armbian build.
 /armbian/base/config/latest_commit
 
+# File enables loop device cleanup (contrib/cleanup-loop-devices.sh) when building the Armbian image
+armbian/.cleanup-loop-devices
+
 # Ignore compiled Go binaries.
 /tools/bbbfancontrol/bbbfancontrol
 /tools/bbbsupervisor/bbbsupervisor

--- a/contrib/cleanup-loop-devices.sh
+++ b/contrib/cleanup-loop-devices.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+#
+# Remove unused loop devices
+# 
+
+if [[ ${UID} -ne 0 ]]; then
+    echo "${0}: needs to be run as superuser." >&2
+    exit 1
+fi
+
+echo "Removing unused loop devices:"
+for LOOPS in $(losetup -a | grep "(/)\|BitBoxBase" | cut -f 1 -d ":"); do
+    echo "- ${LOOPS}"
+    losetup -d "${LOOPS}";
+done
+
+dmsetup remove_all


### PR DESCRIPTION
I experience issues with many leftover loop devices on Ubuntu during after
the build process, causing builds to fail the next time.

As a workaround, the 'mender-convert.sh' script checks if the following
file is present and if so, calls the script contrib/cleanup-loop-devices.sh
```
  armbian/.cleanup-loop-devices
```
This file is added as an exception to .gitignore