### PR TITLE
middleware: handle binary setting calls with rpcmessage, not bool

### DIFF
--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -30,14 +30,14 @@ type Middleware interface {
 	SetHostname(rpcmessages.SetHostnameArgs) rpcmessages.ErrorResponse
 	RestoreSysconfig() rpcmessages.ErrorResponse
 	RestoreHSMSecret() rpcmessages.ErrorResponse
-	EnableTor(bool) rpcmessages.ErrorResponse
-	EnableTorMiddleware(bool) rpcmessages.ErrorResponse
-	EnableTorElectrs(bool) rpcmessages.ErrorResponse
-	EnableTorSSH(bool) rpcmessages.ErrorResponse
-	EnableClearnetIBD(bool) rpcmessages.ErrorResponse
+	EnableTor(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
+	EnableTorMiddleware(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
+	EnableTorElectrs(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
+	EnableTorSSH(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
+	EnableClearnetIBD(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
-	EnableRootLogin(bool) rpcmessages.ErrorResponse
+	EnableRootLogin(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
 	GetBaseVersion() rpcmessages.GetBaseVersionResponse
 	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -31,14 +31,6 @@ type Middleware struct {
 	dummyAdminPassword string
 }
 
-const (
-	// Since enable and disable are two often-used parameters passed to bbb-config
-	// and golangci-lint fails because of "string `disable` has 3 occurrences, make it a constant (goconst)"
-	// they are constants.
-	enableAction  string = "enable"
-	disableAction string = "disable"
-)
-
 // NewMiddleware returns a new instance of the middleware.
 // For testing a mock boolean can be passed, which mocks e.g. redis.
 func NewMiddleware(argumentMap map[string]string, mock bool) *Middleware {
@@ -354,76 +346,48 @@ func (middleware *Middleware) GetHostname() rpcmessages.GetHostnameResponse {
 	}
 }
 
-// EnableTor enables/disables the tor.service and configures bitcoind and lightningd based on the passed boolean argument
+// EnableTor enables/disables the tor.service and configures bitcoind and lightningd based on the passed ToggleSettingEnable/Disable argument
 // and returns a ErrorResponse indicating if the call was successful.
-func (middleware *Middleware) EnableTor(enable bool) rpcmessages.ErrorResponse {
-	var action string
-	if enable {
-		log.Println("Enabling Tor via the config script")
-		action = enableAction
-	} else {
-		log.Println("Disabling Tor via the config script")
-		action = disableAction
-	}
+func (middleware *Middleware) EnableTor(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
+	log.Printf("Executing '%s Tor' via the config script.\n", toggleAction)
 
-	out, err := middleware.runBBBConfigScript(action, "tor", "")
+	out, err := middleware.runBBBConfigScript(string(toggleAction), "tor", "")
 	if err != nil {
 		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
 	}
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
-// EnableTorMiddleware enables/disables the tor hidden service for the middleware based on the passed boolean argument
+// EnableTorMiddleware enables/disables the tor hidden service for the middleware based on the passed ToggleSettingEnable/Disable argument
 // and returns a ErrorResponse indicating if the call was successful.
-func (middleware *Middleware) EnableTorMiddleware(enable bool) rpcmessages.ErrorResponse {
-	var action string
-	if enable {
-		log.Println("Enabling Tor for the middleware via the config script")
-		action = enableAction
-	} else {
-		log.Println("Disabling Tor for the middleware via the config script")
-		action = disableAction
-	}
+func (middleware *Middleware) EnableTorMiddleware(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
+	log.Printf("Executing '%s Tor for middleware' via the config script.\n", toggleAction)
 
-	out, err := middleware.runBBBConfigScript(action, "tor_bbbmiddleware", "")
+	out, err := middleware.runBBBConfigScript(string(toggleAction), "tor_bbbmiddleware", "")
 	if err != nil {
 		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
 	}
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
-// EnableTorElectrs enables/disables the tor hidden service for electrs based on the passed boolean argument
+// EnableTorElectrs enables/disables the tor hidden service for electrs based on the passed ToggleSettingEnable/Disable argument
 // and returns a ErrorResponse indicating if the call was successful.
-func (middleware *Middleware) EnableTorElectrs(enable bool) rpcmessages.ErrorResponse {
-	var action string
-	if enable {
-		log.Println("Enabling Tor for electrs via the config script")
-		action = enableAction
-	} else {
-		log.Println("Disabling Tor for electrs via the config script")
-		action = disableAction
-	}
+func (middleware *Middleware) EnableTorElectrs(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
+	log.Printf("Executing '%s Tor for electrs' via the config script.\n", toggleAction)
 
-	out, err := middleware.runBBBConfigScript(action, "tor_electrs", "")
+	out, err := middleware.runBBBConfigScript(string(toggleAction), "tor_electrs", "")
 	if err != nil {
 		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
 	}
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
-// EnableTorSSH enables/disables the tor hidden service for ssh based on the passed boolean argument
+// EnableTorSSH enables/disables the tor hidden service for ssh based on the passed ToggleSettingEnable/Disable argument
 // and returns a ErrorResponse indicating if the call was successful.
-func (middleware *Middleware) EnableTorSSH(enable bool) rpcmessages.ErrorResponse {
-	var action string
-	if enable {
-		log.Println("Enabling Tor for ssh via the config script")
-		action = enableAction
-	} else {
-		log.Println("Disabling Tor for ssh via the config script")
-		action = disableAction
-	}
+func (middleware *Middleware) EnableTorSSH(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
+	log.Printf("Executing '%s Tor for ssh' via the config script.\n", toggleAction)
 
-	out, err := middleware.runBBBConfigScript(action, "tor_ssh", "")
+	out, err := middleware.runBBBConfigScript(string(toggleAction), "tor_ssh", "")
 	if err != nil {
 		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
 	}
@@ -431,18 +395,11 @@ func (middleware *Middleware) EnableTorSSH(enable bool) rpcmessages.ErrorRespons
 }
 
 // EnableClearnetIBD sets the initial block download over clearnet to either true or false
-// based on the passed boolean argument and returns a ErrorResponse indicating if the call was successful.
-func (middleware *Middleware) EnableClearnetIBD(enable bool) rpcmessages.ErrorResponse {
-	var value string
-	if enable {
-		log.Println("Setting clearnet IDB to true via the config script")
-		value = "true"
-	} else {
-		log.Println("Setting clearnet IDB to false via the config script")
-		value = "false"
-	}
+// based on the passed ToggleSettingEnable/Disable argument and returns a ErrorResponse indicating if the call was successful.
+func (middleware *Middleware) EnableClearnetIBD(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
+	log.Printf("Executing '%s clearnet IBD' via the config script.\n", toggleAction)
 
-	out, err := middleware.runBBBConfigScript("set", "bitcoin_ibd_clearnet", value)
+	out, err := middleware.runBBBConfigScript(string(toggleAction), "bitcoin_ibd_clearnet", "")
 	if err != nil {
 		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
 	}
@@ -495,17 +452,10 @@ func (middleware *Middleware) GetBaseVersion() rpcmessages.GetBaseVersionRespons
 
 // EnableRootLogin enables/disables the login via the root user/password
 // and returns a ErrorResponse indicating if the call was successful.
-func (middleware *Middleware) EnableRootLogin(enable bool) rpcmessages.ErrorResponse {
-	var action string
-	if enable {
-		log.Println("Enabling root login via the config script")
-		action = enableAction
-	} else {
-		log.Println("Disabling root login via the config script")
-		action = disableAction
-	}
+func (middleware *Middleware) EnableRootLogin(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
+	log.Printf("Executing '%s root login' via the config script.\n", toggleAction)
 
-	out, err := middleware.runBBBConfigScript(action, "root_pwlogin", "")
+	out, err := middleware.runBBBConfigScript(string(toggleAction), "root_pwlogin", "")
 	if err != nil {
 		return rpcmessages.ErrorResponse{Success: false, Message: string(out), Code: err.Error()}
 	}

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -138,12 +138,12 @@ func TestRestoreSysconfig(t *testing.T) {
 func TestEnableTor(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableTor(true)
+	responseEnable := testMiddleware.EnableTor(rpcmessages.ToggleSettingEnable)
 	require.Equal(t, responseEnable.Success, true)
 	require.Equal(t, responseEnable.Message, "")
 	require.Equal(t, responseEnable.Code, "")
 
-	responseDisable := testMiddleware.EnableTor(false)
+	responseDisable := testMiddleware.EnableTor(rpcmessages.ToggleSettingDisable)
 	require.Equal(t, responseDisable.Success, true)
 	require.Equal(t, responseDisable.Message, "")
 	require.Equal(t, responseDisable.Code, "")
@@ -152,12 +152,12 @@ func TestEnableTor(t *testing.T) {
 func TestEnableTorMiddleware(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableTorMiddleware(true)
+	responseEnable := testMiddleware.EnableTorMiddleware(rpcmessages.ToggleSettingEnable)
 	require.Equal(t, responseEnable.Success, true)
 	require.Equal(t, responseEnable.Message, "")
 	require.Equal(t, responseEnable.Code, "")
 
-	responseDisable := testMiddleware.EnableTorMiddleware(false)
+	responseDisable := testMiddleware.EnableTorMiddleware(rpcmessages.ToggleSettingDisable)
 	require.Equal(t, responseDisable.Success, true)
 	require.Equal(t, responseDisable.Message, "")
 	require.Equal(t, responseDisable.Code, "")
@@ -166,12 +166,12 @@ func TestEnableTorMiddleware(t *testing.T) {
 func TestEnableTorElectrs(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableTorElectrs(true)
+	responseEnable := testMiddleware.EnableTorElectrs(rpcmessages.ToggleSettingEnable)
 	require.Equal(t, responseEnable.Success, true)
 	require.Equal(t, responseEnable.Message, "")
 	require.Equal(t, responseEnable.Code, "")
 
-	responseDisable := testMiddleware.EnableTorElectrs(false)
+	responseDisable := testMiddleware.EnableTorElectrs(rpcmessages.ToggleSettingDisable)
 	require.Equal(t, responseDisable.Success, true)
 	require.Equal(t, responseDisable.Message, "")
 	require.Equal(t, responseDisable.Code, "")
@@ -180,12 +180,12 @@ func TestEnableTorElectrs(t *testing.T) {
 func TestEnableClearnetIBD(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableClearnetIBD(true)
+	responseEnable := testMiddleware.EnableClearnetIBD(rpcmessages.ToggleSettingEnable)
 	require.Equal(t, responseEnable.Success, true)
 	require.Equal(t, responseEnable.Message, "")
 	require.Equal(t, responseEnable.Code, "")
 
-	responseDisable := testMiddleware.EnableClearnetIBD(false)
+	responseDisable := testMiddleware.EnableClearnetIBD(rpcmessages.ToggleSettingDisable)
 	require.Equal(t, responseDisable.Success, true)
 	require.Equal(t, responseDisable.Message, "")
 	require.Equal(t, responseDisable.Code, "")
@@ -194,12 +194,12 @@ func TestEnableClearnetIBD(t *testing.T) {
 func TestEnableTorSSH(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableTorSSH(true)
+	responseEnable := testMiddleware.EnableTorSSH(rpcmessages.ToggleSettingEnable)
 	require.Equal(t, responseEnable.Success, true)
 	require.Equal(t, responseEnable.Message, "")
 	require.Equal(t, responseEnable.Code, "")
 
-	responseDisable := testMiddleware.EnableTorSSH(false)
+	responseDisable := testMiddleware.EnableTorSSH(rpcmessages.ToggleSettingDisable)
 	require.Equal(t, responseDisable.Success, true)
 	require.Equal(t, responseDisable.Message, "")
 	require.Equal(t, responseDisable.Code, "")
@@ -208,12 +208,12 @@ func TestEnableTorSSH(t *testing.T) {
 func TestEnableRootLogin(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableRootLogin(true)
+	responseEnable := testMiddleware.EnableRootLogin(rpcmessages.ToggleSettingEnable)
 	require.Equal(t, responseEnable.Success, true)
 	require.Equal(t, responseEnable.Message, "")
 	require.Equal(t, responseEnable.Code, "")
 
-	responseDisable := testMiddleware.EnableRootLogin(false)
+	responseDisable := testMiddleware.EnableRootLogin(rpcmessages.ToggleSettingDisable)
 	require.Equal(t, responseDisable.Success, true)
 	require.Equal(t, responseDisable.Message, "")
 	require.Equal(t, responseDisable.Code, "")

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -40,6 +40,15 @@ type SetRootPasswordArgs struct {
 	RootPassword string
 }
 
+// ToggleSetting is a generic message for settings that can be enabled or disabled
+type ToggleSetting string
+
+// Consts for toggling a setting which is done by passing "enable" or "disable" to the corresponding shell script
+const (
+	ToggleSettingEnable  ToggleSetting = "enable"
+	ToggleSettingDisable ToggleSetting = "disable"
+)
+
 /*
 Put Response structs below this line. They should have the format of 'RPC Method Name' + 'Response'.
 */

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -61,14 +61,14 @@ type Middleware interface {
 	RestoreSysconfig() rpcmessages.ErrorResponse
 	RestoreHSMSecret() rpcmessages.ErrorResponse
 	SampleInfo() rpcmessages.SampleInfoResponse
-	EnableTor(bool) rpcmessages.ErrorResponse
-	EnableTorMiddleware(bool) rpcmessages.ErrorResponse
-	EnableTorElectrs(bool) rpcmessages.ErrorResponse
-	EnableTorSSH(bool) rpcmessages.ErrorResponse
-	EnableClearnetIBD(bool) rpcmessages.ErrorResponse
+	EnableTor(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
+	EnableTorMiddleware(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
+	EnableTorElectrs(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
+	EnableTorSSH(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
+	EnableClearnetIBD(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
-	EnableRootLogin(bool) rpcmessages.ErrorResponse
+	EnableRootLogin(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
 	GetBaseVersion() rpcmessages.GetBaseVersionResponse
 	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
@@ -210,8 +210,8 @@ func (server *RPCServer) GetHostname(dummyArg bool, reply *rpcmessages.GetHostna
 // EnableTor enables/disables the tor.service and configures bitcoind and lightningd.
 // The boolean argument passed is used to for enabling and disabling.
 // It sends the middleware's ErrorResponse over rpc.
-func (server *RPCServer) EnableTor(enable bool, reply *rpcmessages.ErrorResponse) error {
-	*reply = server.middleware.EnableTor(enable)
+func (server *RPCServer) EnableTor(toggleAction rpcmessages.ToggleSetting, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableTor(toggleAction)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }
@@ -219,8 +219,8 @@ func (server *RPCServer) EnableTor(enable bool, reply *rpcmessages.ErrorResponse
 // EnableTorMiddleware enables/disables the tor hidden service for the middleware.
 // The boolean argument passed is used to for enabling and disabling.
 // It sends the middleware's ErrorResponse over rpc.
-func (server *RPCServer) EnableTorMiddleware(enable bool, reply *rpcmessages.ErrorResponse) error {
-	*reply = server.middleware.EnableTorMiddleware(enable)
+func (server *RPCServer) EnableTorMiddleware(toggleAction rpcmessages.ToggleSetting, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableTorMiddleware(toggleAction)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }
@@ -228,8 +228,8 @@ func (server *RPCServer) EnableTorMiddleware(enable bool, reply *rpcmessages.Err
 // EnableTorElectrs enables/disables the tor hidden service for Electrs.
 // The boolean argument passed is used to for enabling and disabling.
 // It sends the middleware's ErrorResponse over rpc.
-func (server *RPCServer) EnableTorElectrs(enable bool, reply *rpcmessages.ErrorResponse) error {
-	*reply = server.middleware.EnableTorElectrs(enable)
+func (server *RPCServer) EnableTorElectrs(toggleAction rpcmessages.ToggleSetting, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableTorElectrs(toggleAction)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }
@@ -237,8 +237,8 @@ func (server *RPCServer) EnableTorElectrs(enable bool, reply *rpcmessages.ErrorR
 // EnableTorSSH enables/disables the tor hidden service for SSH.
 // The boolean argument passed is used to for enabling and disabling.
 // It sends the middleware's ErrorResponse over rpc.
-func (server *RPCServer) EnableTorSSH(enable bool, reply *rpcmessages.ErrorResponse) error {
-	*reply = server.middleware.EnableTorSSH(enable)
+func (server *RPCServer) EnableTorSSH(toggleAction rpcmessages.ToggleSetting, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableTorSSH(toggleAction)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }
@@ -246,8 +246,8 @@ func (server *RPCServer) EnableTorSSH(enable bool, reply *rpcmessages.ErrorRespo
 // EnableClearnetIBD enables/disables the tor hidden service for SSH.
 // The boolean argument passed is used to for enabling and disabling.
 // It sends the middleware's ErrorResponse over rpc.
-func (server *RPCServer) EnableClearnetIBD(enable bool, reply *rpcmessages.ErrorResponse) error {
-	*reply = server.middleware.EnableClearnetIBD(enable)
+func (server *RPCServer) EnableClearnetIBD(toggleAction rpcmessages.ToggleSetting, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableClearnetIBD(toggleAction)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }
@@ -271,8 +271,8 @@ func (server *RPCServer) RebootBase(dummyArg bool, reply *rpcmessages.ErrorRespo
 // EnableRootLogin enables/disables login via the root user/password.
 // The boolean argument passed is used to for enabling and disabling.
 // It sends the middleware's ErrorResponse over rpc.
-func (server *RPCServer) EnableRootLogin(enable bool, reply *rpcmessages.ErrorResponse) error {
-	*reply = server.middleware.EnableRootLogin(enable)
+func (server *RPCServer) EnableRootLogin(toggleAction rpcmessages.ToggleSetting, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableRootLogin(toggleAction)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -149,51 +149,51 @@ func TestRPCServer(t *testing.T) {
 	require.Equal(t, true, restoreSysconfigReply.Success)
 
 	var enableTorReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTor", true, &enableTorReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTor", rpcmessages.ToggleSettingEnable, &enableTorReply)
 	require.Equal(t, true, enableTorReply.Success)
 
 	var disableTorReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTor", false, &disableTorReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTor", rpcmessages.ToggleSettingDisable, &disableTorReply)
 	require.Equal(t, true, disableTorReply.Success)
 
 	var enableTorMiddlewareReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorMiddleware", true, &enableTorMiddlewareReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorMiddleware", rpcmessages.ToggleSettingEnable, &enableTorMiddlewareReply)
 	require.Equal(t, true, enableTorMiddlewareReply.Success)
 
 	var disableTorMiddlewareReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorMiddleware", false, &disableTorMiddlewareReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorMiddleware", rpcmessages.ToggleSettingDisable, &disableTorMiddlewareReply)
 	require.Equal(t, true, disableTorMiddlewareReply.Success)
 
 	var enableTorElectrsReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorElectrs", true, &enableTorElectrsReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorElectrs", rpcmessages.ToggleSettingEnable, &enableTorElectrsReply)
 	require.Equal(t, true, enableTorElectrsReply.Success)
 
 	var disableTorElectrsReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorElectrs", false, &disableTorElectrsReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorElectrs", rpcmessages.ToggleSettingDisable, &disableTorElectrsReply)
 	require.Equal(t, true, disableTorElectrsReply.Success)
 
 	var enableTorSSHReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorSSH", true, &enableTorSSHReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorSSH", rpcmessages.ToggleSettingEnable, &enableTorSSHReply)
 	require.Equal(t, true, enableTorSSHReply.Success)
 
 	var disableTorSSHReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorSSH", false, &disableTorSSHReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorSSH", rpcmessages.ToggleSettingDisable, &disableTorSSHReply)
 	require.Equal(t, true, disableTorSSHReply.Success)
 
 	var enableClearnetIBDReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableClearnetIBD", true, &enableClearnetIBDReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableClearnetIBD", rpcmessages.ToggleSettingEnable, &enableClearnetIBDReply)
 	require.Equal(t, true, enableClearnetIBDReply.Success)
 
 	var disableClearnetIBDReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableClearnetIBD", false, &disableClearnetIBDReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableClearnetIBD", rpcmessages.ToggleSettingDisable, &disableClearnetIBDReply)
 	require.Equal(t, true, disableClearnetIBDReply.Success)
 
 	var enableRootLoginReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", true, &enableRootLoginReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", rpcmessages.ToggleSettingEnable, &enableRootLoginReply)
 	require.Equal(t, true, enableRootLoginReply.Success)
 
 	var disableRootLoginReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", false, &disableRootLoginReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", rpcmessages.ToggleSettingDisable, &disableRootLoginReply)
 	require.Equal(t, true, disableRootLoginReply.Success)
 
 	userAuthenticateArg := rpcmessages.UserAuthenticateArgs{Username: "admin", Password: "ICanHasPassword?"}


### PR DESCRIPTION
This commit uses the new ToggleSetting type to handle enabling or
disabling Base settings that have binary options.
This is for two reasons:
1. All parameters used in rpc calls should come from rpcmessages.go as discussed with @TheCharlatan 
2. Simplify middleware methods so there is no need for global
"enable/disable" variables and checking within each method call