### PR TITLE
tor: add .onion to Redis / harmonize service names

### DIFF
--- a/armbian/base/config/redis/factorysettings.txt
+++ b/armbian/base/config/redis/factorysettings.txt
@@ -12,8 +12,12 @@ SET base:updating 0
 
 SET tor:base:enabled 1
 SET tor:ssh:enabled 0
+SET tor:ssh:onion xxx
 SET tor:electrs:enabled 1
+SET tor:electrs:onion xxx
 SET tor:bbbmiddleware:enabled 1
+SET tor:bbbmiddleware:onion xxx
+SET tor:lightningd:onion xxx
 
 SET bitcoind:version xxx
 SET bitcoind:ibd 1

--- a/armbian/base/config/templates/torrc.template
+++ b/armbian/base/config/templates/torrc.template
@@ -7,14 +7,14 @@ HiddenServiceDir /var/lib/tor/hidden_service_ssh/           {{ tor:ssh:enabled #
 HiddenServiceVersion 3                                      {{ tor:ssh:enabled #rmLineFalse }}
 HiddenServicePort 22 127.0.0.1:22                           {{ tor:ssh:enabled #rmLineFalse }}
 
-HiddenServiceDir /var/lib/tor/hidden_service_electrum/      {{ tor:electrs:enabled #rmLineFalse }}
+HiddenServiceDir /var/lib/tor/hidden_service_electrs/       {{ tor:electrs:enabled #rmLineFalse }}
 HiddenServiceVersion 3                                      {{ tor:electrs:enabled #rmLineFalse }}
 HiddenServicePort 50002 127.0.0.1:50002                     {{ tor:electrs:enabled #rmLineFalse }}
 
-HiddenServiceDir /var/lib/tor/lightningd-service_v3/        {{ tor:base:enabled #rmLineFalse }}
+HiddenServiceDir /var/lib/tor/hidden_service_lightningd/    {{ tor:base:enabled #rmLineFalse }}
 HiddenServiceVersion 3                                      {{ tor:base:enabled #rmLineFalse }}
 HiddenServicePort 9375 127.0.0.1:9735                       {{ tor:base:enabled #rmLineFalse }}
 
-HiddenServiceDir /var/lib/tor/hidden_service_middleware/    {{ tor:bbbmiddleware:enabled #rmLineFalse }}
+HiddenServiceDir /var/lib/tor/hidden_service_bbbmiddleware/ {{ tor:bbbmiddleware:enabled #rmLineFalse }}
 HiddenServiceVersion 3                                      {{ tor:bbbmiddleware:enabled #rmLineFalse }}
 HiddenServicePort 9375 127.0.0.1:8845                       {{ tor:bbbmiddleware:enabled #rmLineFalse }}

--- a/armbian/base/scripts/include/updateTorOnions.sh.inc
+++ b/armbian/base/scripts/include/updateTorOnions.sh.inc
@@ -1,0 +1,25 @@
+# function to update all .onion addresses in Redis
+#
+# note: bitcoind onion address is stored in Prometheus as 'bitcoin_tor_address'
+#
+function updateTorOnions() {
+    if [[ -f /var/lib/tor/hidden_service_ssh/hostname ]]; then
+        redis_set   "tor:ssh:onion" \
+                    "$(cat /var/lib/tor/hidden_service_ssh/hostname)"
+    fi
+
+    if [[ -f /var/lib/tor/hidden_service_electrs/hostname ]]; then
+        redis_set   "tor:electrs:onion" \
+                    "$(cat /var/lib/tor/hidden_service_electrs/hostname)"
+    fi
+
+    if [[ -f /var/lib/tor/hidden_service_lightningd/hostname ]]; then
+        redis_set   "tor:lightningd:onion" \
+                    "$(cat /var/lib/tor/hidden_service_lightningd/hostname)"
+    fi
+
+    if [[ -f /var/lib/tor/hidden_service_bbbmiddleware/hostname ]]; then
+        redis_set   "tor:bbbmiddleware:onion" \
+                    "$(cat /var/lib/tor/hidden_service_bbbmiddleware/hostname)"
+    fi
+}

--- a/armbian/base/scripts/systemd-update-checks.sh
+++ b/armbian/base/scripts/systemd-update-checks.sh
@@ -6,7 +6,7 @@
 # validation actions.
 #
 # The Redis config mgmt must available for this script.
-# 
+#
 set -eu
 
 # include function exec_overlayroot(), to execute a command, either within overlayroot-chroot or directly
@@ -21,6 +21,9 @@ source /opt/shift/scripts/include/generateConfig.sh.inc
 # include errorExit() function
 source /opt/shift/scripts/include/errorExit.sh.inc
 
+# include updateTorOnions() function
+source /opt/shift/scripts/include/updateTorOnions.sh.inc
+
 # ------------------------------------------------------------------------------
 
 redis_require
@@ -28,6 +31,9 @@ redis_require
 # update hardcoded firmware version
 VERSION=$(head -n1 /opt/shift/config/version)
 redis_set "base:version" "${VERSION}"
+
+# update onion addresses in Redis
+updateTorOnions
 
 # check if booting after update
 # valid status codes of 'base:updating'
@@ -119,12 +125,12 @@ else
     fi
 
     if [[ $(redis_get "base:updating") -eq 40 ]]; then
-        echo "OK: updated to BitBox Base version $(redis_get 'base:version')" 
+        echo "OK: updated to BitBox Base version $(redis_get 'base:version')"
         redis_set "base:updating" 0
     fi
 
     if [[ $(redis_get "base:updating") -ne 0 ]]; then
-        echo "ERR: undefined value $(redis_get 'base:updating') for Redis key 'base:updating'" 
+        echo "ERR: undefined value $(redis_get 'base:updating') for Redis key 'base:updating'"
     fi
 
 fi


### PR DESCRIPTION
https://github.com/shiftdevices/bitbox-base-internal/issues/281

Because:

* Redis is the central configuration store, so the .onion addresses
  of the hidden services of the Middleware, SSH, Electrs and Lighting
  should be readily available there.
* Hidden service names are harmonized (e.g. electrum --> electrs) to
  avoid confusion when referring to them on os-level / Redis / RPC
* The 'bbb-config get' command is no longer necessary, as its only
  purpose was to fetch the onion addresses.

This commit:

* adds uninitialized Redis keys (e.g. tor:ssh:onion = xxx) for onion
  addresses to the Redis factory settings
* harmonizes Tor hidden service names
* adds the function 'updateTorOnions()' as an include which is
  called when enabling/disabling Tor or individual services
* this include is also called on startup, after Redis is ready
* removes the 'bbb-config.sh' command
* removes some unnecessary whitespaces

Note:

* The Tor connection of bitcoind is managed by bitcoind directly. This
  is why it is frequently queried by the Prometheus scraper and the
  current value is stored in Prometheus in 'bitcoin_tor_address'