### PR TITLE
refactor: ErrorResponse Error() method

### DIFF
--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -88,6 +88,18 @@ type ErrorResponse struct {
 	Message string
 }
 
+// Error formats the ErrorResponse in the following two formats:
+// If no error occoured:
+//  ErrorResponse: Success: true
+//
+// If an error occoured:
+// 	ErrorResponse:
+// 		Success: false
+// 		Code: <ERROR_CODE>
+//		Message: <message>
 func (err *ErrorResponse) Error() string {
-	return fmt.Sprintf("bbBaseError: Code: %s | Message: %s", err.Code, err.Message)
+	if err.Success {
+		return fmt.Sprintf("ErrorResponse: Success: %t \n", err.Success)
+	}
+	return fmt.Sprintf("ErrorResponse:\n\tSuccess: %t \n\tCode: %s \n\tMessage: %s\n", err.Success, err.Code, err.Message)
 }


### PR DESCRIPTION
I found the logging output for the print `ErrorResponse` uninformative and not well formatted when dealing with Errors in the logs. The Error() method is changed to print just `ErrorResponse: Success: true` when there is no Error. If an Error occurs the Success, Code and Message values printed in multiple lines. This should increased readability in the logs.

potential problem: If `Success` is incorrectly set to `true`, the message and code are not printed. This case should however be covered by unit tests for the RPC call. 