### PR TITLE
Middleware: add /version endpoint 

### DIFF
--- a/middleware/cmd/middleware/main.go
+++ b/middleware/cmd/middleware/main.go
@@ -11,6 +11,10 @@ import (
 	"github.com/digitalbitbox/bitbox-base/middleware/src/handlers"
 )
 
+// version defines the middleware version
+// The version is upgraded via semantic versioning
+const version string = "0.0.1"
+
 func main() {
 	bitcoinRPCUser := flag.String("rpcuser", "rpcuser", "Bitcoin rpc user name")
 	bitcoinRPCPassword := flag.String("rpcpassword", "rpcpassword", "Bitcoin rpc password")
@@ -36,6 +40,7 @@ func main() {
 	argumentMap["bbbCmdScript"] = *bbbCmdScript
 	argumentMap["prometheusURL"] = *prometheusURL
 	argumentMap["redisPort"] = *redisPort
+	argumentMap["middlewareVersion"] = version
 
 	logBeforeExit := func() {
 		// Recover from all panics and log error before panicking again.

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -30,6 +30,11 @@ type Middleware struct {
 	dummyAdminPassword string
 }
 
+// GetMiddlewareVersion returns the Middleware Version for the `GET /version` endpoint.
+func (middleware *Middleware) GetMiddlewareVersion() string {
+	return middleware.environment.GetMiddlewareVersion()
+}
+
 // NewMiddleware returns a new instance of the middleware.
 // For testing a mock boolean can be passed, which mocks e.g. redis.
 func NewMiddleware(argumentMap map[string]string, mock bool) *Middleware {

--- a/middleware/src/system/system.go
+++ b/middleware/src/system/system.go
@@ -13,6 +13,7 @@ type Environment struct {
 	bbbCmdScript       string
 	prometheusURL      string
 	redisPort          string
+	middlewareVersion  string
 }
 
 // NewEnvironment returns a new Environment instance.
@@ -30,6 +31,7 @@ func NewEnvironment(argumentMap map[string]string) Environment {
 		bbbCmdScript:       argumentMap["bbbCmdScript"],
 		prometheusURL:      argumentMap["prometheusURL"],
 		redisPort:          argumentMap["redisPort"],
+		middlewareVersion:  argumentMap["middlewareVersion"],
 	}
 	return environment
 }
@@ -72,4 +74,9 @@ func (environment *Environment) GetPrometheusURL() string {
 // GetRedisPort is a getter for the port the redis server is listening on
 func (environment *Environment) GetRedisPort() string {
 	return environment.redisPort
+}
+
+// GetMiddlewareVersion is a getter for the middleware version
+func (environment *Environment) GetMiddlewareVersion() string {
+	return environment.middlewareVersion
 }

--- a/middleware/src/system/system_test.go
+++ b/middleware/src/system/system_test.go
@@ -19,6 +19,7 @@ func TestSystem(t *testing.T) {
 	argumentMap["bbbCmdScript"] = "/home/bitcoin/cmd-script.sh"
 	argumentMap["prometheusURL"] = "http://localhost:9090"
 	argumentMap["redisPort"] = "6379"
+	argumentMap["middlewareVersion"] = "0.0.1"
 
 	environmentInstance := system.NewEnvironment(argumentMap)
 	require.Equal(t, environmentInstance.GetBitcoinRPCPort(), "8332")
@@ -31,6 +32,7 @@ func TestSystem(t *testing.T) {
 	require.Equal(t, environmentInstance.ElectrsRPCPort, "18442")
 	require.Equal(t, environmentInstance.GetPrometheusURL(), "http://localhost:9090")
 	require.Equal(t, "6379", environmentInstance.GetRedisPort())
+	require.Equal(t, "0.0.1", environmentInstance.GetMiddlewareVersion())
 
 	//test unhappy path
 	argumentMap = make(map[string]string)


### PR DESCRIPTION
The Middleware needs an unauthenticated endpoint providing the
Middleware version. This Endpoint is added and reachable under
`http://<ip>:8845/version`

This is a replacement for #224.