### PR TITLE
Middleware: Add GetBaseVersion RPC

### DIFF
--- a/middleware/cmd/middleware/main.go
+++ b/middleware/cmd/middleware/main.go
@@ -46,7 +46,7 @@ func main() {
 		}
 	}
 	defer logBeforeExit()
-	middleware := middleware.NewMiddleware(argumentMap)
+	middleware := middleware.NewMiddleware(argumentMap, false)
 	log.Println("--------------- Started middleware --------------")
 
 	handlers := handlers.NewHandlers(middleware, *dataDir)

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -38,6 +38,7 @@ type Middleware interface {
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
 	EnableRootLogin(bool) rpcmessages.ErrorResponse
+	GetBaseVersion() rpcmessages.GetBaseVersionResponse
 	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse

--- a/middleware/src/handlers/handlers_test.go
+++ b/middleware/src/handlers/handlers_test.go
@@ -32,7 +32,7 @@ func TestRootHandler(t *testing.T) {
 	argumentMap["network"] = "testnet"
 	argumentMap["bbbConfigScript"] = "/home/bitcoin/script.sh"
 
-	middlewareInstance := middleware.NewMiddleware(argumentMap)
+	middlewareInstance := middleware.NewMiddleware(argumentMap, true)
 	handlers := handlers.NewHandlers(middlewareInstance, ".base")
 	req, err := http.NewRequest("GET", "/", nil)
 	require.NoError(t, err)
@@ -52,7 +52,7 @@ func TestWebsocketHandler(t *testing.T) {
 	argumentMap["network"] = "testnet"
 	argumentMap["bbbConfigScript"] = "/home/bitcoin/script.sh"
 
-	middlewareInstance := middleware.NewMiddleware(argumentMap)
+	middlewareInstance := middleware.NewMiddleware(argumentMap, true)
 	handlers := handlers.NewHandlers(middlewareInstance, ".base")
 	rr := httptest.NewServer(handlers.Router)
 	defer rr.Close()

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -2,6 +2,7 @@
 package middleware
 
 import (
+	"fmt"
 	"log"
 	"os/exec"
 	"regexp"
@@ -462,6 +463,28 @@ func (middleware *Middleware) RebootBase() rpcmessages.ErrorResponse {
 		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
 	}
 	return rpcmessages.ErrorResponse{Success: true}
+}
+
+// GetBaseVersion returns an GetBaseVersionResponse struct containing the base version in response to a rpcserver request
+func (middleware *Middleware) GetBaseVersion() rpcmessages.GetBaseVersionResponse {
+	log.Println("getting the Base version from redis")
+	const baseVersionKey string = "base:version"
+	version, err := middleware.redisClient.GetString(baseVersionKey)
+	if err != nil {
+		return rpcmessages.GetBaseVersionResponse{
+			ErrorResponse: &rpcmessages.ErrorResponse{
+				Success: false,
+				Message: fmt.Errorf("could not get %s from redis: %s", baseVersionKey, err.Error()).Error(),
+				Code:    "PLACEHOLDER", // TODO(0xb10c): replace with ErrorCode once defined.
+			},
+		}
+	}
+	return rpcmessages.GetBaseVersionResponse{
+		ErrorResponse: &rpcmessages.ErrorResponse{
+			Success: true,
+		},
+		Version: version,
+	}
 }
 
 // EnableRootLogin enables/disables the login via the root user/password

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -26,8 +26,7 @@ func setupTestMiddleware() *middleware.Middleware {
 	argumentMap["bbbConfigScript"] = "/bin/echo"
 	argumentMap["bbbCmdScript"] = "/bin/echo"
 
-	testMiddleware := middleware.NewMiddleware(argumentMap)
-
+	testMiddleware := middleware.NewMiddleware(argumentMap, true)
 	return testMiddleware
 }
 
@@ -392,6 +391,14 @@ func TestSetHostname(t *testing.T) {
 	response7 := testMiddleware.SetHostname(invalidArgs4)
 	require.Equal(t, false, response7.Success)
 	require.Equal(t, "invalid hostname", response7.Message)
+}
+
+func TestGetBaseVersion(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	response := testMiddleware.GetBaseVersion()
+	require.Equal(t, true, response.ErrorResponse.Success)
+	require.Equal(t, "0.0.1", response.Version)
 }
 
 func TestShutdownBase(t *testing.T) {

--- a/middleware/src/redis/redis_mock.go
+++ b/middleware/src/redis/redis_mock.go
@@ -1,0 +1,36 @@
+package redis
+
+import (
+	"strconv"
+)
+
+// MockClient is a mock redis client
+type MockClient struct {
+	mockRedisMap map[string]string
+}
+
+// NewMockClient returns a new redis client.
+// It does not ensure that the client has connectivity.
+func NewMockClient(port string) (mockClient *MockClient) {
+	mockRedisMap := make(map[string]string)
+	mockRedisMap["base:version"] = "0.0.1"
+	return &MockClient{mockRedisMap: mockRedisMap}
+}
+
+// SetString sets a mock value to given key.
+func (mc *MockClient) SetString(key string, value string) error {
+	mc.mockRedisMap[key] = value
+	return nil
+}
+
+// GetInt gets an integer value for a given key.
+func (mc *MockClient) GetInt(key string) (val int, err error) {
+	s := mc.mockRedisMap[key]
+	val, err = strconv.Atoi(s)
+	return
+}
+
+// GetString gets an string for a given key.
+func (mc *MockClient) GetString(key string) (val string, err error) {
+	return mc.mockRedisMap[key], nil
+}

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -64,6 +64,12 @@ type VerificationProgressResponse struct {
 	VerificationProgress float64 `json:"verificationProgress"`
 }
 
+// GetBaseVersionResponse is the struct that get sent by the rpc server during a GetBaseVersion rpc call
+type GetBaseVersionResponse struct {
+	ErrorResponse *ErrorResponse
+	Version       string
+}
+
 // GetHostnameResponse is the struct that get sent by the rpc server during a GetHostname rpc call
 type GetHostnameResponse struct {
 	ErrorResponse *ErrorResponse

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -69,6 +69,7 @@ type Middleware interface {
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
 	EnableRootLogin(bool) rpcmessages.ErrorResponse
+	GetBaseVersion() rpcmessages.GetBaseVersionResponse
 	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
@@ -276,11 +277,19 @@ func (server *RPCServer) EnableRootLogin(enable bool, reply *rpcmessages.ErrorRe
 	return nil
 }
 
-// EnableRootLogin enables/disables login via the root user/password.
-// The boolean argument passed is used to for enabling and disabling.
+// SetRootPassword sets the systems root password.
+// Passwords have to be at least 8 chars in length.
+// For Unicode passwords the number of unicode chars is counted and not the byte count.
 // It sends the middleware's ErrorResponse over rpc.
 func (server *RPCServer) SetRootPassword(args rpcmessages.SetRootPasswordArgs, reply *rpcmessages.ErrorResponse) error {
 	*reply = server.middleware.SetRootPassword(args)
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// GetBaseVersion returns a GetBaseVersionResponse containing the base version.
+func (server *RPCServer) GetBaseVersion(dummyArg bool, reply *rpcmessages.GetBaseVersionResponse) error {
+	*reply = server.middleware.GetBaseVersion()
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -60,7 +60,7 @@ func NewTestingRPCServer() TestingRPCServer {
 	argumentMap["bbbConfigScript"] = "/bin/echo"
 	argumentMap["bbbCmdScript"] = "/bin/echo"
 
-	middlewareInstance := middleware.NewMiddleware(argumentMap)
+	middlewareInstance := middleware.NewMiddleware(argumentMap, true)
 
 	testingRPCServer.rpcServer = rpcserver.NewRPCServer(middlewareInstance)
 	testingRPCServer.serverWriteChan = testingRPCServer.rpcServer.RPCConnection.WriteChan()
@@ -213,5 +213,9 @@ func TestRPCServer(t *testing.T) {
 	var rebootBaseReply rpcmessages.ErrorResponse
 	testingRPCServer.RunRPCCall(t, "RPCServer.RebootBase", dummyArg, &rebootBaseReply)
 	require.Equal(t, true, rebootBaseReply.Success)
+
+	var getBaseVersionReply rpcmessages.GetBaseVersionResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.GetBaseVersion", dummyArg, &getBaseVersionReply)
+	require.Equal(t, true, getBaseVersionReply.ErrorResponse.Success)
 
 }


### PR DESCRIPTION
This PR adds the GetBaseVersion RPC. Additionally a Redis mock is introduced to enable unit tests on RPCs that GET or SET redis values.