### PR TITLE
bitcoind: add 'sysperms=1' to config

### DIFF
--- a/armbian/base/config/redis/factorysettings.txt
+++ b/armbian/base/config/redis/factorysettings.txt
@@ -26,6 +26,7 @@ SET bitcoind:listen 1
 SET bitcoind:txindex 0
 SET bitcoind:prune 0
 SET bitcoind:disablewallet 1
+SET bitcoind:sysperms 1
 SET bitcoind:refresh-rpcauth 1
 SET bitcoind:rpcauth xxx
 SET bitcoind:rpcuser xxx

--- a/armbian/base/config/templates/bitcoin.conf.template
+++ b/armbian/base/config/templates/bitcoin.conf.template
@@ -11,6 +11,7 @@ listenonion=0                                                               {{ b
 txindex={{          bitcoind:txindex            #default: 0 }}
 prune={{            bitcoind:prune              #default: 0 }}
 disablewallet={{    bitcoind:disablewallet      #default: 1 }}
+sysperms={{         bitcoind:sysperms           #default: 1 }}
 printtoconsole={{   bitcoind:printtoconsole     #default: 1 }}
 onlynet={{          bitcoind:onlynet            #default: ipv4 }}           {{ tor:base:enabled #rmLineTrue }}
 onlynet={{          bitcoind:onlynet            #default: ipv4 }}           {{ tor:base:enabled #rmLineFalse }} {{ bitcoind:ibd-clearnet #rmLineFalse }}

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -73,6 +73,8 @@ chown bitcoin:system /mnt/ssd/
 mkdir -p /mnt/ssd/bitcoin/.bitcoin/testnet3
 chown -R bitcoin:bitcoin /mnt/ssd/bitcoin/
 chmod -R u+rw,g+r,g-w,o-rwx /mnt/ssd/bitcoin/
+setfacl -d -m g::rx /mnt/ssd/bitcoin/.bitcoin/
+setfacl -d -m o::- /mnt/ssd/bitcoin/.bitcoin/
 
 ## lightningd socket
 chmod 770 /mnt/ssd/bitcoin/.lightning/lightning-rpc || true


### PR DESCRIPTION
This setting instructs bitcoind to create new files (e.g. blocks and indices)
with system default permissions, instead of umask 077 (-rwx------).

It has been removed in error, but is needed for members of the bitcoin group
like electrs to have access to the blockchain data.

Access Control Lists (ACL) have also been added to control the default
permissions (set on startup with 'setfacl').