### PR TITLE
middleware: Add ShutdownBase and RebootBase RPCs

### DIFF
--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -36,6 +36,7 @@ type Middleware interface {
 	EnableTorSSH(bool) rpcmessages.ErrorResponse
 	EnableClearnetIBD(bool) rpcmessages.ErrorResponse
 	ShutdownBase() rpcmessages.ErrorResponse
+	RebootBase() rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -35,6 +35,7 @@ type Middleware interface {
 	EnableTorElectrs(bool) rpcmessages.ErrorResponse
 	EnableTorSSH(bool) rpcmessages.ErrorResponse
 	EnableClearnetIBD(bool) rpcmessages.ErrorResponse
+	ShutdownBase() rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -440,6 +440,17 @@ func (middleware *Middleware) EnableClearnetIBD(enable bool) rpcmessages.ErrorRe
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
+// ShutdownBase returns an ErrorResponse struct in response to a rpcserver request
+// It calls the bbb-cmd.sh script which initialtes a shutdown
+func (middleware *Middleware) ShutdownBase() rpcmessages.ErrorResponse {
+	log.Println("shutting down the Base via the cmd script")
+	out, err := middleware.runBBBCmdScript("base", "shutdown", "")
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
+	}
+	return rpcmessages.ErrorResponse{Success: true}
+}
+
 // runBBBCmdScript runs the bbb-cmd.sh script.
 // The script executes commands like for example mounting a USB drive, doing a backup and copying files.
 func (middleware *Middleware) runBBBCmdScript(method string, arg1 string, arg2 string) (out []byte, err error) {

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -441,10 +441,21 @@ func (middleware *Middleware) EnableClearnetIBD(enable bool) rpcmessages.ErrorRe
 }
 
 // ShutdownBase returns an ErrorResponse struct in response to a rpcserver request
-// It calls the bbb-cmd.sh script which initialtes a shutdown
+// It calls the bbb-cmd.sh script which initializes a shutdown
 func (middleware *Middleware) ShutdownBase() rpcmessages.ErrorResponse {
 	log.Println("shutting down the Base via the cmd script")
 	out, err := middleware.runBBBCmdScript("base", "shutdown", "")
+	if err != nil {
+		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
+	}
+	return rpcmessages.ErrorResponse{Success: true}
+}
+
+// RebootBase returns an ErrorResponse struct in response to a rpcserver request
+// It calls the bbb-cmd.sh script which initializes a reboot
+func (middleware *Middleware) RebootBase() rpcmessages.ErrorResponse {
+	log.Println("rebooting the Base via the cmd script")
+	out, err := middleware.runBBBCmdScript("base", "reboot", "")
 	if err != nil {
 		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
 	}

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -351,3 +351,12 @@ func TestSetHostname(t *testing.T) {
 	require.Equal(t, false, repsonse7.Success)
 	require.Equal(t, "invalid hostname", repsonse7.Message)
 }
+
+func TestShutdownBase(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	response := testMiddleware.ShutdownBase()
+	require.Equal(t, response.Success, true)
+	require.Equal(t, response.Message, "")
+	require.Equal(t, response.Code, "")
+}

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -347,15 +347,24 @@ func TestSetHostname(t *testing.T) {
 
 	/* test a hostname that starts with a number  */
 	invalidArgs4 := rpcmessages.SetHostnameArgs{Hostname: "0-number-start"}
-	repsonse7 := testMiddleware.SetHostname(invalidArgs4)
-	require.Equal(t, false, repsonse7.Success)
-	require.Equal(t, "invalid hostname", repsonse7.Message)
+	response7 := testMiddleware.SetHostname(invalidArgs4)
+	require.Equal(t, false, response7.Success)
+	require.Equal(t, "invalid hostname", response7.Message)
 }
 
 func TestShutdownBase(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
 	response := testMiddleware.ShutdownBase()
+	require.Equal(t, response.Success, true)
+	require.Equal(t, response.Message, "")
+	require.Equal(t, response.Code, "")
+}
+
+func TestRebootBase(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	response := testMiddleware.RebootBase()
 	require.Equal(t, response.Success, true)
 	require.Equal(t, response.Message, "")
 	require.Equal(t, response.Code, "")

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -66,6 +66,7 @@ type Middleware interface {
 	EnableTorElectrs(bool) rpcmessages.ErrorResponse
 	EnableTorSSH(bool) rpcmessages.ErrorResponse
 	EnableClearnetIBD(bool) rpcmessages.ErrorResponse
+	ShutdownBase() rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse
@@ -243,6 +244,14 @@ func (server *RPCServer) EnableTorSSH(enable bool, reply *rpcmessages.ErrorRespo
 // It sends the middleware's ErrorResponse over rpc.
 func (server *RPCServer) EnableClearnetIBD(enable bool, reply *rpcmessages.ErrorResponse) error {
 	*reply = server.middleware.EnableClearnetIBD(enable)
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// ShutdownBase sends the middleware's ErrorResponse over rpc
+// The RPC calls the bbb-cmd.sh script which initialtes a `shutdown now`
+func (server *RPCServer) ShutdownBase(dummyArg bool, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.ShutdownBase()
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -67,6 +67,7 @@ type Middleware interface {
 	EnableTorSSH(bool) rpcmessages.ErrorResponse
 	EnableClearnetIBD(bool) rpcmessages.ErrorResponse
 	ShutdownBase() rpcmessages.ErrorResponse
+	RebootBase() rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse
@@ -252,6 +253,14 @@ func (server *RPCServer) EnableClearnetIBD(enable bool, reply *rpcmessages.Error
 // The RPC calls the bbb-cmd.sh script which initialtes a `shutdown now`
 func (server *RPCServer) ShutdownBase(dummyArg bool, reply *rpcmessages.ErrorResponse) error {
 	*reply = server.middleware.ShutdownBase()
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// RebootBase sends the middleware's ErrorResponse over rpc
+// The RPC calls the bbb-cmd.sh script which initialtes a `reboot`
+func (server *RPCServer) RebootBase(dummyArg bool, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.RebootBase()
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -198,4 +198,8 @@ func TestRPCServer(t *testing.T) {
 	testingRPCServer.RunRPCCall(t, "RPCServer.UserChangePassword", userChangePasswordArg, &userChangePasswordReply)
 	require.Equal(t, true, userChangePasswordReply.Success)
 
+	var shutdownBaseReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.ShutdownBase", dummyArg, &shutdownBaseReply)
+	require.Equal(t, true, shutdownBaseReply.Success)
+
 }

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -202,4 +202,8 @@ func TestRPCServer(t *testing.T) {
 	testingRPCServer.RunRPCCall(t, "RPCServer.ShutdownBase", dummyArg, &shutdownBaseReply)
 	require.Equal(t, true, shutdownBaseReply.Success)
 
+	var rebootBaseReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.RebootBase", dummyArg, &rebootBaseReply)
+	require.Equal(t, true, rebootBaseReply.Success)
+
 }


### PR DESCRIPTION
This PR implements following RPCs:

| RPC                | Input                 | Output                 |                  
|--------------------|-----------------------|-----------------------|
| ShutdownBase         | `dummyArg bool`  | ErrorResponse |
| RebootBase    | `dummyArg bool`  | ErrorResponse |