### PR TITLE
scripts: cleanup / add error codes

### DIFF
--- a/armbian/base/rootfs/etc/systemd/system/bitcoind.service
+++ b/armbian/base/rootfs/etc/systemd/system/bitcoind.service
@@ -14,7 +14,6 @@ ExecStartPre=+/opt/shift/scripts/systemd-bitcoind-startpre.sh
 ExecStart=/usr/bin/bitcoind \
     -conf=/etc/bitcoin/bitcoin.conf \
     -pid=/run/bitcoind/bitcoind.pid
-ExecStartPost=/opt/shift/scripts/systemd-bitcoind-startpost.sh
 
 # Process management
 ####################

--- a/armbian/base/scripts/autosetup-ssd.sh
+++ b/armbian/base/scripts/autosetup-ssd.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
+# shellcheck disable=SC1091
+
 set -eu
 
 # BitBox Base: auto-setup of SSD
 #
+
+# include errorExit() function
+source /opt/shift/scripts/include/errorExit.sh.inc
+
+# ------------------------------------------------------------------------------
 
 function usage() {
     printf "
@@ -11,13 +18,13 @@ BitBox Base: Auto-Setup SSD
 This script checks for potential storage targets and automates the setup process.
 Use with caution, data on targets will be deleted.
 
-Usage: $0 <status|format> [device] [--assume-yes]
+Usage: autosetup-ssd.sh <status|format> [device] [--assume-yes]
 
 Examples:
-* $0 status                     Get list of potential target devices in system
-* $0 format /dev/sda            Set up specified device interactively
-* $0 format auto                Detect device and set up interactively
-* $0 format auto --assume-yes   WARNING! Execute only in well defined environments!
+* autosetup-ssd.sh status                     Get list of potential target devices in system
+* autosetup-ssd.sh format /dev/sda            Set up specified device interactively
+* autosetup-ssd.sh format auto                Detect device and set up interactively
+* autosetup-ssd.sh format auto --assume-yes   WARNING! Execute only in well defined environments!
 
 "
 }
