### PR TITLE
iptables: dynamic config from template

### DIFF
--- a/armbian/base/config/redis/factorysettings.txt
+++ b/armbian/base/config/redis/factorysettings.txt
@@ -52,6 +52,7 @@ SET lightningd:log-level debug
 SET lightningd:plugin:1 /opt/shift/scripts/prometheus-lightningd.py
 
 SET electrs:version xxx
+SET electrs:clearnet 1
 SET electrs:db_dir /mnt/ssd/electrs/db
 SET electrs:daemon_dir /mnt/ssd/bitcoin/.bitcoin
 SET electrs:monitoring_addr 127.0.0.1:4224

--- a/armbian/base/config/templates/iptables.rules.template
+++ b/armbian/base/config/templates/iptables.rules.template
@@ -1,3 +1,4 @@
+{{ #output: /etc/iptables/iptables.rules }}
 *filter
 # Default policy is DROP; we need to explicitly allow any packets we
 # do want.
@@ -31,18 +32,18 @@
 # Allow mDNS.
 -A INPUT -p udp --sport 5353 --dport 5353 -j ACCEPT
 
-# Allow inbound TCP traffic to bitcoin port.
--A INPUT -p tcp --dport 8333 -j ACCEPT
--A INPUT -p tcp --dport 18333 -j ACCEPT
+# Allow inbound TCP traffic to bitcoin port, if Tor is disabled
+-A INPUT -p tcp --dport 8333 -j ACCEPT                  {{ tor:base:enabled #rmLineTrue }}
+-A INPUT -p tcp --dport 18333 -j ACCEPT                 {{ tor:base:enabled #rmLineTrue }}
 
 # Allow inbound TCP traffic to Base Middleware port.
 -A INPUT -p tcp --dport 8845 -j ACCEPT
 
-# Allow inbound TCP traffic to Tor port.
--A INPUT -p tcp --dport 9001 -j ACCEPT
--A INPUT -p tcp --sport 9001 -j ACCEPT
+# Allow inbound TCP traffic to Tor port, if Tor is enabled
+-A INPUT -p tcp --dport 9001 -j ACCEPT                  {{ tor:base:enabled #rmLineFalse }}
+-A INPUT -p tcp --sport 9001 -j ACCEPT                  {{ tor:base:enabled #rmLineFalse }}
 
-# Allow inbound TCP traffic to electrs port.
+# Allow inbound TCP traffic to electrs port.            (TODO)Stadicus: add config to enable/disable Electrs clearnet
 -A INPUT -p tcp --dport 50002 -j ACCEPT
 
 # Allow inbound ICMP type 0, 3 and 8 ("Echo Reply", "Destination
@@ -102,11 +103,19 @@
 # Allow outbound TCP traffic from sshd port.
 -A OUTPUT -p tcp --sport 22 -j ACCEPT
 
-# Allow outbound lightningd traffic.
--A OUTPUT -p tcp --dport 9735 -j ACCEPT
+# Allow outbound TCP traffic to bitcoin port, if Tor disabled
+-A OUTPUT -p tcp --dport 8333 -j ACCEPT                 {{ tor:base:enabled #rmLineTrue }}
+-A OUTPUT -p tcp --dport 18333 -j ACCEPT                {{ tor:base:enabled #rmLineTrue }}
 
-# Allow outbound TCP traffic to Tor port.
--A OUTPUT -p tcp --dport 9001 -j ACCEPT
+# Allow outbound TCP traffic to bitcoin port, if IBD over Clearnet enabled
+-A OUTPUT -p tcp --dport 8333 -j ACCEPT                 {{ tor:base:enabled #rmLineFalse }} {{ bitcoind:ibd-clearnet #rmLineFalse }}
+-A OUTPUT -p tcp --dport 18333 -j ACCEPT                {{ tor:base:enabled #rmLineFalse }} {{ bitcoind:ibd-clearnet #rmLineFalse }}
+
+# Allow outbound lightningd traffic, if Tor disabled
+-A OUTPUT -p tcp --dport 9735 -j ACCEPT                 {{ tor:base:enabled #rmLineTrue }}
+
+# Allow outbound TCP traffic to Tor port, if Tor enabled
+-A OUTPUT -p tcp --dport 9001 -j ACCEPT                 {{ tor:base:enabled #rmLineFalse }}
 
 # Explicitly whitelist established / related connections. This is a
 # last-ditch safeguard to avoid locking yourself out if a too-restrictive

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -715,7 +715,7 @@ sed -i '/PUBLISH-WORKSTATION/Ic\publish-workstation=yes' /etc/avahi/avahi-daemon
 importFile "/etc/avahi/services/bitboxbase.service"
 
 ## firewall: restore iptables rules on startup
-importFile "/etc/iptables/iptables.rules"
+generateConfig "iptables.rules.template" # -->  /etc/iptables/iptables.rules
 importFile "/etc/systemd/system/iptables-restore.service"
 
 

--- a/armbian/base/rootfs/etc/systemd/system/iptables-restore.service
+++ b/armbian/base/rootfs/etc/systemd/system/iptables-restore.service
@@ -7,7 +7,7 @@ Before=network.target
 # Service execution
 ###################
 
-ExecStart=/bin/sh -c "/sbin/iptables-restore < /etc/iptables/iptables.rules"
+ExecStart=/opt/shift/scripts/systemd-iptables-restore.sh
 
 # Process management
 ####################

--- a/armbian/base/scripts/systemd-iptables-restore.sh
+++ b/armbian/base/scripts/systemd-iptables-restore.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# shellcheck disable=SC1091
+#
+# This script restores the iptables firewall rules
+#
+set -eu
+
+# flush existing iptables rules
+iptables -P INPUT ACCEPT
+iptables -P FORWARD ACCEPT
+iptables -P OUTPUT ACCEPT
+iptables -t nat -F
+iptables -t mangle -F
+iptables -F
+iptables -X
+
+# restore iptables rules
+/sbin/iptables-restore < /etc/iptables/iptables.rules
+
+# list active iptables rules
+iptables -L -n

--- a/armbian/mender-convert.sh
+++ b/armbian/mender-convert.sh
@@ -39,6 +39,11 @@ case ${ACTION} in
 			cd mender-convert
 		fi
 
+		# cleanup loop devices if trigger file present
+		if [ -f .cleanup-loop-devices ]; then
+			../contrib/cleanup-loop-devices.sh
+		fi
+
 		# conversion settings
 		DEVICE_TYPE="rockpro64"
 		RAW_DISK_IMAGE="input/${SOURCE_NAME}.img"


### PR DESCRIPTION
To avoid permissive iptables rules, the various configurations (esp. `tor:base:enabled` and `bitcoind:ibd-clearnet`) include or exclude certain rules when recreating the file `iptables.rules` from the template `iptables.rules.template`.

The build script and especially `bbb-config.sh` is extended to recreate and activate these rules by triggering the `iptables-restore.service` via systemd. This service no longer calls `/sbin/iptables-restore` directly but the script `systemd-iptables-restore.sh` that first flushes existing iptables rules.

Minor fix: also cleanup loop devices before mender-convert if trigger file is present (not just after).
