### PR TITLE
fix: error string in handleBBBScriptErrorCode

### DIFF
--- a/middleware/src/util.go
+++ b/middleware/src/util.go
@@ -125,7 +125,7 @@ func handleBBBScriptErrorCode(outputLines []string, err error, possibleErrors []
 
 	if os.IsNotExist(err) {
 		return rpcmessages.ErrorScriptNotFound
-	} else if err.Error() == "error status 1" {
+	} else if err.Error() == "exit status 1" {
 
 		if len(outputLines) == 0 {
 			log.Println("Error: no log lines provided before exit with error status 1.")


### PR DESCRIPTION
The error string matched for a script exiting with a status code of 1 was wrong. 'exit status 1' is correct.