@@ -32,7 +39,7 @@ function list_targets() {
     blockdev_target_path=""
 
     # loop over all top-level block devices
-    while read blockdev; do
+    while read -r blockdev; do
         name=$( echo "${blockdev}" | cut -f 1 -d " " )
         type=$( echo "${blockdev}" | cut -f 2 -d " " )
         size=$( echo "${blockdev}" | cut -f 4 -d " " )
@@ -49,9 +56,9 @@ function list_targets() {
         else
             # check top-level device for partitions
             partition_count=0
-            while read partition; do
+            while read -r partition; do
                 name_part=$( echo "${partition}" | cut -f 1 -d " " )
-                if [[ "${name_part}" =~ "${name}" ]] && [[ "${name_part}" != "${name}" ]]; then
+                if [[ "${name_part}" =~ ${name} ]] && [[ "${name_part}" != "${name}" ]]; then
                     partition_count=$((partition_count+1))
                     blockdev_target="NO: has ${partition_count} partition(s)"
                 fi
@@ -91,7 +98,7 @@ function format() {
         echo   # First sector (Accept default: 1)
         echo   # Last sector (Accept default: varies)
         echo w # Write changes
-    ) | fdisk ${DEVICE}
+    ) | fdisk "${DEVICE}"
 
     case ${DEVICE} in
         # internal drive (e.g. PCIe)
@@ -104,11 +111,11 @@ function format() {
             ;;
     esac
 
-    partprobe ${DEVICE}
+    partprobe "${DEVICE}"
     sleep 10
-    mkfs.ext4 -F ${PARTITION}
+    mkfs.ext4 -F "${PARTITION}"
 
-    printf "\nDevice ${DEVICE} prepared, partition ${PARTITION} formatted:\n\n"
+    printf "\nDevice %s prepared, partition %s formatted:\n\n" "${DEVICE}" "${PARTITION}"
     lsblk
     echo
 }
@@ -120,12 +127,12 @@ ASSUMEYES=${3:-""}
 
 if ! [[ "${ACTION}" =~ ^(status|format)$ ]]; then
     usage
-    exit 1
+    errorExit SCRIPT_INVALID_ARG
 fi
 
 if [[ ${UID} -ne 0 ]]; then
     echo "${0}: needs to be run as superuser." >&2
-    exit 1
+    errorExit SCRIPT_NOT_RUN_AS_SUPERUSER
 fi
 
 case ${ACTION} in
@@ -137,7 +144,7 @@ case ${ACTION} in
         if [ "${#}" -lt 2 ]; then
             usage
             printf "Please specify a DEVICE, e.g. /dev/sda\n\n"
-            exit 1
+            errorExit SCRIPT_INVALID_ARG
         fi
 
         format_target=0
@@ -146,8 +153,8 @@ case ${ACTION} in
         list_targets
 
         if [[ "${device_found}" -eq 0 ]] && [[ "${DEVICE}" != "auto" ]]; then
-            printf "Specified DEVICE '${DEVICE}' not found as potential target.\n\n"
-            exit 1
+            printf "Specified DEVICE '%s' not found as potential target.\n\n" "${DEVICE}"
+            errorExit SSDSETUP_NO_TARGET
         fi
 
         # sanity checks ------------------------------
@@ -156,22 +163,22 @@ case ${ACTION} in
             if [[ ${targets_total} -gt 0 ]]; then
                 if [[ ${targets_total} -eq 1 ]]; then
                     DEVICE="${blockdev_target_path}"
-                    printf "Target selected due to AUTO option: ${DEVICE}\n"
+                    printf "Target selected due to AUTO option: %s\n" "${DEVICE}"
                 else
                     printf "More than one suitable blockdevice found.\nPlease specify device manually.\n\n"
-                    exit 1
+                    errorExit SSDSETUP_TOO_MANY_TARGETS
                 fi
             else
                 printf "No suitable blockdevice found.\n\n"
-                exit 1
+                errorExit SSDSETUP_NO_TARGET
             fi
         fi
 
         # check for 2 slashes & min length
         device_dashes=$(echo "${DEVICE}" | awk -F"/" '{print NF-1}')
         if [[ device_dashes -lt 2 ]] || [[ ${#DEVICE} -lt 8 ]]; then
-            printf "This is not a valid blockdevice: ${DEVICE}\n\n"
-            exit 1
+            printf "This is not a valid blockdevice: %s\n\n" "${DEVICE}"
+            errorExit SSDSETUP_NO_TARGET
         fi
 
         # assume-yes specified? otherwise ask
@@ -180,23 +187,23 @@ case ${ACTION} in
         else
             # is device recommended for storage? works only with one recommended drive.
             if [[ "${DEVICE}" != "${blockdev_target_path}" ]]; then
-                printf "\nDevice ${DEVICE} is not recommended for storage. Continue?\nType: YES or abort with Ctrl-C\n> "
-                read ask_confirmation
+                printf "\nDevice %s is not recommended for storage. Continue?\nType: YES or abort with Ctrl-C\n> " "${DEVICE}"
+                read -r ask_confirmation
 
                 if [[ "${ask_confirmation}" != "YES" ]]; then
                     echo "Aborted."
-                    exit 1
+                    errorExit SSDSETUP_ABORTED_MANUALLY
                 fi
             fi
 
-            printf "\nAre you sure you want to COMPLETELY WIPE device ${DEVICE}?\nContinue?\nType: YES or abort with Ctrl-C\n> "
-            read ask_confirmation
+            printf "\nAre you sure you want to COMPLETELY WIPE device %s?\nContinue?\nType: YES or abort with Ctrl-C\n> " "${DEVICE}"
+            read -r ask_confirmation
 
             if [[ "${ask_confirmation}" == "YES" ]]; then
                 format_target=1
             else
                 echo "Aborted."
-                exit 1
+                errorExit SSDSETUP_ABORTED_MANUALLY
             fi
         fi
 

--- a/armbian/base/scripts/bbb-cmd.sh
+++ b/armbian/base/scripts/bbb-cmd.sh
@@ -31,11 +31,8 @@ source /opt/shift/scripts/include/redis.sh.inc
 # include function generateConfig() to generate config files from templates
 source /opt/shift/scripts/include/generateConfig.sh.inc
 
-# error handling function
-errorExit() {
-    echo "$@" 1>&2
-    exit 1
-}
+# include errorExit() function
+source /opt/shift/scripts/include/errorExit.sh.inc
 
 # ------------------------------------------------------------------------------
 

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -43,11 +43,8 @@ source /opt/shift/scripts/include/redis.sh.inc
 # include function generateConfig() to generate config files from templates
 source /opt/shift/scripts/include/generateConfig.sh.inc
 
-# error handling function
-errorExit() {
-    echo "$@" 1>&2
-    exit 1
-}
+# include errorExit() function
+source /opt/shift/scripts/include/errorExit.sh.inc
 
 # ------------------------------------------------------------------------------
 

--- a/armbian/base/scripts/bbb-systemctl.sh
+++ b/armbian/base/scripts/bbb-systemctl.sh
@@ -8,11 +8,8 @@ set -eu
 # include functions redis_set() and redis_get()
 source /opt/shift/scripts/include/redis.sh.inc
 
-# error handling function
-errorExit() {
-    echo "$@" 1>&2
-    exit 1
-}
+# include errorExit() function
+source /opt/shift/scripts/include/errorExit.sh.inc
 
 # ------------------------------------------------------------------------------
 

--- a/armbian/base/scripts/include/errorExit.sh.inc
+++ b/armbian/base/scripts/include/errorExit.sh.inc
@@ -1,0 +1,6 @@
+# error handling function
+
+errorExit() {
+    echo "$@" 1>&2
+    exit 1
+}

--- a/armbian/base/scripts/include/redis.sh.inc
+++ b/armbian/base/scripts/include/redis.sh.inc
@@ -27,6 +27,7 @@ redis_require() {
     ok=$(redis-cli -h localhost -p 6379 -n 0 PING) || true
     if [[ "${ok}"  != "PONG" ]]; then
         echo "ERR: Redis not available, aborting"
+        echo "REDIS_REQUIRED_BUT_NOT_RUNNING" 1>&2
         exit 1
     else
         echo "INFO: Redis available"

--- a/armbian/base/scripts/systemd-bbbmiddleware-startpre.sh
+++ b/armbian/base/scripts/systemd-bbbmiddleware-startpre.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC1091
 #
 # This script is run by systemd using the ExecStartPre option
 # before starting bbbmiddleware.service.
@@ -6,7 +7,6 @@
 set -eu
 
 # include functions redis_set() and redis_get()
-# shellcheck disable=SC1091
 source /opt/shift/scripts/include/redis.sh.inc
 
 # ------------------------------------------------------------------------------

--- a/armbian/base/scripts/systemd-bitcoind-startpost.sh
+++ b/armbian/base/scripts/systemd-bitcoind-startpost.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-#
-# This script is run by systemd using the ExecStartPost option 
-# after starting bitcoind.service (Bitcoin Core).
-set -eu

--- a/armbian/base/scripts/systemd-bitcoind-startpre.sh
+++ b/armbian/base/scripts/systemd-bitcoind-startpre.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC1091
 #
 # This script is run by systemd using the ExecStartPre option
 # before starting bitcoind.service (Bitcoin Core).
@@ -8,8 +9,13 @@
 set -eu
 
 # include functions redis_set() and redis_get()
-# shellcheck disable=SC1091
 source /opt/shift/scripts/include/redis.sh.inc
+
+# include errorExit() function
+source /opt/shift/scripts/include/errorExit.sh.inc
+
+# include errorExit() function
+source /opt/shift/scripts/include/errorExit.sh.inc
 
 # ------------------------------------------------------------------------------
 
@@ -34,7 +40,7 @@ fi
 BITCOIN_DIR="/mnt/ssd/bitcoin/.bitcoin"
 if [ ! -d "${BITCOIN_DIR}" ] || [ ! -x "${BITCOIN_DIR}" ]; then
     echo "ERR: cannot start 'bitcoind', directory ${BITCOIN_DIR} not accessible"
-    exit 1
+    errorExit BITCOIND_DIRECTORY_NOT_ACCESSIBLE
 else
     echo "INFO: starting 'bitcoind', directory ${BITCOIN_DIR} accessible"
 fi

--- a/armbian/base/scripts/systemd-electrs-startpre.sh
+++ b/armbian/base/scripts/systemd-electrs-startpre.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC1091
 #
 # This script is run by systemd using the ExecStartPre option 
 # before starting electrs.service (Electrum Server in Rust).
@@ -6,24 +7,24 @@
 
 set -eu
 
-redis_get() {
-    # usage: str=$(redis_get "key")
-    ok=$(redis-cli -h localhost -p 6379 -n 0 GET "${1}")
-    echo "${ok}"
-}
+# include functions redis_set() and redis_get()
+source /opt/shift/scripts/include/redis.sh.inc
+
+# include errorExit() function
+source /opt/shift/scripts/include/errorExit.sh.inc
 
 # ------------------------------------------------------------------------------
 
 if ! systemctl is-active bitcoind.service; then
     echo "ERR: bitcoind.service is not active. Not starting electrs.service."
-    exit 1
+    errorExit BITCOIND_DEPENDENCY_NOT_ACTIVE
 fi
 
 # check if bitcoind is in Initial Block Download (IBD) mode
 BITCOIN_IBD=$(redis_get 'bitcoind:ibd')
 BITCOIN_IBD=${BITCOIN_IBD:-0}
 
-if [ $BITCOIN_IBD -eq 1 ]; then
+if [ "${BITCOIN_IBD}" -eq 1 ]; then
     echo "ERR: bitcoind.service is in IBD mode. Not starting electrs.service."
-    exit 1
+    errorExit BITCOIND_IN_IBD
 fi

--- a/armbian/base/scripts/systemd-lightningd-startpost.sh
+++ b/armbian/base/scripts/systemd-lightningd-startpost.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC1091
 #
 # This script is run by systemd using the ExecStartPost option 
 # after starting lightningd.service (c-lightning).
@@ -6,11 +7,8 @@
 
 set -eu
 
-redis_get() {
-    # usage: str=$(redis_get "key")
-    ok=$(redis-cli -h localhost -p 6379 -n 0 GET "${1}")
-    echo "${ok}"
-}
+# include functions redis_set() and redis_get()
+source /opt/shift/scripts/include/redis.sh.inc
 
 # ------------------------------------------------------------------------------
 

--- a/armbian/base/scripts/systemd-lightningd-startpre.sh
+++ b/armbian/base/scripts/systemd-lightningd-startpre.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC1091
 #
 # This script is run by systemd using the ExecStartPre option 
 # before starting lightningd.service (c-lightning).
@@ -6,24 +7,24 @@
 
 set -eu
 
-redis_get() {
-    # usage: str=$(redis_get "key")
-    ok=$(redis-cli -h localhost -p 6379 -n 0 GET "${1}")
-    echo "${ok}"
-}
+# include functions redis_set() and redis_get()
+source /opt/shift/scripts/include/redis.sh.inc
+
+# include errorExit() function
+source /opt/shift/scripts/include/errorExit.sh.inc
 
 # ------------------------------------------------------------------------------
 
 if ! systemctl is-active bitcoind.service; then
     echo "ERR: bitcoind.service is not active. Not starting lightningd.service."
-    exit 1
+    errorExit BITCOIND_DEPENDENCY_NOT_ACTIVE
 fi
 
 # check if bitcoind is in Initial Block Download (IBD) mode
 BITCOIN_IBD=$(redis_get 'bitcoind:ibd')
 BITCOIN_IBD=${BITCOIN_IBD:-0}
 
-if [ $BITCOIN_IBD -eq 1 ]; then
+if [ "${BITCOIN_IBD}" -eq 1 ]; then
     echo "ERR: bitcoind.service is in IBD mode. Not starting lightningd.service."
-    exit 1
+    errorExit BITCOIND_IN_IBD
 fi

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+# shellcheck disable=SC1091
 #
 # This script is called by the startup-checks.service on boot
 # to check basic system parameters and assure correct configuration.
@@ -12,32 +13,6 @@ set -eu
 source /opt/shift/scripts/include/exec_overlayroot.sh.inc
 
 # ------------------------------------------------------------------------------
-
-# UART configuration
-# ------------------------------------------------------------------------------
-# TODO(Stadicus): Adjust to new Mender configuration
-
-# disable serial output on UART0
-# if ! grep -Fiq "console=display" /boot/armbianEnv.txt; then
-#   if ! grep -Fiq "console=" /boot/armbianEnv.txt; then
-#     echo "console=display" >> /boot/armbianEnv.txt
-#   else
-#     sed -i '/console=/Ic\console=display' /boot/armbianEnv.txt
-#   fi
-#   mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr > /opt/shift/config/uartconfig.log
-#
-#   UART_REBOOT=0
-#   [ -f "${SYSCONFIG_PATH}/UART_REBOOT" ] && source "${SYSCONFIG_PATH}/UART_REBOOT"
-#   if [ ${UART_REBOOT} -eq 1 ]; then 
-#     echo "ERR: previous UART_REBOOT not successful, check system"
-#   else
-#     echo "UART_REBOOT=1" > /data/sysconfig/UART_REBOOT
-#     reboot
-#   fi
-# else
-#   echo "UART_REBOOT=0" > /data/sysconfig/UART_REBOOT
-# fi
-
 
 # SSD configuration
 # ------------------------------------------------------------------------------
@@ -85,7 +60,7 @@ sudo mount -a
 ## abort check if SSD mount is not successful
 if ! mountpoint /mnt/ssd -q; then 
     echo "Mounting of SSD failed"
-    exit 1
+    errorExit SSD_NOT_MOUNTED
 fi
 
 # Folders & permissions

--- a/armbian/base/scripts/systemd-update-checks.sh
+++ b/armbian/base/scripts/systemd-update-checks.sh
@@ -18,11 +18,8 @@ source /opt/shift/scripts/include/redis.sh.inc
 # include function generateConfig() to generate config files from templates
 source /opt/shift/scripts/include/generateConfig.sh.inc
 
-# error handling function
-errorExit() {
-    echo "$@" 1>&2
-    exit 1
-}
+# include errorExit() function
+source /opt/shift/scripts/include/errorExit.sh.inc
 
 # ------------------------------------------------------------------------------
 


### PR DESCRIPTION
all scripts have been cleaned up with shellcheck, unnecessary parts are removed and all aborts are handled with an error code.

The following new error codes are introduced:

generic
* SCRIPT_INVALID_ARG

ssd autosetup
* SSDSETUP_NO_TARGET
* SSDSETUP_TOO_MANY_TARGETS
* SSDSETUP_ABORTED_MANUALLY

lightningd / electrs
* BITCOIND_DEPENDENCY_NOT_ACTIVE
* BITCOIND_IN_IBD

bbb-systemctl.sh
* SYSTEMD_NOT_ALL_SERVICES_RUNNING

systemd-bitcoin-startpre.sh
* BITCOIND_DIRECTORY_NOT_ACCESSIBLE

redis.sh.inc
* REDIS_REQUIRED_BUT_NOT_RUNNING

systemd-startup-checks.sh
* SSD_NOT_MOUNTED

systemd-update-checks.sh
* MENDER_UPDATE_SYSCONFIG_FAILED