### PR TITLE
bbb-config: valdiate hostname using regex

### DIFF
--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -299,17 +299,17 @@ case "${COMMAND}" in
                 ;;
 
             HOSTNAME)
-                case "${3}" in
-                    [^0-9A-Za-z]*|*[^-0-9A-Z_a-z]*|*[^0-9A-Za-z]|*-_*|*_-*)
-                        echo "Invalid argument: '${3}' is not a valid hostname."
-                        exit 1
-                        ;;
-                    *)
-                        exec_overlayroot all-layers "echo '${3}' > /etc/hostname"
-                        exec_overlayroot all-layers "echo '127.0.0.1   localhost ${3}' > /etc/hosts"
-                        hostname -F /etc/hostname
-                        redis_set "base:hostname" "${3}"
-                esac
+                # check that hostname is valid
+                regex='^[a-z][a-z0-9-]{0,22}[a-z0-9]$'
+                if [[ "${3}" =~ ${regex} ]]; then
+                    exec_overlayroot all-layers "echo '${3}' > /etc/hostname"
+                    exec_overlayroot all-layers "echo '127.0.0.1   localhost ${3}' > /etc/hosts"
+                    hostname -F /etc/hostname
+                    redis_set "base:hostname" "${3}"
+                else
+                    echo "Invalid argument: ${3} is not a valid hostname."
+                    exit 1
+                fi
                 ;;
 
             ROOT_PW)


### PR DESCRIPTION
According to IETF RFC 952 (https://tools.ietf.org/html/rfc952),

    A "name" (Net, Host, Gateway, or Domain name) is a text string up to
    24 characters drawn from the alphabet (A-Z), digits (0-9), minus sign (-),
    and period (.). Note that periods are only allowed when they serve to
    delimit components of "domain style names". No blank or space characters
    are permitted as part of a name. No distinction is made between upper and
    lower case. The first character must be an alpha character. The last
    character must not be a minus sign or period.

Using the following regex to validate hostname before change:

    ^[a-z][a-z0-9-]{0,22}[a-z0-9]$