### PR TITLE
middleware: add first version of GetBaseInfo RPC

### DIFF
--- a/middleware/cmd/middleware/main.go
+++ b/middleware/cmd/middleware/main.go
@@ -16,6 +16,7 @@ import (
 const version string = "0.0.1"
 
 func main() {
+	middlewarePort := flag.String("middlewareport", "8845", "Port the middleware should listen on (default 8845)")
 	bitcoinRPCUser := flag.String("rpcuser", "rpcuser", "Bitcoin rpc user name")
 	bitcoinRPCPassword := flag.String("rpcpassword", "rpcpassword", "Bitcoin rpc password")
 	bitcoinRPCPort := flag.String("rpcport", "18332", "Bitcoin rpc port, localhost is assumed as an address")
@@ -30,6 +31,7 @@ func main() {
 	flag.Parse()
 
 	argumentMap := make(map[string]string)
+	argumentMap["middlewarePort"] = *middlewarePort
 	argumentMap["bitcoinRPCUser"] = *bitcoinRPCUser
 	argumentMap["bitcoinRPCPassword"] = *bitcoinRPCPassword
 	argumentMap["bitcoinRPCPort"] = *bitcoinRPCPort
@@ -55,9 +57,9 @@ func main() {
 	log.Println("--------------- Started middleware --------------")
 
 	handlers := handlers.NewHandlers(middleware, *dataDir)
-	log.Println("Binding middleware api to port 8845")
+	log.Printf("Binding middleware api to port %s\n", *middlewarePort)
 
-	if err := http.ListenAndServe(":8845", handlers.Router); err != nil {
+	if err := http.ListenAndServe(":"+*middlewarePort, handlers.Router); err != nil {
 		log.Println(err.Error() + " Failed to listen for HTTP")
 	}
 }

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -27,7 +27,6 @@ type Middleware interface {
 	ReindexBitcoin() rpcmessages.ErrorResponse
 	BackupSysconfig() rpcmessages.ErrorResponse
 	BackupHSMSecret() rpcmessages.ErrorResponse
-	GetHostname() rpcmessages.GetHostnameResponse
 	SetHostname(rpcmessages.SetHostnameArgs) rpcmessages.ErrorResponse
 	RestoreSysconfig() rpcmessages.ErrorResponse
 	RestoreHSMSecret() rpcmessages.ErrorResponse
@@ -39,7 +38,7 @@ type Middleware interface {
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
 	EnableRootLogin(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
-	GetBaseVersion() rpcmessages.GetBaseVersionResponse
+	GetBaseInfo() rpcmessages.GetBaseInfoResponse
 	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -21,7 +21,7 @@ func setupTestMiddleware() *middleware.Middleware {
 	/* The config and cmd script are mocked with /bin/echo which just returns
 	the passed arguments. The real scripts can't be used here, because
 	- the absolute location of those is different on each host this is run on
-	- the relative location is differen depending here the tests are run from
+	- the relative location is different depending here the tests are run from
 	*/
 	argumentMap["bbbConfigScript"] = "/bin/echo"
 	argumentMap["bbbCmdScript"] = "/bin/echo"
@@ -330,16 +330,6 @@ func TestUserChangePassword(t *testing.T) {
 	require.Equal(t, "password change unsuccessful (too short)", changepasswordEmpty.Message)
 }
 
-func TestGetHostname(t *testing.T) {
-	testMiddleware := setupTestMiddleware()
-	response := testMiddleware.GetHostname()
-
-	require.Equal(t, false, response.ErrorResponse.Success)
-	require.Equal(t, "GetHostname is not implemnted", response.ErrorResponse.Message)
-	require.Equal(t, rpcmessages.ErrorUnexpected, response.ErrorResponse.Code)
-	require.Equal(t, "", response.Hostname)
-}
-
 func TestSetHostname(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
@@ -378,15 +368,6 @@ func TestSetHostname(t *testing.T) {
 	response7 := testMiddleware.SetHostname(invalidArgs4)
 	require.Equal(t, false, response7.Success)
 	require.Equal(t, "invalid hostname", response7.Message)
-}
-
-func TestGetBaseVersion(t *testing.T) {
-	testMiddleware := setupTestMiddleware()
-
-	response := testMiddleware.GetBaseVersion()
-	require.Equal(t, true, response.ErrorResponse.Success)
-	require.Equal(t, "0.0.1", response.Version)
-	require.Equal(t, rpcmessages.ErrorCode(""), response.ErrorResponse.Code)
 }
 
 func TestShutdownBase(t *testing.T) {

--- a/middleware/src/prometheus/prometheus.go
+++ b/middleware/src/prometheus/prometheus.go
@@ -1,12 +1,14 @@
 package prometheus
 
 import (
-	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"time"
 
+	"github.com/digitalbitbox/bitbox-base/middleware/src/rpcmessages"
 	"github.com/tidwall/gjson"
 )
 
@@ -14,76 +16,236 @@ const (
 	success = "success"
 )
 
-type PromClient struct {
+// response represents a Prometheus response returned by the query() function
+type response string
+
+// resultType represents a Prometheus JSON result type
+// The resultType is specified by the value of `data.resultType` in the JSON result
+type resultType string
+
+const (
+	vector resultType = "vector"
+)
+
+// Client is a Prometheus client
+type Client struct {
 	address string
 }
 
-func NewPromClient(address string) *PromClient {
-	return &PromClient{
+// NewClient returns a new Prometheus client.
+// It does not ensure that the client has connectivity.
+func NewClient(address string) Client {
+	return Client{
 		address: address,
 	}
 }
 
-func (client *PromClient) query(endpoint string) (string, error) {
+// query queries the Prometheus server and returns the response.
+/* Dummy Prometheus JSON response with the resultType being "vector":
+  {
+		"status": "success",
+		"data": {
+			"resultType": "vector",
+			"result": [
+				{
+					"metric": {
+						"__name__": "base_system_info",
+						<metric>: <value>,
+					},
+					"value": [
+						<timestamp>,
+						<value>
+					]
+				}
+			]
+		}
+  }
+*/
+func (client *Client) query(query BasePrometheusQuery) (response, error) {
 	httpClient := http.Client{
 		Timeout: 5 * time.Second,
 	}
-	response, err := httpClient.Get(client.address + "/api/v1/query?query=" + endpoint)
+
+	escapedQuery := url.QueryEscape(string(query))
+	queryURL := client.address + "/api/v1/query?query=" + escapedQuery
+
+	resp, err := httpClient.Get(queryURL)
 	if err != nil {
-		log.Printf("HTTP Error")
-		return "", err
+		return "", fmt.Errorf("a HTTP error occurred: %s", err.Error())
 	}
-	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		log.Println("Could not read prometheus response body")
-		return "", err
+		return "", fmt.Errorf("could not read response body: %s", err.Error())
 	}
 	bodyString := string(body)
 	if !gjson.Valid(bodyString) {
-		log.Println("Received unvalid json from prometheus")
-		return "", errors.New("received Invalid json from Prometheus")
+		return "", fmt.Errorf("received invalid JSON from as result of the Prometheus query: %s", bodyString)
 	}
 	if success != gjson.Get(bodyString, "status").String() {
-		log.Println("Failed")
-		return "", nil
+		return "", fmt.Errorf("the Prometheus query failed: %s", bodyString)
 	}
 
-	return bodyString, nil
+	return response(bodyString), nil
 }
 
-func (client *PromClient) Headers() int64 {
-	response, err := client.query("bitcoin_headers")
+// checkResultType compares the result type of a Prometheus query to a passed expected result type.
+// If the result type of the response is not equal to the passed type then an error is returend.
+func (r response) checkResultType(expected resultType) error {
+	queryResultType := gjson.Get(string(r), "data.resultType")
+	if !queryResultType.Exists() {
+		return fmt.Errorf("the JSON response does not have a field 'data.resultType'")
+	}
+	if queryResultType.String() != string(expected) {
+		return fmt.Errorf("the JSON response field 'data.resultType' does not match the expected value of '%s'. It's '%s'", string(expected), queryResultType.String())
+	}
+	return nil
+}
+
+// getFirstResultValue returns the value of the first result of a JSON response from Prometheus.
+// The first result value is that is being queried for by when not quering for a information over a time range.
+// This function expects a string representing a Prometheus JSON response with `data.resultType` equaling `"vector"`.
+func (r response) getFirstResultValue() (value gjson.Result, err error) {
+	err = r.checkResultType(vector)
 	if err != nil {
-		log.Println(err.Error())
+		return value, err
+	}
+
+	queryResult := gjson.Get(string(r), "data.result")
+	if !queryResult.Exists() {
+		return value, fmt.Errorf("the query result does not have '%s'", "data.result")
+	}
+	queryResults := queryResult.Array()
+	if len(queryResults) == 0 {
+		return value, fmt.Errorf("the query result does not have any result entries")
+	}
+	queryResultValue := queryResults[0].Map()["value"]
+	if !queryResultValue.Exists() {
+		return value, fmt.Errorf("the query result does not have '%s'", "data.result[0]['values']")
+	}
+	queryResultValues := queryResultValue.Array()
+	if len(queryResultValues) < 2 {
+		return value, fmt.Errorf("the first query result value has less than two entries")
+	}
+
+	// queryResultValues is a parsed JSON array of [<timestamp>,<value>]
+	value = queryResultValues[1]
+	return value, nil
+}
+
+// getMetricsMap returns the metrics map that a Prometheus response can include.
+// The metrics map includes for example string key value pairs and are sometime
+// used to store non-integer values in Prometheus.
+func (r response) getMetricsMap() (metricMap map[string]gjson.Result, err error) {
+	err = r.checkResultType(vector)
+	if err != nil {
+		return metricMap, err
+	}
+
+	queryResult := gjson.Get(string(r), "data.result")
+	if !queryResult.Exists() {
+		return metricMap, fmt.Errorf("the query result does not have '%s'", "data.result")
+	}
+	queryResults := queryResult.Array()
+	if len(queryResults) == 0 {
+		return metricMap, fmt.Errorf("the query result does not have any result entries")
+	}
+	queryResultMetric := queryResults[0].Map()["metric"]
+	if !queryResultMetric.Exists() {
+		return metricMap, fmt.Errorf("the query result does not have '%s'", "data.result[0]['metric']")
+	}
+
+	metricMap = queryResultMetric.Map()
+	return metricMap, nil
+}
+
+// GetFloat queries Prometheus with the provided query and returns an int64.
+func (client *Client) GetFloat(query BasePrometheusQuery) (float64, error) {
+	response, err := client.query(query)
+	if err != nil {
+		return 0, fmt.Errorf("could not query an integer for query '%s': %s", query, err.Error())
+	}
+	value, err := response.getFirstResultValue()
+	if err != nil {
+		return 0, fmt.Errorf("could not get the first result value from '%s': %s", response, err.Error())
+	}
+
+	return value.Float(), nil
+}
+
+// GetInt queries Prometheus with the provided query and returns an int64.
+func (client *Client) GetInt(query BasePrometheusQuery) (int64, error) {
+	response, err := client.query(query)
+	if err != nil {
+		return 0, fmt.Errorf("could not query an integer for query '%s': %s", query, err.Error())
+	}
+
+	value, err := response.getFirstResultValue()
+	if err != nil {
+		return 0, fmt.Errorf("could not get the first result value from '%s': %s", response, err.Error())
+	}
+
+	return value.Int(), nil
+}
+
+// GetMetricString gets a metric from a Prometheus query.
+// Metrics are returned by Prometheus as extra information for the result.
+func (client *Client) GetMetricString(query BasePrometheusQuery, metric string) (string, error) {
+	response, err := client.query(query)
+	if err != nil {
+		return "", fmt.Errorf("could not query '%s' from Prometheus: %s", query, err.Error())
+	}
+
+	metricsMap, err := response.getMetricsMap()
+	if err != nil {
+		return "", fmt.Errorf("could not read the metrics map from Prometheus (response: %s): %s", string(response), err.Error())
+	}
+
+	value := metricsMap[metric].String()
+	return value, nil
+}
+
+// ConvertErrorToErrorResponse converts an error returned by Prometheus to an ErrorResponse
+func (client Client) ConvertErrorToErrorResponse(err error) rpcmessages.ErrorResponse {
+	return rpcmessages.ErrorResponse{
+		Success: false,
+		Message: err.Error(),
+		Code:    rpcmessages.ErrorPrometheusError,
+	}
+}
+
+// Blocks returns the bitcoin block count from Prometheus
+// Deprecated: is needed util middleware.GetVerificationProgress is replaced by GetServiceInfo or refactored to use GetInt itself.
+func (client *Client) Blocks() int64 {
+	log.Println("Calling deprecated function prometheus.Blocks()")
+	blocks, err := client.GetInt(BitcoinBlockCount)
+	if err != nil {
+		log.Printf("Deprecated function Blocks(): %s", err.Error())
 		return 0
 	}
-	queryResult := gjson.Get(response, "data.result").Array()
-	firstResultValue := queryResult[0].Map()["value"].Array()
-	log.Println("result")
-	return firstResultValue[1].Int()
+	return blocks
 }
 
-func (client *PromClient) Blocks() int64 {
-	response, err := client.query("bitcoin_blocks")
+// Headers returns the bitcoin header count from Prometheus
+// Deprecated: is needed util middleware.GetVerificationProgress is replaced by GetServiceInfo or refactored to use GetInt itself.
+func (client *Client) Headers() int64 {
+	log.Println("Calling deprecated function prometheus.Headers()")
+	headers, err := client.GetInt(BitcoinHeaderCount)
 	if err != nil {
-		log.Println(err.Error())
+		log.Printf("Deprecated function Headers(): %s", err.Error())
 		return 0
 	}
-	queryResult := gjson.Get(response, "data.result").Array()
-	firstResultValue := queryResult[0].Map()["value"].Array()
-	log.Println("result")
-	return firstResultValue[1].Int()
+	return headers
 }
 
-func (client *PromClient) VerificationProgress() float64 {
-	response, err := client.query("bitcoin_verification_progress")
+// VerificationProgress returns the bitcoin verification progress from Prometheus
+// Deprecated: is needed util middleware.GetVerificationProgress is replaced by GetServiceInfo or refactored to use GetInt itself.
+func (client *Client) VerificationProgress() float64 {
+	log.Println("Calling deprecated function prometheus.VerificationProgress()")
+	verificationProgress, err := client.GetFloat(BitcoinVerificationProgress)
 	if err != nil {
-		log.Println(err.Error())
-		return 0.0
+		log.Printf("Deprecated function VerificationProgress(): %s", err.Error())
+		return 0
 	}
-	queryResult := gjson.Get(response, "data.result").Array()
-	firstResultValue := queryResult[0].Map()["value"].Array()
-	log.Println("result")
-	return firstResultValue[1].Float()
+	return verificationProgress
 }

--- a/middleware/src/prometheus/queries.go
+++ b/middleware/src/prometheus/queries.go
@@ -1,0 +1,16 @@
+package prometheus
+
+/* This file holds constants for the used Prometheus queries */
+
+// BasePrometheusQuery is a string representing a Prometheus query used in the BitBox Base.
+type BasePrometheusQuery string
+
+// Queries for the Prometheus server running on the Bitbox Base
+const (
+	BitcoinVerificationProgress BasePrometheusQuery = "bitcoin_verification_progress"
+	BitcoinBlockCount           BasePrometheusQuery = "bitcoin_blocks"
+	BitcoinHeaderCount          BasePrometheusQuery = "bitcoin_headers"
+	BaseSystemInfo              BasePrometheusQuery = "base_system_info"
+	BaseFreeDiskspace           BasePrometheusQuery = "node_filesystem_free_bytes{fstype=\"ext4\", mountpoint=\"/mnt/ssd\"}"
+	BaseTotalDiskspace          BasePrometheusQuery = "node_filesystem_size_bytes{fstype=\"ext4\", mountpoint=\"/mnt/ssd\"}"
+)

--- a/middleware/src/redis/keys.go
+++ b/middleware/src/redis/keys.go
@@ -1,0 +1,18 @@
+package redis
+
+/* This file includes the redis keys used on the Bitbox Base */
+
+// BaseRedisKey is a string representing a Redis key used in the BitBox Base.
+type BaseRedisKey string
+
+// BitBox Base redis keys for configuration options.
+const (
+	BaseHostname      BaseRedisKey = "base:hostname"
+	TorEnabled        BaseRedisKey = "tor:base:enabled"
+	MiddlewareOnion   BaseRedisKey = "tor:bbbmiddleware:onion"
+	BitcoindListen    BaseRedisKey = "bitcoind:listen"
+	BaseVersion       BaseRedisKey = "base:version"
+	BitcoindVersion   BaseRedisKey = "bitcoind:version"
+	LightningdVersion BaseRedisKey = "lightningd:version"
+	ElectrsVersion    BaseRedisKey = "electrs:version"
+)

--- a/middleware/src/redis/redis_mock.go
+++ b/middleware/src/redis/redis_mock.go
@@ -2,6 +2,8 @@ package redis
 
 import (
 	"strconv"
+
+	"github.com/digitalbitbox/bitbox-base/middleware/src/rpcmessages"
 )
 
 // MockClient is a mock redis client
@@ -12,25 +14,67 @@ type MockClient struct {
 // NewMockClient returns a new redis client.
 // It does not ensure that the client has connectivity.
 func NewMockClient(port string) (mockClient *MockClient) {
-	mockRedisMap := make(map[string]string)
-	mockRedisMap["base:version"] = "0.0.1"
+	mockRedisMap := setupTestData()
 	return &MockClient{mockRedisMap: mockRedisMap}
 }
 
 // SetString sets a mock value to given key.
-func (mc *MockClient) SetString(key string, value string) error {
-	mc.mockRedisMap[key] = value
+func (mc *MockClient) SetString(key BaseRedisKey, value string) error {
+	mc.mockRedisMap[string(key)] = value
 	return nil
 }
 
 // GetInt gets an integer value for a given key.
-func (mc *MockClient) GetInt(key string) (val int, err error) {
-	s := mc.mockRedisMap[key]
+func (mc *MockClient) GetInt(key BaseRedisKey) (val int, err error) {
+	s := mc.mockRedisMap[string(key)]
 	val, err = strconv.Atoi(s)
 	return
 }
 
+// GetBool gets a boolean value for a given key.
+// Internally checks if the value for the given key is set to 1.
+// If so, then true is returned, else false.
+// GetInt gets an integer value for a given key.
+func (mc *MockClient) GetBool(key BaseRedisKey) (val bool, err error) {
+	s := mc.mockRedisMap[string(key)]
+	valAsInt, err := strconv.Atoi(s)
+	return valAsInt == 1, err
+}
+
 // GetString gets an string for a given key.
-func (mc *MockClient) GetString(key string) (val string, err error) {
-	return mc.mockRedisMap[key], nil
+func (mc *MockClient) GetString(key BaseRedisKey) (val string, err error) {
+	return mc.mockRedisMap[string(key)], nil
+}
+
+func setupTestData() map[string]string {
+	mockRedisMap := make(map[string]string)
+
+	// General mock data
+	mockRedisMap[string(BaseVersion)] = "0.0.1-redis-mock"
+	mockRedisMap[string(BaseHostname)] = "bitbox-base-redis-mock"
+	mockRedisMap[string(TorEnabled)] = "1"
+	mockRedisMap[string(BitcoindListen)] = "1"
+
+	// Specific test values for testing util.go getBooleanFromRedis()
+	// TestGetBooleanFromRedis() in util_test.go
+	mockRedisMap["test:getBooleanFromRedis:true"] = "1"
+	mockRedisMap["test:getBooleanFromRedis:false1"] = "0"
+	mockRedisMap["test:getBooleanFromRedis:false2"] = "3"
+	mockRedisMap["test:getBooleanFromRedis:false3"] = "abc"
+
+	// Specific test values for testing util.go getStringFromRedis()
+	// TestGetStringFromRedis() in util_test.go
+	mockRedisMap["test:getStringFromRedis:abc"] = "abc"
+	mockRedisMap["test:getStringFromRedis:empty"] = ""
+
+	return mockRedisMap
+}
+
+// ConvertErrorToErrorResponse converts an error returned by Redis to an ErrorResponse
+func (mc *MockClient) ConvertErrorToErrorResponse(err error) rpcmessages.ErrorResponse {
+	return rpcmessages.ErrorResponse{
+		Success: false,
+		Message: err.Error(),
+		Code:    rpcmessages.ErrorRedisError,
+	}
 }

--- a/middleware/src/rpcmessages/errorcodes.go
+++ b/middleware/src/rpcmessages/errorcodes.go
@@ -19,7 +19,11 @@ const (
 	// There is no differentiation of Redis errors because the front-end most likely handles them similar.
 	ErrorRedisError ErrorCode = "REDIS_ERROR"
 
-	// ErrorUnexpected is thrown when a a unknown/unhandled/unexpected error occurrs.
+	// ErrorPrometheusError is a general Prometheus related error.
+	// There is no differentiation of Prometheus errors because the front-end most likely handles them similar.
+	ErrorPrometheusError ErrorCode = "PROMETHEUS_ERROR"
+
+	// ErrorUnexpected is thrown when a a unknown/unhandled/unexpected error occurs.
 	// It's a catch-all error.
 	ErrorUnexpected ErrorCode = "UNEXPECTED_ERROR"
 )
@@ -33,7 +37,7 @@ const (
 	/* bbb-cmd.sh flashdrive check
 	-------------------------------*/
 
-	// ErrorFlashdriveCheckMultiple is thrown if multiple USB flashdrives are found. Needs exacly one.
+	// ErrorFlashdriveCheckMultiple is thrown if multiple USB flashdrives are found. Needs exactly one.
 	ErrorFlashdriveCheckMultiple ErrorCode = "FLASHDRIVE_CHECK_MULTI"
 	// ErrorFlashdriveCheckNone is thrown if no USB flashdrive is found.
 	ErrorFlashdriveCheckNone ErrorCode = "FLASHDRIVE_CHECK_NONE"
@@ -129,7 +133,7 @@ const (
 )
 
 const (
-	// ErrorDummyAuthenticationNotSuccessful is thrown if the dummy autentication is not successful.
+	// ErrorDummyAuthenticationNotSuccessful is thrown if the dummy authentication is not successful.
 	ErrorDummyAuthenticationNotSuccessful ErrorCode = "DUMMY_AUTHENTICATION_NOT_SUCCESSFUL"
 
 	// ErrorDummyPasswordTooShort is thrown if the provided password is too short.

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -67,16 +67,23 @@ type VerificationProgressResponse struct {
 	VerificationProgress float64 `json:"verificationProgress"`
 }
 
-// GetBaseVersionResponse is the struct that get sent by the rpc server during a GetBaseVersion rpc call
-type GetBaseVersionResponse struct {
-	ErrorResponse *ErrorResponse
-	Version       string
-}
-
-// GetHostnameResponse is the struct that get sent by the rpc server during a GetHostname rpc call
-type GetHostnameResponse struct {
-	ErrorResponse *ErrorResponse
-	Hostname      string
+// GetBaseInfoResponse is the struct that get sent by the rpc server during a GetBaseInfo rpc call
+type GetBaseInfoResponse struct {
+	ErrorResponse       *ErrorResponse
+	Status              string
+	Hostname            string
+	MiddlewareLocalIP   string
+	MiddlewareLocalPort string
+	MiddlewareTorOnion  string
+	MiddlewareTorPort   string
+	IsTorEnabled        bool
+	IsBitcoindListening bool
+	FreeDiskspace       int64 // in Byte
+	TotalDiskspace      int64 // in Byte
+	BaseVersion         string
+	BitcoindVersion     string
+	LightningdVersion   string
+	ElectrsVersion      string
 }
 
 // ErrorResponse is a generic RPC response indicating if a RPC call was successful or not.

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -54,7 +54,6 @@ type Middleware interface {
 	ReindexBitcoin() rpcmessages.ErrorResponse
 	BackupSysconfig() rpcmessages.ErrorResponse
 	BackupHSMSecret() rpcmessages.ErrorResponse
-	GetHostname() rpcmessages.GetHostnameResponse
 	SetHostname(rpcmessages.SetHostnameArgs) rpcmessages.ErrorResponse
 	RestoreSysconfig() rpcmessages.ErrorResponse
 	RestoreHSMSecret() rpcmessages.ErrorResponse
@@ -67,7 +66,7 @@ type Middleware interface {
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
 	EnableRootLogin(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
-	GetBaseVersion() rpcmessages.GetBaseVersionResponse
+	GetBaseInfo() rpcmessages.GetBaseInfoResponse
 	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
@@ -95,6 +94,13 @@ func NewRPCServer(middleware Middleware) *RPCServer {
 
 	return server
 }
+
+// Serve starts a gob rpc server
+func (server *RPCServer) Serve() {
+	rpc.ServeConn(server.RPCConnection)
+}
+
+/* --- Middleware RPCs start here --- */
 
 // GetSystemEnv sends the middleware's GetEnvResponse over rpc
 func (server *RPCServer) GetSystemEnv(dummyArg bool, reply *rpcmessages.GetEnvResponse) error {
@@ -176,17 +182,9 @@ func (server *RPCServer) UserChangePassword(args *rpcmessages.UserChangePassword
 }
 
 // SetHostname sends the middleware's ErrorResponse over rpc
-// The argument given specifys the hostname to be set
+// The argument given specifies the hostname to be set
 func (server *RPCServer) SetHostname(args *rpcmessages.SetHostnameArgs, reply *rpcmessages.ErrorResponse) error {
 	*reply = server.middleware.SetHostname(*args)
-	log.Printf("sent reply %v: ", reply)
-	return nil
-}
-
-// GetHostname sends the middleware's GetHostnameResponse over rpc
-// The GetHostnameResponse includes the current system hostname
-func (server *RPCServer) GetHostname(dummyArg bool, reply *rpcmessages.GetHostnameResponse) error {
-	*reply = server.middleware.GetHostname()
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }
@@ -271,14 +269,12 @@ func (server *RPCServer) SetRootPassword(args rpcmessages.SetRootPasswordArgs, r
 	return nil
 }
 
-// GetBaseVersion returns a GetBaseVersionResponse containing the base version.
-func (server *RPCServer) GetBaseVersion(dummyArg bool, reply *rpcmessages.GetBaseVersionResponse) error {
-	*reply = server.middleware.GetBaseVersion()
+// GetBaseInfo sends the middleware's GetBaseInfoResponse over rpc.
+// This includes information about the Base and the Middleware.
+func (server *RPCServer) GetBaseInfo(dummyArg bool, reply *rpcmessages.GetBaseInfoResponse) error {
+	*reply = server.middleware.GetBaseInfo()
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }
 
-// Serve starts a gob rpc server
-func (server *RPCServer) Serve() {
-	rpc.ServeConn(server.RPCConnection)
-}
+/* --- Middleware RPCs end here --- */

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -117,10 +117,6 @@ func TestRPCServer(t *testing.T) {
 	testingRPCServer.RunRPCCall(t, "RPCServer.SetHostname", setHostnameArg, &setHostnameReply)
 	require.Equal(t, true, setHostnameReply.Success)
 
-	var getHostnameReply rpcmessages.GetHostnameResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.GetHostname", dummyArg, &getHostnameReply)
-	require.Equal(t, false, getHostnameReply.ErrorResponse.Success)
-
 	var verificationProgressReply rpcmessages.VerificationProgressResponse
 	testingRPCServer.RunRPCCall(t, "RPCServer.GetVerificationProgress", dummyArg, &verificationProgressReply)
 
@@ -206,8 +202,10 @@ func TestRPCServer(t *testing.T) {
 	testingRPCServer.RunRPCCall(t, "RPCServer.RebootBase", dummyArg, &rebootBaseReply)
 	require.Equal(t, true, rebootBaseReply.Success)
 
-	var getBaseVersionReply rpcmessages.GetBaseVersionResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.GetBaseVersion", dummyArg, &getBaseVersionReply)
-	require.Equal(t, true, getBaseVersionReply.ErrorResponse.Success)
-
+	/*
+		This can't be unit tested until there is a Prometheus mock.
+			var baseInfoReply rpcmessages.GetBaseInfoResponse
+			testingRPCServer.RunRPCCall(t, "RPCServer.GetBaseInfo", dummyArg, &baseInfoReply)
+			require.Equal(t, true, baseInfoReply.ErrorResponse.Success)
+	*/
 }

--- a/middleware/src/system/system.go
+++ b/middleware/src/system/system.go
@@ -3,6 +3,7 @@ package system
 
 // Environment provides some information on the system we are running on.
 type Environment struct {
+	middlewarePort     string
 	Network            string `json:"network"`
 	ElectrsRPCPort     string `json:"electrsRPCPort"`
 	bitcoinRPCUser     string
@@ -21,6 +22,7 @@ type Environment struct {
 func NewEnvironment(argumentMap map[string]string) Environment {
 	// TODO(TheCharlatan) Instead of just accepting a long list of arguments, use a map here and check if the arguments can be read from a system config.
 	environment := Environment{
+		middlewarePort:     argumentMap["middlewarePort"],
 		bitcoinRPCUser:     argumentMap["bitcoinRPCUser"],
 		bitcoinRPCPassword: argumentMap["bitcoinRPCPassword"],
 		bitcoinRPCPort:     argumentMap["bitcoinRPCPort"],
@@ -79,4 +81,9 @@ func (environment *Environment) GetRedisPort() string {
 // GetMiddlewareVersion is a getter for the middleware version
 func (environment *Environment) GetMiddlewareVersion() string {
 	return environment.middlewareVersion
+}
+
+// GetMiddlewarePort is a getter for the port the middleware is listening on
+func (environment *Environment) GetMiddlewarePort() string {
+	return environment.middlewarePort
 }

--- a/middleware/src/system/system_test.go
+++ b/middleware/src/system/system_test.go
@@ -20,8 +20,10 @@ func TestSystem(t *testing.T) {
 	argumentMap["prometheusURL"] = "http://localhost:9090"
 	argumentMap["redisPort"] = "6379"
 	argumentMap["middlewareVersion"] = "0.0.1"
+	argumentMap["middlewarePort"] = "8085"
 
 	environmentInstance := system.NewEnvironment(argumentMap)
+	// TODO: refactor require.Equal() to take (t, <expected>, <actual>). It's currently <actual> <expected>.
 	require.Equal(t, environmentInstance.GetBitcoinRPCPort(), "8332")
 	require.Equal(t, environmentInstance.GetBitcoinRPCUser(), "user")
 	require.Equal(t, environmentInstance.GetBitcoinRPCPassword(), "password")
@@ -33,6 +35,7 @@ func TestSystem(t *testing.T) {
 	require.Equal(t, environmentInstance.GetPrometheusURL(), "http://localhost:9090")
 	require.Equal(t, "6379", environmentInstance.GetRedisPort())
 	require.Equal(t, "0.0.1", environmentInstance.GetMiddlewareVersion())
+	require.Equal(t, "8085", environmentInstance.GetMiddlewarePort())
 
 	//test unhappy path
 	argumentMap = make(map[string]string)

--- a/middleware/src/util.go
+++ b/middleware/src/util.go
@@ -9,8 +9,8 @@ import (
 	"github.com/digitalbitbox/bitbox-base/middleware/src/rpcmessages"
 )
 
-// The util.go file includes utillity functions for the Middleware.
-// These are private and called by the middleware RPCs. Utillity
+// The util.go file includes utility functions for the Middleware.
+// These are private and called by the middleware RPCs. Utility
 // functions like `mountFlashdrive` or `unmountFlashdrive` are
 // reused in multiple RPCs.
 
@@ -121,7 +121,7 @@ func handleBBBScriptErrorCode(outputLines []string, err error, possibleErrors []
 	// 	2.2. CMD Script was not run with correct parameters. ErrorCode ErrorCmdScriptInvalidArg is expected as the last outputLine.
 	// 	2.3. Config Script was not run with correct parameters. ErrorCode ErrorConfigScriptInvalidArg is expected as the last outputLine.
 	// 	2.4. One of the `possibleErrors` is expected as the last outputLine.
-	// All other errors are unknow and not handled. ErrorUnexpected is returned as a last resort.
+	// All other errors are unknown and not handled. ErrorUnexpected is returned as a last resort.
 
 	if os.IsNotExist(err) {
 		return rpcmessages.ExecutableNotFound


### PR DESCRIPTION
The GetBaseInfo RPC provides information about the Base, which is displayed in the app's 'Base management' section. The RPCs `GetHostname` and `GetBaseVersion` are included in `GetBaseInfo`.

This PR includes placeholder values for:
- the current Base system status
- the Middleware's hidden service tor port

This PR does not include a unit test for `GetBaseInfo`, because a Prometheus mock is needed first.

I'll keep track of both, the placeholders (https://github.com/shiftdevices/bitbox-base-internal/issues/292) and unit tests (https://github.com/shiftdevices/bitbox-base-internal/issues/274) in a separate issues.