### PR TITLE
middleware: change ToggleSetting rpc message from string to bool

### DIFF
--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -60,7 +60,7 @@ func NewMiddleware(argumentMap map[string]string, mock bool) *Middleware {
 	return middleware
 }
 
-// demoBitcoinRPC is a function that demonstrates a connection to bitcoind. Currently it gets the blockcount and difficulty and writes it into the SampleInfo. Once the demo is no longer needed, it should be removed
+// GetSampleInfo is a function that demonstrates a connection to bitcoind. Currently it gets the blockcount and difficulty and writes it into the SampleInfo. Once the demo is no longer needed, it should be removed
 func (middleware *Middleware) GetSampleInfo() bool {
 	connCfg := rpcclient.ConnConfig{
 		HTTPPostMode: true,
@@ -409,8 +409,8 @@ func (middleware *Middleware) GetHostname() rpcmessages.GetHostnameResponse {
 // EnableTor enables/disables the tor.service and configures bitcoind and lightningd based on the passed ToggleSettingEnable/Disable argument
 // and returns a ErrorResponse indicating if the call was successful.
 func (middleware *Middleware) EnableTor(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
-	log.Printf("Executing '%s Tor' via the config script.\n", toggleAction)
-	out, err := middleware.runBBBConfigScript([]string{string(toggleAction), "tor"})
+	log.Printf("Executing 'Enable Tor: %t' via the config script.\n", toggleAction)
+	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "tor"})
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
 		return rpcmessages.ErrorResponse{
@@ -426,8 +426,8 @@ func (middleware *Middleware) EnableTor(toggleAction rpcmessages.ToggleSetting) 
 // EnableTorMiddleware enables/disables the tor hidden service for the middleware based on the passed ToggleSettingEnable/Disable argument
 // and returns a ErrorResponse indicating if the call was successful.
 func (middleware *Middleware) EnableTorMiddleware(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
-	log.Printf("Executing '%s Tor for middleware' via the config script.\n", toggleAction)
-	out, err := middleware.runBBBConfigScript([]string{string(toggleAction), "tor_bbbmiddleware"})
+	log.Printf("Executing 'Enable Tor for middleware: %t' via the config script.\n", toggleAction)
+	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "tor_bbbmiddleware"})
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
 		return rpcmessages.ErrorResponse{
@@ -443,8 +443,8 @@ func (middleware *Middleware) EnableTorMiddleware(toggleAction rpcmessages.Toggl
 // EnableTorElectrs enables/disables the tor hidden service for electrs based on the passed ToggleSettingEnable/Disable argument
 // and returns a ErrorResponse indicating if the call was successful.
 func (middleware *Middleware) EnableTorElectrs(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
-	log.Printf("Executing '%s Tor for electrs' via the config script.\n", toggleAction)
-	out, err := middleware.runBBBConfigScript([]string{string(toggleAction), "tor_electrs"})
+	log.Printf("Executing 'Enable Tor for electrs: %t' via the config script.\n", toggleAction)
+	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "tor_electrs"})
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
 		return rpcmessages.ErrorResponse{
@@ -460,8 +460,8 @@ func (middleware *Middleware) EnableTorElectrs(toggleAction rpcmessages.ToggleSe
 // EnableTorSSH enables/disables the tor hidden service for ssh based on the passed ToggleSettingEnable/Disable argument
 // and returns a ErrorResponse indicating if the call was successful.
 func (middleware *Middleware) EnableTorSSH(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
-	log.Printf("Executing '%s Tor for ssh' via the config script.\n", toggleAction)
-	out, err := middleware.runBBBConfigScript([]string{string(toggleAction), "tor_ssh"})
+	log.Printf("Executing 'Enable Tor for ssh: %t' via the config script.\n", toggleAction)
+	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "tor_ssh"})
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
 		return rpcmessages.ErrorResponse{
@@ -476,8 +476,8 @@ func (middleware *Middleware) EnableTorSSH(toggleAction rpcmessages.ToggleSettin
 
 // EnableClearnetIBD enables/disables the initial block download over clearnet based on the passed ToggleSettingEnable/Disable argument
 func (middleware *Middleware) EnableClearnetIBD(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
-	log.Printf("Executing '%s clearnet IBD' via the config script.\n", toggleAction)
-	out, err := middleware.runBBBConfigScript([]string{string(toggleAction), "bitcoin_ibd_clearnet"})
+	log.Printf("Executing 'Enable clearnet IBD: %t' via the config script.\n", toggleAction)
+	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "bitcoin_ibd_clearnet"})
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, []rpcmessages.ErrorCode{
 			rpcmessages.ErrorSetNeedsTwoArguments,
@@ -552,8 +552,8 @@ func (middleware *Middleware) GetBaseVersion() rpcmessages.GetBaseVersionRespons
 // EnableRootLogin enables/disables the login via the root user/password
 // and returns a ErrorResponse indicating if the call was successful.
 func (middleware *Middleware) EnableRootLogin(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
-	log.Printf("Executing '%s root login' via the config script.\n", toggleAction)
-	out, err := middleware.runBBBConfigScript([]string{string(toggleAction), "root_pwlogin"})
+	log.Printf("Executing 'Enable root login: %t' via the config script.\n", toggleAction)
+	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "root_pwlogin"})
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
 		return rpcmessages.ErrorResponse{

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -122,12 +122,12 @@ func TestRestoreSysconfig(t *testing.T) {
 func TestEnableTor(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableTor(rpcmessages.ToggleSettingEnable)
+	responseEnable := testMiddleware.EnableTor(true)
 	require.Equal(t, true, responseEnable.Success)
 	require.Equal(t, "", responseEnable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseEnable.Code)
 
-	responseDisable := testMiddleware.EnableTor(rpcmessages.ToggleSettingDisable)
+	responseDisable := testMiddleware.EnableTor(false)
 	require.Equal(t, true, responseDisable.Success)
 	require.Equal(t, "", responseDisable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)
@@ -136,12 +136,12 @@ func TestEnableTor(t *testing.T) {
 func TestEnableTorMiddleware(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableTorMiddleware(rpcmessages.ToggleSettingEnable)
+	responseEnable := testMiddleware.EnableTorMiddleware(true)
 	require.Equal(t, responseEnable.Success, true)
 	require.Equal(t, responseEnable.Message, "")
 	require.Equal(t, rpcmessages.ErrorCode(""), responseEnable.Code)
 
-	responseDisable := testMiddleware.EnableTorMiddleware(rpcmessages.ToggleSettingDisable)
+	responseDisable := testMiddleware.EnableTorMiddleware(false)
 	require.Equal(t, true, responseDisable.Success)
 	require.Equal(t, "", responseDisable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)
@@ -150,12 +150,12 @@ func TestEnableTorMiddleware(t *testing.T) {
 func TestEnableTorElectrs(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableTorElectrs(rpcmessages.ToggleSettingEnable)
+	responseEnable := testMiddleware.EnableTorElectrs(true)
 	require.Equal(t, true, responseEnable.Success)
 	require.Equal(t, "", responseEnable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseEnable.Code)
 
-	responseDisable := testMiddleware.EnableTorElectrs(rpcmessages.ToggleSettingDisable)
+	responseDisable := testMiddleware.EnableTorElectrs(false)
 	require.Equal(t, true, responseDisable.Success)
 	require.Equal(t, "", responseDisable.Message, "")
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)
@@ -164,12 +164,12 @@ func TestEnableTorElectrs(t *testing.T) {
 func TestEnableClearnetIBD(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableClearnetIBD(rpcmessages.ToggleSettingEnable)
+	responseEnable := testMiddleware.EnableClearnetIBD(true)
 	require.Equal(t, true, responseEnable.Success)
 	require.Equal(t, "", responseEnable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseEnable.Code)
 
-	responseDisable := testMiddleware.EnableClearnetIBD(rpcmessages.ToggleSettingDisable)
+	responseDisable := testMiddleware.EnableClearnetIBD(false)
 	require.Equal(t, true, responseDisable.Success)
 	require.Equal(t, "", responseDisable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)
@@ -178,12 +178,12 @@ func TestEnableClearnetIBD(t *testing.T) {
 func TestEnableTorSSH(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableTorSSH(rpcmessages.ToggleSettingEnable)
+	responseEnable := testMiddleware.EnableTorSSH(true)
 	require.Equal(t, true, responseEnable.Success)
 	require.Equal(t, "", responseEnable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseEnable.Code)
 
-	responseDisable := testMiddleware.EnableTorSSH(rpcmessages.ToggleSettingDisable)
+	responseDisable := testMiddleware.EnableTorSSH(false)
 	require.Equal(t, responseDisable.Success, true)
 	require.Equal(t, "", responseDisable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)
@@ -192,12 +192,12 @@ func TestEnableTorSSH(t *testing.T) {
 func TestEnableRootLogin(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableRootLogin(rpcmessages.ToggleSettingEnable)
+	responseEnable := testMiddleware.EnableRootLogin(true)
 	require.Equal(t, true, responseEnable.Success)
 	require.Equal(t, "", responseEnable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseEnable.Code)
 
-	responseDisable := testMiddleware.EnableRootLogin(rpcmessages.ToggleSettingDisable)
+	responseDisable := testMiddleware.EnableRootLogin(false)
 	require.Equal(t, true, responseDisable.Success, true)
 	require.Equal(t, "", responseDisable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -41,13 +41,7 @@ type SetRootPasswordArgs struct {
 }
 
 // ToggleSetting is a generic message for settings that can be enabled or disabled
-type ToggleSetting string
-
-// Consts for toggling a setting which is done by passing "enable" or "disable" to the corresponding shell script
-const (
-	ToggleSettingEnable  ToggleSetting = "enable"
-	ToggleSettingDisable ToggleSetting = "disable"
-)
+type ToggleSetting bool
 
 /*
 Put Response structs below this line. They should have the format of 'RPC Method Name' + 'Response'.

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -141,51 +141,51 @@ func TestRPCServer(t *testing.T) {
 	require.Equal(t, true, restoreSysconfigReply.Success)
 
 	var enableTorReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTor", rpcmessages.ToggleSettingEnable, &enableTorReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTor", true, &enableTorReply)
 	require.Equal(t, true, enableTorReply.Success)
 
 	var disableTorReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTor", rpcmessages.ToggleSettingDisable, &disableTorReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTor", false, &disableTorReply)
 	require.Equal(t, true, disableTorReply.Success)
 
 	var enableTorMiddlewareReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorMiddleware", rpcmessages.ToggleSettingEnable, &enableTorMiddlewareReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorMiddleware", true, &enableTorMiddlewareReply)
 	require.Equal(t, true, enableTorMiddlewareReply.Success)
 
 	var disableTorMiddlewareReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorMiddleware", rpcmessages.ToggleSettingDisable, &disableTorMiddlewareReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorMiddleware", false, &disableTorMiddlewareReply)
 	require.Equal(t, true, disableTorMiddlewareReply.Success)
 
 	var enableTorElectrsReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorElectrs", rpcmessages.ToggleSettingEnable, &enableTorElectrsReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorElectrs", true, &enableTorElectrsReply)
 	require.Equal(t, true, enableTorElectrsReply.Success)
 
 	var disableTorElectrsReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorElectrs", rpcmessages.ToggleSettingDisable, &disableTorElectrsReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorElectrs", false, &disableTorElectrsReply)
 	require.Equal(t, true, disableTorElectrsReply.Success)
 
 	var enableTorSSHReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorSSH", rpcmessages.ToggleSettingEnable, &enableTorSSHReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorSSH", true, &enableTorSSHReply)
 	require.Equal(t, true, enableTorSSHReply.Success)
 
 	var disableTorSSHReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorSSH", rpcmessages.ToggleSettingDisable, &disableTorSSHReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorSSH", false, &disableTorSSHReply)
 	require.Equal(t, true, disableTorSSHReply.Success)
 
 	var enableClearnetIBDReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableClearnetIBD", rpcmessages.ToggleSettingEnable, &enableClearnetIBDReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableClearnetIBD", true, &enableClearnetIBDReply)
 	require.Equal(t, true, enableClearnetIBDReply.Success)
 
 	var disableClearnetIBDReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableClearnetIBD", rpcmessages.ToggleSettingDisable, &disableClearnetIBDReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableClearnetIBD", false, &disableClearnetIBDReply)
 	require.Equal(t, true, disableClearnetIBDReply.Success)
 
 	var enableRootLoginReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", rpcmessages.ToggleSettingEnable, &enableRootLoginReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", true, &enableRootLoginReply)
 	require.Equal(t, true, enableRootLoginReply.Success)
 
 	var disableRootLoginReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", rpcmessages.ToggleSettingDisable, &disableRootLoginReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", false, &disableRootLoginReply)
 	require.Equal(t, true, disableRootLoginReply.Success)
 
 	userAuthenticateArg := rpcmessages.UserAuthenticateArgs{Username: "admin", Password: "ICanHasPassword?"}

--- a/middleware/src/util.go
+++ b/middleware/src/util.go
@@ -156,3 +156,11 @@ func handleBBBScriptErrorCode(outputLines []string, err error, possibleErrors []
 	log.Printf("Error: unhandled error '%s' with output '%s'", err.Error(), outputLines)
 	return rpcmessages.ErrorUnexpected
 }
+
+// determineEnableValue returns a string (either "enable" or "disable") used as parameter for the bbb-config.sh script for a given ToggleSetting
+func determineEnableValue(enable rpcmessages.ToggleSetting) string {
+	if enable {
+		return "enable"
+	}
+	return "disable"
+}


### PR DESCRIPTION
Originally, the rpc parameter for all `Enable*` type calls was a `bool` that wasn't typed in `rpcmessages.go`
Later changed this to `"enable"`/`"disable"` strings required by the `bbb-config.sh` script on the base.
As there are only two options, this change avoids passing around unnecessary strings and instead typing the bool as `type ToggleSetting bool` in `rpcmessages.go`