### PR TITLE
Middleware: Include Flashdrive methods in Backup/Restore Sysconfig

### DIFF
--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -22,8 +22,6 @@ type Middleware interface {
 	SampleInfo() rpcmessages.SampleInfoResponse
 	ResyncBitcoin() rpcmessages.ErrorResponse
 	ReindexBitcoin() rpcmessages.ErrorResponse
-	MountFlashdrive() rpcmessages.ErrorResponse
-	UnmountFlashdrive() rpcmessages.ErrorResponse
 	BackupSysconfig() rpcmessages.ErrorResponse
 	BackupHSMSecret() rpcmessages.ErrorResponse
 	GetHostname() rpcmessages.GetHostnameResponse

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -204,66 +204,29 @@ func (middleware *Middleware) DummyAdminPassword() string {
 	return middleware.dummyAdminPassword
 }
 
-// MountFlashdrive returns an ErrorResponse struct in a response to a rpcserver request
-func (middleware *Middleware) MountFlashdrive() rpcmessages.ErrorResponse {
-	log.Println("Executing a USB flashdrive check via the cmd script")
-	outCheck, err := middleware.runBBBCmdScript([]string{"flashdrive", "check"})
-	if err != nil {
-		errorCode := handleBBBScriptErrorCode(outCheck, err, []rpcmessages.ErrorCode{
-			rpcmessages.ErrorFlashdriveCheckMultiple,
-			rpcmessages.ErrorFlashdriveCheckNone,
-		})
+// BackupSysconfig creates a backup of the system configuration onto a flashdrive.
+// 1. Check if one and only one valid flashdrive is plugged in
+// 2. Mount the flashdrive
+// 3. Backup the system configuration
+// 4. Unmount the flashdrive
+func (middleware *Middleware) BackupSysconfig() (response rpcmessages.ErrorResponse) {
 
-		return rpcmessages.ErrorResponse{
-			Success: false,
-			Message: strings.Join(outCheck, "\n"),
-			Code:    errorCode,
-		}
+	response = middleware.mountFlashdrive()
+	if !response.Success {
+		return response
 	}
 
-	// `bbb-cmd.sh flashdrive check` prints only the flashdrive name, if no error occurs
-	flashDriveName := outCheck[0]
-
-	log.Println("Executing a USB flashdrive mount via the cmd script")
-	outMount, err := middleware.runBBBCmdScript([]string{"flashdrive", "mount", flashDriveName})
-	if err != nil {
-		errorCode := handleBBBScriptErrorCode(outMount, err, []rpcmessages.ErrorCode{
-			rpcmessages.ErrorFlashdriveMountNotFound,
-			rpcmessages.ErrorFlashdriveMountNotSupported,
-			rpcmessages.ErrorFlashdriveMountNotUnique,
-		})
-
-		return rpcmessages.ErrorResponse{
-			Success: false,
-			Message: strings.Join(outMount, "\n"),
-			Code:    errorCode,
+	// It's crucial that mounted flashdrives get unmounted.
+	defer func() {
+		unmountResponse := middleware.unmountFlashdrive()
+		// In case the backing up the system configuration fails the error message should
+		// be preserved. If the backup was successful, but the unmouting fails, then the
+		// ErrorCode and message should be overwritten.
+		if response.Success {
+			response = unmountResponse // overrites the backup response
 		}
-	}
+	}()
 
-	return rpcmessages.ErrorResponse{Success: true}
-}
-
-// UnmountFlashdrive returns an ErrorResponse struct in a response to a rpcserver request
-func (middleware *Middleware) UnmountFlashdrive() rpcmessages.ErrorResponse {
-	log.Println("Executing a USB flashdrive unmount via the cmd script")
-	out, err := middleware.runBBBCmdScript([]string{"flashdrive", "unmount"})
-	if err != nil {
-		errorCode := handleBBBScriptErrorCode(out, err, []rpcmessages.ErrorCode{
-			rpcmessages.ErrorFlashdriveUnmountNotMounted,
-		})
-
-		return rpcmessages.ErrorResponse{
-			Success: false,
-			Message: strings.Join(out, "\n"),
-			Code:    errorCode,
-		}
-	}
-
-	return rpcmessages.ErrorResponse{Success: true}
-}
-
-// BackupSysconfig returns a ErrorResponse struct in response to a rpcserver request
-func (middleware *Middleware) BackupSysconfig() rpcmessages.ErrorResponse {
 	log.Println("Executing a backup of the system config via the cmd script")
 	out, err := middleware.runBBBCmdScript([]string{"backup", "sysconfig"})
 	if err != nil {
@@ -297,8 +260,28 @@ func (middleware *Middleware) BackupHSMSecret() rpcmessages.ErrorResponse {
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
-// RestoreSysconfig returns a ErrorResponse struct in response to a rpcserver request
-func (middleware *Middleware) RestoreSysconfig() rpcmessages.ErrorResponse {
+// RestoreSysconfig restores a backup of the system configuration from the flashdrive.
+// 1. Check if one and only one valid flashdrive is plugged in
+// 2. Mount the flashdrive
+// 3. Restore the system configuration (currently not choosable)
+// 4. Unmount the flashdrive
+func (middleware *Middleware) RestoreSysconfig() (response rpcmessages.ErrorResponse) {
+	response = middleware.mountFlashdrive()
+	if !response.Success {
+		return response
+	}
+
+	// It's crucial that mounted flashdrives get unmounted.
+	defer func() {
+		unmountResponse := middleware.unmountFlashdrive()
+		// In case the restoring up the system configuration fails the error message should
+		// be preserved. If the backup was successful, but the unmouting fails, then the
+		// ErrorCode and message should be overwritten.
+		if response.Success {
+			response = unmountResponse // overrites the backup response
+		}
+	}()
+
 	log.Println("Executing a restore of the system config via the cmd script")
 	out, err := middleware.runBBBCmdScript([]string{"restore", "sysconfig"})
 	if err != nil {
@@ -312,7 +295,6 @@ func (middleware *Middleware) RestoreSysconfig() rpcmessages.ErrorResponse {
 			Code:    errorCode,
 		}
 	}
-
 	return rpcmessages.ErrorResponse{Success: true}
 }
 

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -4,8 +4,6 @@ package middleware
 import (
 	"fmt"
 	"log"
-	"os"
-	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -616,80 +614,4 @@ func (middleware *Middleware) SetRootPassword(args rpcmessages.SetRootPasswordAr
 		Message: "The password has to be at least 8 chars. An unicode char is counted as one.",
 		Code:    rpcmessages.ErrorSetRootPasswordTooShort,
 	}
-}
-
-// runBBBCmdScript runs the bbb-cmd.sh script.
-// The script executes commands like for example mounting a USB drive, doing a backup and copying files.
-func (middleware *Middleware) runBBBCmdScript(args []string) (outputLines []string, err error) {
-	outputLines, err = runCommand(middleware.environment.GetBBBCmdScript(), args)
-	return
-}
-
-// runBBBConfigScript runs the bbb-config.sh script.
-// The script changes the system configuration in redis by setting or unsetting the appropriate keys.
-// If necessary the affected services are restarted.
-func (middleware *Middleware) runBBBConfigScript(args []string) (outputLines []string, err error) {
-	outputLines, err = runCommand(middleware.environment.GetBBBConfigScript(), args)
-	return
-}
-
-// runCommand runs the passed command and returns the combined stdout and stderr output.
-// If the command could not be run, err is not nil.
-func runCommand(command string, args []string) (combinedLines []string, err error) {
-	cmd := exec.Command(command, args...)
-	log.Printf("executing command: %s %s", command, strings.Join(args, " "))
-
-	rawstdoutStderr, err := cmd.CombinedOutput()
-	if err != nil {
-		// no error handling here, just logging
-		log.Printf("Error executing command '%s %s': '%s'", command, strings.Join(args, " "), err.Error())
-	}
-
-	combined := strings.TrimSuffix(string(rawstdoutStderr), "\n")
-	combinedLines = strings.Split(combined, "\n")
-	return combinedLines, err
-}
-
-func handleBBBScriptErrorCode(outputLines []string, err error, possibleErrors []rpcmessages.ErrorCode) rpcmessages.ErrorCode {
-	// There are two possible types of errors handled here:
-	// 1.   The script could not be found.
-	// 2.   Script exited with `exit status 1`:
-	// 	2.1. Script was not run as superuser. ErrorCode ErrorScriptNotSuperuser is expected as the last outputLine.
-	// 	2.2. CMD Script was not run with correct parameters. ErrorCode ErrorCmdScriptInvalidArg is expected as the last outputLine.
-	// 	2.3. Config Script was not run with correct parameters. ErrorCode ErrorConfigScriptInvalidArg is expected as the last outputLine.
-	// 	2.4. One of the `possibleErrors` is expected as the last outputLine.
-	// All other errors are unknow and not handled. ErrorUnexpected is returned as a last resort.
-
-	if os.IsNotExist(err) {
-		return rpcmessages.ErrorScriptNotFound
-	} else if err.Error() == "error status 1" {
-
-		if len(outputLines) == 0 {
-			log.Println("Error: no log lines provided before exit with error status 1.")
-			return rpcmessages.ErrorUnexpected
-		}
-
-		outputErrorCode := outputLines[len(outputLines)-1]
-
-		// handling default errors the bbb-cmd and bbb-config scripts can return
-		switch outputErrorCode {
-		case string(rpcmessages.ErrorScriptNotSuperuser):
-			return rpcmessages.ErrorScriptNotSuperuser // Script was not run as superuser.
-		case string(rpcmessages.ErrorCmdScriptInvalidArg):
-			return rpcmessages.ErrorCmdScriptInvalidArg // Invalid arguments passed to the bbb-cmd.sh script.
-		case string(rpcmessages.ErrorConfigScriptInvalidArg):
-			return rpcmessages.ErrorConfigScriptInvalidArg // Invalid arguments passed to the bbb-config.sh script.
-		}
-
-		// handling specific possible errors the executed part of the script can throw
-		// e.g. flashdrive mounting errors when executing a flashdrive mount
-		for _, possible := range possibleErrors {
-			if outputErrorCode == string(possible) {
-				return possible
-			}
-		}
-	}
-
-	log.Printf("Error: unhandled error '%s' with output '%s'", err.Error(), outputLines)
-	return rpcmessages.ErrorUnexpected
 }

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -252,7 +252,6 @@ func (middleware *Middleware) MountFlashdrive() rpcmessages.ErrorResponse {
 func (middleware *Middleware) UnmountFlashdrive() rpcmessages.ErrorResponse {
 	log.Println("Executing a USB flashdrive unmount via the cmd script")
 	out, err := middleware.runBBBCmdScript([]string{"flashdrive", "unmount"})
-
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, []rpcmessages.ErrorCode{
 			rpcmessages.ErrorFlashdriveUnmountNotMounted,
@@ -272,7 +271,6 @@ func (middleware *Middleware) UnmountFlashdrive() rpcmessages.ErrorResponse {
 func (middleware *Middleware) BackupSysconfig() rpcmessages.ErrorResponse {
 	log.Println("Executing a backup of the system config via the cmd script")
 	out, err := middleware.runBBBCmdScript([]string{"backup", "sysconfig"})
-
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, []rpcmessages.ErrorCode{
 			rpcmessages.ErrorBackupSysconfigNotAMountpoint,
@@ -292,7 +290,6 @@ func (middleware *Middleware) BackupSysconfig() rpcmessages.ErrorResponse {
 func (middleware *Middleware) BackupHSMSecret() rpcmessages.ErrorResponse {
 	log.Println("Executing a backup of the c-lightning hsm_secret via the cmd script")
 	out, err := middleware.runBBBCmdScript([]string{"backup", "hsm_secret"})
-
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
 		return rpcmessages.ErrorResponse{
@@ -309,7 +306,6 @@ func (middleware *Middleware) BackupHSMSecret() rpcmessages.ErrorResponse {
 func (middleware *Middleware) RestoreSysconfig() rpcmessages.ErrorResponse {
 	log.Println("Executing a restore of the system config via the cmd script")
 	out, err := middleware.runBBBCmdScript([]string{"restore", "sysconfig"})
-
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, []rpcmessages.ErrorCode{
 			rpcmessages.ErrorRestoreSysconfigBackupNotFound,
@@ -329,7 +325,6 @@ func (middleware *Middleware) RestoreSysconfig() rpcmessages.ErrorResponse {
 func (middleware *Middleware) RestoreHSMSecret() rpcmessages.ErrorResponse {
 	log.Println("Executing a restore of the c-lightning hsm_secret via the cmd script")
 	out, err := middleware.runBBBCmdScript([]string{"restore", "hsm_secret"})
-
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
 		return rpcmessages.ErrorResponse{
@@ -423,8 +418,6 @@ func (middleware *Middleware) SetHostname(args rpcmessages.SetHostnameArgs) rpcm
 
 // GetHostname returns a the systems hostname in a GetHostnameResponse
 func (middleware *Middleware) GetHostname() rpcmessages.GetHostnameResponse {
-	log.Println("Getting the hostname from redis")
-
 	// TODO: Implement get hostname from redis
 	// TODO: define error codes for this
 	return rpcmessages.GetHostnameResponse{
@@ -531,7 +524,6 @@ func (middleware *Middleware) EnableClearnetIBD(toggleAction rpcmessages.ToggleS
 func (middleware *Middleware) ShutdownBase() rpcmessages.ErrorResponse {
 	log.Println("shutting down the Base via the cmd script")
 	out, err := middleware.runBBBCmdScript([]string{"base", "shutdown"})
-
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
 		return rpcmessages.ErrorResponse{
@@ -549,7 +541,6 @@ func (middleware *Middleware) ShutdownBase() rpcmessages.ErrorResponse {
 func (middleware *Middleware) RebootBase() rpcmessages.ErrorResponse {
 	log.Println("rebooting the Base via the cmd script")
 	out, err := middleware.runBBBCmdScript([]string{"base", "reboot"})
-
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
 		return rpcmessages.ErrorResponse{
@@ -611,7 +602,6 @@ func (middleware *Middleware) SetRootPassword(args rpcmessages.SetRootPasswordAr
 	// len([]rune("₿")) = 1
 	if len([]rune(password)) >= 8 {
 		out, err := middleware.runBBBConfigScript([]string{"set", "root_pw", password})
-
 		if err != nil {
 			errorCode := handleBBBScriptErrorCode(out, err, []rpcmessages.ErrorCode{
 				rpcmessages.ErrorSetNeedsTwoArguments,

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -150,7 +150,6 @@ func (middleware *Middleware) Start() <-chan []byte {
 func (middleware *Middleware) ResyncBitcoin() rpcmessages.ErrorResponse {
 	log.Println("executing full bitcoin resync via the cmd script")
 	out, err := middleware.runBBBCmdScript([]string{"bitcoind", "resync"})
-
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
 		return rpcmessages.ErrorResponse{
@@ -167,7 +166,6 @@ func (middleware *Middleware) ResyncBitcoin() rpcmessages.ErrorResponse {
 func (middleware *Middleware) ReindexBitcoin() rpcmessages.ErrorResponse {
 	log.Println("executing full bitcoin resync via the cmd script")
 	out, err := middleware.runBBBCmdScript([]string{"bitcoind", "reindex"})
-
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
 		return rpcmessages.ErrorResponse{
@@ -212,7 +210,6 @@ func (middleware *Middleware) DummyAdminPassword() string {
 func (middleware *Middleware) MountFlashdrive() rpcmessages.ErrorResponse {
 	log.Println("Executing a USB flashdrive check via the cmd script")
 	outCheck, err := middleware.runBBBCmdScript([]string{"flashdrive", "check"})
-
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(outCheck, err, []rpcmessages.ErrorCode{
 			rpcmessages.ErrorFlashdriveCheckMultiple,
@@ -436,7 +433,6 @@ func (middleware *Middleware) EnableTor(toggleAction rpcmessages.ToggleSetting) 
 	out, err := middleware.runBBBConfigScript([]string{string(toggleAction), "tor"})
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
-
 		return rpcmessages.ErrorResponse{
 			Success: false,
 			Message: strings.Join(out, "\n"),
@@ -454,7 +450,6 @@ func (middleware *Middleware) EnableTorMiddleware(toggleAction rpcmessages.Toggl
 	out, err := middleware.runBBBConfigScript([]string{string(toggleAction), "tor_bbbmiddleware"})
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
-
 		return rpcmessages.ErrorResponse{
 			Success: false,
 			Message: strings.Join(out, "\n"),
@@ -472,7 +467,6 @@ func (middleware *Middleware) EnableTorElectrs(toggleAction rpcmessages.ToggleSe
 	out, err := middleware.runBBBConfigScript([]string{string(toggleAction), "tor_electrs"})
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
-
 		return rpcmessages.ErrorResponse{
 			Success: false,
 			Message: strings.Join(out, "\n"),

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -83,22 +83,6 @@ func TestReindexBitcoin(t *testing.T) {
 	require.Equal(t, rpcmessages.ErrorCode(""), response.Code)
 }
 
-func TestMountFlashdrive(t *testing.T) {
-	testMiddleware := setupTestMiddleware()
-	response := testMiddleware.MountFlashdrive()
-	require.Equal(t, true, response.Success)
-	require.Equal(t, "", response.Message)
-	require.Equal(t, rpcmessages.ErrorCode(""), response.Code)
-}
-
-func TestUnmountFlashdrive(t *testing.T) {
-	testMiddleware := setupTestMiddleware()
-	response := testMiddleware.UnmountFlashdrive()
-	require.Equal(t, true, response.Success)
-	require.Equal(t, "", response.Message)
-	require.Equal(t, rpcmessages.ErrorCode(""), response.Code)
-}
-
 func TestBackupHSMSecret(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -52,8 +52,6 @@ type Middleware interface {
 	SystemEnv() rpcmessages.GetEnvResponse
 	ResyncBitcoin() rpcmessages.ErrorResponse
 	ReindexBitcoin() rpcmessages.ErrorResponse
-	MountFlashdrive() rpcmessages.ErrorResponse
-	UnmountFlashdrive() rpcmessages.ErrorResponse
 	BackupSysconfig() rpcmessages.ErrorResponse
 	BackupHSMSecret() rpcmessages.ErrorResponse
 	GetHostname() rpcmessages.GetHostnameResponse
@@ -129,20 +127,6 @@ func (server *RPCServer) GetSampleInfo(dummyArg bool, reply *rpcmessages.SampleI
 // GetVerificationProgress sends the middleware's VerificationProgressResponse over rpc
 func (server *RPCServer) GetVerificationProgress(dummyArg bool, reply *rpcmessages.VerificationProgressResponse) error {
 	*reply = server.middleware.VerificationProgress()
-	log.Printf("sent reply %v: ", reply)
-	return nil
-}
-
-// MountFlashdrive sends the middleware's ErrorResponse over RPC.
-func (server *RPCServer) MountFlashdrive(dummyArg bool, reply *rpcmessages.ErrorResponse) error {
-	*reply = server.middleware.MountFlashdrive()
-	log.Printf("sent reply %v: ", reply)
-	return nil
-}
-
-// UnmountFlashdrive sends the middleware's ErrorResponse over RPC.
-func (server *RPCServer) UnmountFlashdrive(dummyArg bool, reply *rpcmessages.ErrorResponse) error {
-	*reply = server.middleware.UnmountFlashdrive()
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -124,14 +124,6 @@ func TestRPCServer(t *testing.T) {
 	var verificationProgressReply rpcmessages.VerificationProgressResponse
 	testingRPCServer.RunRPCCall(t, "RPCServer.GetVerificationProgress", dummyArg, &verificationProgressReply)
 
-	var mountFlashdriveReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.MountFlashdrive", dummyArg, &mountFlashdriveReply)
-	require.Equal(t, true, mountFlashdriveReply.Success)
-
-	var unmountFlashdriveReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.UnmountFlashdrive", dummyArg, &unmountFlashdriveReply)
-	require.Equal(t, true, unmountFlashdriveReply.Success)
-
 	var backupSysconfigReply rpcmessages.ErrorResponse
 	testingRPCServer.RunRPCCall(t, "RPCServer.BackupSysconfig", dummyArg, &backupSysconfigReply)
 	require.Equal(t, true, backupSysconfigReply.Success)

--- a/middleware/src/util.go
+++ b/middleware/src/util.go
@@ -1,0 +1,91 @@
+package middleware
+
+import (
+	"log"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/digitalbitbox/bitbox-base/middleware/src/rpcmessages"
+)
+
+// The util.go file includes utillity functions for the Middleware.
+// These are private and called by the middleware RPCs. Utillity
+// functions like `mountFlashdrive` or `unmountFlashdrive` are
+// reused in multiple RPCs.
+
+// runBBBCmdScript runs the bbb-cmd.sh script.
+// The script executes commands like for example mounting a USB drive, doing a backup and copying files.
+func (middleware *Middleware) runBBBCmdScript(args []string) (outputLines []string, err error) {
+	outputLines, err = runCommand(middleware.environment.GetBBBCmdScript(), args)
+	return
+}
+
+// runBBBConfigScript runs the bbb-config.sh script.
+// The script changes the system configuration in redis by setting or unsetting the appropriate keys.
+// If necessary the affected services are restarted.
+func (middleware *Middleware) runBBBConfigScript(args []string) (outputLines []string, err error) {
+	outputLines, err = runCommand(middleware.environment.GetBBBConfigScript(), args)
+	return
+}
+
+// runCommand runs the passed command and returns the combined stdout and stderr output.
+// If the command could not be run, err is not nil.
+func runCommand(command string, args []string) (combinedLines []string, err error) {
+	cmd := exec.Command(command, args...)
+	log.Printf("executing command: %s %s", command, strings.Join(args, " "))
+
+	rawstdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		// no error handling here, just logging
+		log.Printf("Error executing command '%s %s': '%s'", command, strings.Join(args, " "), err.Error())
+	}
+
+	combined := strings.TrimSuffix(string(rawstdoutStderr), "\n")
+	combinedLines = strings.Split(combined, "\n")
+	return combinedLines, err
+}
+
+func handleBBBScriptErrorCode(outputLines []string, err error, possibleErrors []rpcmessages.ErrorCode) rpcmessages.ErrorCode {
+	// There are two possible types of errors handled here:
+	// 1.   The script could not be found.
+	// 2.   Script exited with `exit status 1`:
+	// 	2.1. Script was not run as superuser. ErrorCode ErrorScriptNotSuperuser is expected as the last outputLine.
+	// 	2.2. CMD Script was not run with correct parameters. ErrorCode ErrorCmdScriptInvalidArg is expected as the last outputLine.
+	// 	2.3. Config Script was not run with correct parameters. ErrorCode ErrorConfigScriptInvalidArg is expected as the last outputLine.
+	// 	2.4. One of the `possibleErrors` is expected as the last outputLine.
+	// All other errors are unknow and not handled. ErrorUnexpected is returned as a last resort.
+
+	if os.IsNotExist(err) {
+		return rpcmessages.ErrorScriptNotFound
+	} else if err.Error() == "error status 1" {
+
+		if len(outputLines) == 0 {
+			log.Println("Error: no log lines provided before exit with error status 1.")
+			return rpcmessages.ErrorUnexpected
+		}
+
+		outputErrorCode := outputLines[len(outputLines)-1]
+
+		// handling default errors the bbb-cmd and bbb-config scripts can return
+		switch outputErrorCode {
+		case string(rpcmessages.ErrorScriptNotSuperuser):
+			return rpcmessages.ErrorScriptNotSuperuser // Script was not run as superuser.
+		case string(rpcmessages.ErrorCmdScriptInvalidArg):
+			return rpcmessages.ErrorCmdScriptInvalidArg // Invalid arguments passed to the bbb-cmd.sh script.
+		case string(rpcmessages.ErrorConfigScriptInvalidArg):
+			return rpcmessages.ErrorConfigScriptInvalidArg // Invalid arguments passed to the bbb-config.sh script.
+		}
+
+		// handling specific possible errors the executed part of the script can throw
+		// e.g. flashdrive mounting errors when executing a flashdrive mount
+		for _, possible := range possibleErrors {
+			if outputErrorCode == string(possible) {
+				return possible
+			}
+		}
+	}
+
+	log.Printf("Error: unhandled error '%s' with output '%s'", err.Error(), outputLines)
+	return rpcmessages.ErrorUnexpected
+}


### PR DESCRIPTION
The middleware calls the bbb-cmd script with `check` `mount` and `unmount` for flashdrive operations. These fuctions were avaliable as RPCs, but are now included in the Backup and Restore sysconfig RPCs. This is done to minimize the amount of RPC calls and traffic, which might need to be send over Tor.

Removed are following RPCs:
- `MountFlashdrive`
- `UnmountFlashdrive`
