### PR TITLE
middelware: Add EnableRootLogin and SetRootPassword RPCs

### DIFF
--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -38,6 +38,7 @@ type Middleware interface {
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
 	EnableRootLogin(bool) rpcmessages.ErrorResponse
+	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -37,6 +37,7 @@ type Middleware interface {
 	EnableClearnetIBD(bool) rpcmessages.ErrorResponse
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
+	EnableRootLogin(bool) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -462,6 +462,25 @@ func (middleware *Middleware) RebootBase() rpcmessages.ErrorResponse {
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
+// EnableRootLogin enables/disables the login via the root user/password
+// and returns a ErrorResponse indicating if the call was successful.
+func (middleware *Middleware) EnableRootLogin(enable bool) rpcmessages.ErrorResponse {
+	var action string
+	if enable {
+		log.Println("Enabling root login via the config script")
+		action = enableAction
+	} else {
+		log.Println("Disabling root login via the config script")
+		action = disableAction
+	}
+
+	out, err := middleware.runBBBConfigScript(action, "root_pwlogin", "")
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
+	}
+	return rpcmessages.ErrorResponse{Success: true}
+}
+
 // runBBBCmdScript runs the bbb-cmd.sh script.
 // The script executes commands like for example mounting a USB drive, doing a backup and copying files.
 func (middleware *Middleware) runBBBCmdScript(method string, arg1 string, arg2 string) (out []byte, err error) {

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -481,6 +481,24 @@ func (middleware *Middleware) EnableRootLogin(enable bool) rpcmessages.ErrorResp
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
+// SetRootPassword sets the systems root password
+func (middleware *Middleware) SetRootPassword(args rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse {
+	log.Println("Setting a new root password via the config script")
+	password := args.RootPassword
+
+	// Unicode passwords are allowed, but each Unicode rune is only counted as one when comparing the length
+	// len("₿") = 3
+	// len([]rune("₿")) = 1
+	if len([]rune(password)) >= 8 {
+		out, err := middleware.runBBBConfigScript("set", "root_pw", password)
+		if err != nil {
+			return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
+		}
+		return rpcmessages.ErrorResponse{Success: true}
+	}
+	return rpcmessages.ErrorResponse{Success: false, Message: "invalid password"}
+}
+
 // runBBBCmdScript runs the bbb-cmd.sh script.
 // The script executes commands like for example mounting a USB drive, doing a backup and copying files.
 func (middleware *Middleware) runBBBCmdScript(method string, arg1 string, arg2 string) (out []byte, err error) {

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -206,6 +206,20 @@ func TestEnableTorSSH(t *testing.T) {
 	require.Equal(t, responseDisable.Code, "")
 }
 
+func TestEnableRootLogin(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	responseEnable := testMiddleware.EnableRootLogin(true)
+	require.Equal(t, responseEnable.Success, true)
+	require.Equal(t, responseEnable.Message, "")
+	require.Equal(t, responseEnable.Code, "")
+
+	responseDisable := testMiddleware.EnableRootLogin(false)
+	require.Equal(t, responseDisable.Success, true)
+	require.Equal(t, responseDisable.Message, "")
+	require.Equal(t, responseDisable.Code, "")
+}
+
 func TestUserAuthenticate(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -220,6 +220,34 @@ func TestEnableRootLogin(t *testing.T) {
 	require.Equal(t, responseDisable.Code, "")
 }
 
+func TestSetRootPassword(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	// test valid root password set
+	responseValid := testMiddleware.SetRootPassword(rpcmessages.SetRootPasswordArgs{RootPassword: "iusethispasswordeverywhere"})
+	require.Equal(t, responseValid.Success, true)
+	require.Equal(t, responseValid.Message, "")
+	require.Equal(t, responseValid.Code, "")
+
+	// test invalid (to short) root password set
+	responseInvalid := testMiddleware.SetRootPassword(rpcmessages.SetRootPasswordArgs{RootPassword: "shrtone"})
+	require.Equal(t, responseInvalid.Success, false)
+	require.Equal(t, responseInvalid.Message, "invalid password")
+	require.Equal(t, responseInvalid.Code, "")
+
+	// test 7 unicode's as password (to short)
+	responseUnicode7 := testMiddleware.SetRootPassword(rpcmessages.SetRootPasswordArgs{RootPassword: "₿₿₿₿₿₿₿"})
+	require.Equal(t, responseUnicode7.Success, false)
+	require.Equal(t, responseUnicode7.Message, "invalid password")
+	require.Equal(t, responseUnicode7.Code, "")
+
+	// test 7 unicode's as password (to short)
+	responseUnicode8 := testMiddleware.SetRootPassword(rpcmessages.SetRootPasswordArgs{RootPassword: "₿😂🔥🌑🚀📈世界"})
+	require.Equal(t, responseUnicode8.Success, true)
+	require.Equal(t, responseUnicode8.Message, "")
+	require.Equal(t, responseUnicode8.Code, "")
+}
+
 func TestUserAuthenticate(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -35,6 +35,11 @@ type SetHostnameArgs struct {
 	Hostname string
 }
 
+// SetRootPasswordArgs is a struct that holds the to be set root password
+type SetRootPasswordArgs struct {
+	RootPassword string
+}
+
 /*
 Put Response structs below this line. They should have the format of 'RPC Method Name' + 'Response'.
 */

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -69,6 +69,7 @@ type Middleware interface {
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
 	EnableRootLogin(bool) rpcmessages.ErrorResponse
+	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse
@@ -271,6 +272,15 @@ func (server *RPCServer) RebootBase(dummyArg bool, reply *rpcmessages.ErrorRespo
 // It sends the middleware's ErrorResponse over rpc.
 func (server *RPCServer) EnableRootLogin(enable bool, reply *rpcmessages.ErrorResponse) error {
 	*reply = server.middleware.EnableRootLogin(enable)
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// EnableRootLogin enables/disables login via the root user/password.
+// The boolean argument passed is used to for enabling and disabling.
+// It sends the middleware's ErrorResponse over rpc.
+func (server *RPCServer) SetRootPassword(args rpcmessages.SetRootPasswordArgs, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.SetRootPassword(args)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -68,6 +68,7 @@ type Middleware interface {
 	EnableClearnetIBD(bool) rpcmessages.ErrorResponse
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
+	EnableRootLogin(bool) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse
@@ -261,6 +262,15 @@ func (server *RPCServer) ShutdownBase(dummyArg bool, reply *rpcmessages.ErrorRes
 // The RPC calls the bbb-cmd.sh script which initialtes a `reboot`
 func (server *RPCServer) RebootBase(dummyArg bool, reply *rpcmessages.ErrorResponse) error {
 	*reply = server.middleware.RebootBase()
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// EnableRootLogin enables/disables login via the root user/password.
+// The boolean argument passed is used to for enabling and disabling.
+// It sends the middleware's ErrorResponse over rpc.
+func (server *RPCServer) EnableRootLogin(enable bool, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableRootLogin(enable)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -188,6 +188,14 @@ func TestRPCServer(t *testing.T) {
 	testingRPCServer.RunRPCCall(t, "RPCServer.EnableClearnetIBD", false, &disableClearnetIBDReply)
 	require.Equal(t, true, disableClearnetIBDReply.Success)
 
+	var enableRootLoginReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", true, &enableRootLoginReply)
+	require.Equal(t, true, enableRootLoginReply.Success)
+
+	var disableRootLoginReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", false, &disableRootLoginReply)
+	require.Equal(t, true, disableRootLoginReply.Success)
+
 	userAuthenticateArg := rpcmessages.UserAuthenticateArgs{Username: "admin", Password: "ICanHasPassword?"}
 	var userAuthenticateReply rpcmessages.ErrorResponse
 	testingRPCServer.RunRPCCall(t, "RPCServer.UserAuthenticate", userAuthenticateArg, &userAuthenticateReply)


### PR DESCRIPTION
This PR adds the following RPCs

| RPC                | Input                 | Output                 |                  
|--------------------|-----------------------|-----------------------|
| EnableRootLogin    |`enable bool`| ErrorResponse                                       |
| SetRootPassword    | `SetRootPasswordArgs`              | ErrorResponse                               |

The SetRootPassword RPC allows only passwords with a length greater or equal to 8 chars. The rune length is counted, so that Unicode symbols as e.g. `₿` don't count as multiple chars. See https://play.golang.org/p/yw6Adi167tk. 