### PR TITLE
middleware: Update hostname restrictions

### DIFF
--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -309,10 +309,10 @@ func (middleware *Middleware) UserChangePassword(args rpcmessages.UserChangePass
 // SetHostname sets the systems hostname
 func (middleware *Middleware) SetHostname(args rpcmessages.SetHostnameArgs) rpcmessages.ErrorResponse {
 	log.Println("Setting the hostname via the config script")
-	var r = regexp.MustCompile(`^[a-z0-9]+[a-z0-9-.]{0,62}[a-z0-9]$`)
+	var r = regexp.MustCompile(`^[a-z][a-z0-9-]{0,22}[a-z0-9]$`)
 	hostname := args.Hostname
 
-	if len(hostname) >= 2 && len(hostname) <= 64 && r.MatchString(hostname) {
+	if r.MatchString(hostname) {
 		out, err := middleware.runBBBConfigScript("set", "hostname", hostname)
 		if err != nil {
 			return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -321,20 +321,14 @@ func TestSetHostname(t *testing.T) {
 	require.Equal(t, true, response1.Success)
 	require.Empty(t, response1.Message)
 
-	/* test special char hostname */
-	validArgs2 := rpcmessages.SetHostnameArgs{Hostname: "a.hostname-with.allowed.-....special.chars"}
-	response2 := testMiddleware.SetHostname(validArgs2)
-	require.Equal(t, true, response2.Success)
-	require.Empty(t, response2.Message)
-
-	/* test a long and valid 64 char hostname */
-	validArgs3 := rpcmessages.SetHostnameArgs{Hostname: "a.loooooooooooooooooooooooooooooooooooooooooong.64-char.hostname"}
+	/* test a long and valid 24 char hostname */
+	validArgs3 := rpcmessages.SetHostnameArgs{Hostname: "a-loong-24-char-hostname"}
 	response3 := testMiddleware.SetHostname(validArgs3)
 	require.Equal(t, true, response3.Success)
 	require.Empty(t, response3.Message)
 
-	/* test a long and invalid 65 char hostname */
-	invalidArgs1 := rpcmessages.SetHostnameArgs{Hostname: "a.tooooo.loooooooooooooooooooooooooooooooooooong.65-char.hostname"}
+	/* test a long and invalid 25 char hostname */
+	invalidArgs1 := rpcmessages.SetHostnameArgs{Hostname: "too-long-25-char-hostname"}
 	response4 := testMiddleware.SetHostname(invalidArgs1)
 	require.Equal(t, false, response4.Success)
 	require.Equal(t, "invalid hostname", response4.Message)
@@ -344,4 +338,16 @@ func TestSetHostname(t *testing.T) {
 	response5 := testMiddleware.SetHostname(invalidArgs2)
 	require.Equal(t, false, response5.Success)
 	require.Equal(t, "invalid hostname", response5.Message)
+
+	/* test a hostname that ends with a minus sign  */
+	invalidArgs3 := rpcmessages.SetHostnameArgs{Hostname: "ending-with-"}
+	response6 := testMiddleware.SetHostname(invalidArgs3)
+	require.Equal(t, false, response6.Success)
+	require.Equal(t, "invalid hostname", response6.Message)
+
+	/* test a hostname that starts with a number  */
+	invalidArgs4 := rpcmessages.SetHostnameArgs{Hostname: "0-number-start"}
+	repsonse7 := testMiddleware.SetHostname(invalidArgs4)
+	require.Equal(t, false, repsonse7.Success)
+	require.Equal(t, "invalid hostname", repsonse7.Message)
 }

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -112,8 +112,8 @@ func TestRPCServer(t *testing.T) {
 	var sampleInfoReply rpcmessages.SampleInfoResponse
 	testingRPCServer.RunRPCCall(t, "RPCServer.GetSampleInfo", dummyArg, &sampleInfoReply)
 
-	setHostnameArg := rpcmessages.SetHostnameArgs{Hostname: "bitbox.base.test"}
-	setHostnameReply := rpcmessages.ErrorResponse{Code: "test"}
+	setHostnameArg := rpcmessages.SetHostnameArgs{Hostname: "bitbox-base-test"}
+	setHostnameReply := rpcmessages.ErrorResponse{}
 	testingRPCServer.RunRPCCall(t, "RPCServer.SetHostname", setHostnameArg, &setHostnameReply)
 	require.Equal(t, true, setHostnameReply.Success)
 


### PR DESCRIPTION
The middleware hostname restrictions are updated to a subset of the specifyed valid hostnames in IETF RFC 952. In conjunction with https://github.com/digitalbitbox/bitbox-base/pull/186.