### PR TITLE
Store application version in Redis on build

### DIFF
--- a/armbian/base/config/redis/factorysettings.txt
+++ b/armbian/base/config/redis/factorysettings.txt
@@ -13,7 +13,8 @@ SET tor:base:enabled 1
 SET tor:ssh:enabled 0
 SET tor:electrs:enabled 1
 SET tor:bbbmiddleware:enabled 1
-                        
+
+SET bitcoind:version xxx      
 SET bitcoind:ibd 1
 SET bitcoind:ibd-clearnet 0
 SET bitcoind:network mainnet
@@ -41,6 +42,7 @@ SET bitcoind:seednode:2 xqzfakpeuvrobvpj.onion
 SET bitcoind:seednode:3 tsyvzsqwa2kkf6b2.onion
 SET bitcoind:reindex-chainstate 0
 
+SET lightningd:version xxx
 SET lightningd:bitcoin-cli /usr/bin/bitcoin-cli
 SET lightningd:lightning-dir /mnt/ssd/bitcoin/.lightning
 SET lightningd:bind-addr 127.0.0.1:9735
@@ -48,13 +50,12 @@ SET lightningd:proxy 127.0.0.1:9050
 SET lightningd:log-level debug
 SET lightningd:plugin:1 /opt/shift/scripts/prometheus-lightningd.py
 
+SET electrs:version xxx
 SET electrs:db_dir /mnt/ssd/electrs/db
 SET electrs:daemon_dir /mnt/ssd/bitcoin/.bitcoin
 SET electrs:monitoring_addr 127.0.0.1:4224
 SET electrs:verbosity vvvv
 SET electrs:rust_backtrace 1
-
-SET bbbmiddleware:bitcoin-rpcuser __cookie__
 
 SET grafana:server:http_addr 127.0.0.1                 
 SET grafana:server:root_url http://127.0.0.1:3000/info/ 

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -473,6 +473,8 @@ chmod -R u+rw,g+r,g-w,o-rwx /etc/bitcoin
 importFile "/etc/systemd/system/bitcoind.service"
 systemctl enable bitcoind.service
 
+redis-cli SET bitcoind:version "${BITCOIN_VERSION}"
+
 
 # LIGHTNING --------------------------------------------------------------------
 BIN_DEPS_TAG="v0.0.1-alpha"
@@ -497,6 +499,8 @@ if [ "${BASE_BUILD_LIGHTNINGD}" == "true" ]; then
   make -j 4
   make install
 
+  redis-cli SET lightningd:version "${LIGHTNING_VERSION_BUILD}"
+
 else
   cd /usr/local/src/
   ## temporary storage of 'lightningd' until official arm64 binaries work with stable Armbian release
@@ -509,6 +513,8 @@ else
 
   ## symlink is needed, as the direct compilation (default) installs into /usr/local/bin, while this package uses '/usr/bin'
   ln -sf /usr/bin/lightningd /usr/local/bin/lightningd
+
+  redis-cli SET lightningd:version "${LIGHTNING_VERSION_BIN}"
   
 fi
 
@@ -541,6 +547,8 @@ chown -R root:bitcoin /etc/electrs
 chmod -R u+rw,g+r,g-w,o-rwx /etc/electrs
 importFile "/etc/systemd/system/electrs.service"
 systemctl enable electrs.service
+
+redis-cli SET electrs:version "${ELECTRS_VERSION}"
 
 
 # TOOLS & MIDDLEWARE -------------------------------------------------------------------


### PR DESCRIPTION
The application versions for `bitcoind`, `lightningd` and `electrs` are automatically stored in Redis during the build process.