### PR TITLE
change: Restart & ShutdownBase without bbb-cmd.sh

### DIFF
--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -4,6 +4,7 @@ package middleware
 import (
 	"fmt"
 	"log"
+	"os/exec"
 	"regexp"
 	"strings"
 	"time"
@@ -24,6 +25,7 @@ type Middleware struct {
 	prometheusClient     *prometheus.PromClient
 	redisClient          redis.Redis
 	verificationProgress rpcmessages.VerificationProgressResponse
+	isMockmode           bool
 	// Saves state for the dummy setup process
 	// TODO: should be removed as soon as Authentication is implemented
 	dummyIsBaseSetup   bool
@@ -47,6 +49,7 @@ func NewMiddleware(argumentMap map[string]string, mock bool) *Middleware {
 			Headers:              0,
 			VerificationProgress: 0.0,
 		},
+		isMockmode:         mock,
 		dummyIsBaseSetup:   false,
 		dummyAdminPassword: "",
 	}
@@ -493,36 +496,70 @@ func (middleware *Middleware) EnableClearnetIBD(toggleAction rpcmessages.ToggleS
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
-// ShutdownBase returns an ErrorResponse struct in response to a rpcserver request
-// It calls the bbb-cmd.sh script which initializes a shutdown
+// ShutdownBase shuts the Base down.
+// The shutdown is exectuted in a goroutine with a delay of a few seconds.
+// Prior to starting the goroutine the path for the `shutdown` executable is checked.
+// If the executable is found, a ErrorResponse indicating success is returned.
+// Otherwise a ExecutableNotFound Code is returned.
 func (middleware *Middleware) ShutdownBase() rpcmessages.ErrorResponse {
-	log.Println("shutting down the Base via the cmd script")
-	out, err := middleware.runBBBCmdScript([]string{"base", "shutdown"})
+	const shutdownDelay time.Duration = 5 * time.Second
+	log.Printf("Shutting down the Base in %s\n", shutdownDelay)
+
+	if middleware.isMockmode {
+		return rpcmessages.ErrorResponse{Success: true}
+	}
+
+	_, err := exec.LookPath("shutdown")
 	if err != nil {
-		errorCode := handleBBBScriptErrorCode(out, err, nil)
 		return rpcmessages.ErrorResponse{
 			Success: false,
-			Message: strings.Join(out, "\n"),
-			Code:    errorCode,
+			Message: fmt.Sprintf("could not shut the Base down: %s", err.Error()),
+			Code:    rpcmessages.ExecutableNotFound,
 		}
 	}
+
+	go func(delay time.Duration) {
+		time.Sleep(delay)
+		cmd := exec.Command("shutdown", "now")
+		err = cmd.Start()
+		if err != nil {
+			log.Printf("Could not shutdown the Base: %s", err.Error())
+		}
+	}(shutdownDelay)
 
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
-// RebootBase returns an ErrorResponse struct in response to a rpcserver request
-// It calls the bbb-cmd.sh script which initializes a restart
+// RebootBase reboots the Base.
+// The reboot is exectuted in a goroutine with a delay of a few seconds.
+// Prior to starting the goroutine the path for the `reboot` executable is checked.
+// If the executable is found, a ErrorResponse indicating success is returned.
+// Otherwise a ExecutableNotFound Code is returned.
 func (middleware *Middleware) RebootBase() rpcmessages.ErrorResponse {
-	log.Println("restarting the Base via the cmd script")
-	out, err := middleware.runBBBCmdScript([]string{"base", "restart"})
+	const rebootDelay time.Duration = 5 * time.Second
+	log.Printf("Rebooting the Base in %s\n", rebootDelay)
+
+	if middleware.isMockmode {
+		return rpcmessages.ErrorResponse{Success: true}
+	}
+
+	_, err := exec.LookPath("reboot")
 	if err != nil {
-		errorCode := handleBBBScriptErrorCode(out, err, nil)
 		return rpcmessages.ErrorResponse{
 			Success: false,
-			Message: strings.Join(out, "\n"),
-			Code:    errorCode,
+			Message: fmt.Sprintf("could not reboot the Base: %s", err.Error()),
+			Code:    rpcmessages.ExecutableNotFound,
 		}
 	}
+
+	go func(delay time.Duration) {
+		time.Sleep(delay)
+		cmd := exec.Command("reboot")
+		err = cmd.Start()
+		if err != nil {
+			log.Printf("Could not reboot the Base: %s", err.Error())
+		}
+	}(rebootDelay)
 
 	return rpcmessages.ErrorResponse{Success: true}
 }

--- a/middleware/src/rpcmessages/errorcodes.go
+++ b/middleware/src/rpcmessages/errorcodes.go
@@ -5,8 +5,9 @@ type ErrorCode string
 
 const (
 
-	// ErrorScriptNotFound is thrown if either the bbb-cmd.sh or bbb-config.sh scripts are not found
-	ErrorScriptNotFound ErrorCode = "SCRIPT_NOT_FOUND"
+	// ExecutableNotFound is thrown when a executable is not found.
+	// This can for example be a script (e.g. bbb-cmd.sh or bbb-config.sh) or a executable like `reboot`
+	ExecutableNotFound ErrorCode = "EXECUTABLE_NOT_FOUND"
 
 	// ErrorScriptNotSuperuser is thrown if a run scripts need to be run as superuser.
 	ErrorScriptNotSuperuser ErrorCode = "SCRIPT_NOT_RUN_AS_SUPERUSER"

--- a/middleware/src/util.go
+++ b/middleware/src/util.go
@@ -115,7 +115,7 @@ func runCommand(command string, args []string) (combinedLines []string, err erro
 
 func handleBBBScriptErrorCode(outputLines []string, err error, possibleErrors []rpcmessages.ErrorCode) rpcmessages.ErrorCode {
 	// There are two possible types of errors handled here:
-	// 1.   The script could not be found.
+	// 1.   The script could not be found. -> return ExecutableNotFound
 	// 2.   Script exited with `exit status 1`:
 	// 	2.1. Script was not run as superuser. ErrorCode ErrorScriptNotSuperuser is expected as the last outputLine.
 	// 	2.2. CMD Script was not run with correct parameters. ErrorCode ErrorCmdScriptInvalidArg is expected as the last outputLine.
@@ -124,7 +124,7 @@ func handleBBBScriptErrorCode(outputLines []string, err error, possibleErrors []
 	// All other errors are unknow and not handled. ErrorUnexpected is returned as a last resort.
 
 	if os.IsNotExist(err) {
-		return rpcmessages.ErrorScriptNotFound
+		return rpcmessages.ExecutableNotFound
 	} else if err.Error() == "exit status 1" {
 
 		if len(outputLines) == 0 {


### PR DESCRIPTION
The RestartBase RPC and the ShutdownBase RPC should both return a response to the calling App before the shutdown is started. The previously used os.exec's `CombineOutput` waited for the script to complete and forking in the shell script did not resolve this.

The RPCs now execute the reboot/shutdown with a delay of <s>10 seconds</s> 5 seconds. The middlware responds to the App prior to the shutdown/reboot.