### PR TITLE
Prevent flashdrive to mount as /mnt/ssd

### DIFF
--- a/armbian/base/config/redis/factorysettings.txt
+++ b/armbian/base/config/redis/factorysettings.txt
@@ -8,6 +8,7 @@ SET base:wifi:enabled 0
 SET base:wifi:ssid none
 SET base:wifi:password none
 SET base:hostname bitbox-base
+SET base:updating 0
 
 SET tor:base:enabled 1
 SET tor:ssh:enabled 0

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -363,7 +363,8 @@ rm -f /etc/ssh/ssh_host_*
 
 ## set debug console to only use display, not serial console ttyS2 over UART
 echo 'console=display' >> /boot/armbianEnv.txt
-systemctl mask serial-getty@ttyS2.service
+systemctl mask serial-getty@ttyS2.service || true
+systemctl mask serial-getty@ttyFIQ0       || true
 
 ## generate selfsigned NGINX key when run script is run on device, plus symlink to /data
 mkdir -p /data/ssl/

--- a/armbian/base/scripts/autosetup-ssd.sh
+++ b/armbian/base/scripts/autosetup-ssd.sh
@@ -42,9 +42,9 @@ function list_targets() {
         if [[ ${#type} -gt 0 ]]; then
             blockdev_target="NO: has file system"
 
-        # check if at least 200GB
-        elif [[ ${size} -lt 200000000000 ]]; then
-            blockdev_target="NO: too small (min 200GB)"
+        # check if at least 400GB
+        elif [[ ${size} -lt 400000000000 ]]; then
+            blockdev_target="NO: too small (min 400GB)"
 
         else
             # check top-level device for partitions

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -45,10 +45,10 @@ source /opt/shift/scripts/include/exec_overlayroot.sh.inc
 if ! grep -q '/mnt/ssd ' /etc/fstab ; then
 
     ## valid partition present?
-    if lsblk | grep -q 'nvme0n1p1'; then
+    if lsblk | grep -q 'nvme0n1p1' && [[ $(lsblk -o NAME,SIZE -abrnp | grep nvme0n1p1 | cut -f 2 -d " ") -gt 400000000000 ]]; then
         exec_overlayroot all-layers "echo '/dev/nvme0n1p1 /mnt/ssd ext4 rw,nosuid,dev,noexec,noatime,nodiratime,auto,nouser,async,nofail 0 2' >> /etc/fstab"
 
-    elif lsblk | grep -q 'sda1'; then
+    elif lsblk | grep -q 'sda1' && [[ $(lsblk -o NAME,SIZE -abrnp | grep sda1 | cut -f 2 -d " ") -gt 400000000000 ]]; then
         exec_overlayroot all-layers "echo '/dev/sda1 /mnt/ssd ext4 rw,nosuid,dev,noexec,noatime,nodiratime,auto,nouser,async,nofail 0 2' >> /etc/fstab"
 
     else
@@ -65,10 +65,10 @@ if ! grep -q '/mnt/ssd ' /etc/fstab ; then
             fi
         fi
 
-        ## check for newly created partition
-        if lsblk | grep -q 'nvme0n1p1'; then
+        ## check for newly created partition (must be bigger than 400GB to prevent flashdrive mount)
+        if lsblk | grep -q 'nvme0n1p1' && [[ $(lsblk -o NAME,SIZE -abrnp | grep nvme0n1p1 | cut -f 2 -d " ") -gt 400000000000 ]]; then
             echo "/dev/nvme0n1p1 /mnt/ssd ext4 rw,nosuid,dev,noexec,noatime,nodiratime,auto,nouser,async,nofail 0 2" >> /etc/fstab
-        elif lsblk | grep -q 'sda1'; then
+        elif lsblk | grep -q 'sda1' && [[ $(lsblk -o NAME,SIZE -abrnp | grep sda1 | cut -f 2 -d " ") -gt 400000000000 ]]; then
             echo "/dev/sda1 /mnt/ssd ext4 rw,nosuid,dev,noexec,noatime,nodiratime,auto,nouser,async,nofail 0 2" >> /etc/fstab
         else
             echo "ERR: autosetup partition not found"


### PR DESCRIPTION
If a factory new BitBox Base is started the first time, with an empty SSD and a backup USB flashdrive plugged in, the flashdrive could be mounted at `/mnt/ssd` which is wrong.

Added some checks to only mount a drive with at least 400 GB as SSD (either external or internal is ok).

Additional fix: disable `serial-getty@ttyFIQ0` service that tries to activate non-existing serial console and causes a boot delay.