### PR TITLE
RPC messages: move toggle setting to its own struct

### DIFF
--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -30,14 +30,14 @@ type Middleware interface {
 	SetHostname(rpcmessages.SetHostnameArgs) rpcmessages.ErrorResponse
 	RestoreSysconfig() rpcmessages.ErrorResponse
 	RestoreHSMSecret() rpcmessages.ErrorResponse
-	EnableTor(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
-	EnableTorMiddleware(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
-	EnableTorElectrs(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
-	EnableTorSSH(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
-	EnableClearnetIBD(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
+	EnableTor(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
+	EnableTorMiddleware(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
+	EnableTorElectrs(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
+	EnableTorSSH(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
+	EnableClearnetIBD(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
-	EnableRootLogin(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
+	EnableRootLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
 	GetBaseInfo() rpcmessages.GetBaseInfoResponse
 	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -401,9 +401,9 @@ func (middleware *Middleware) SetHostname(args rpcmessages.SetHostnameArgs) rpcm
 	return rpcmessages.ErrorResponse{Success: false, Message: "invalid hostname"}
 }
 
-// EnableTor enables/disables the tor.service and configures bitcoind and lightningd based on the passed ToggleSettingEnable/Disable argument
+// EnableTor enables/disables the tor.service and configures bitcoind and lightningd based on the passed ToggleSettingArgsEnable/Disable argument
 // and returns a ErrorResponse indicating if the call was successful.
-func (middleware *Middleware) EnableTor(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
+func (middleware *Middleware) EnableTor(toggleAction rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse {
 	log.Printf("Executing 'Enable Tor: %t' via the config script.\n", toggleAction)
 	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "tor"})
 	if err != nil {
@@ -418,9 +418,9 @@ func (middleware *Middleware) EnableTor(toggleAction rpcmessages.ToggleSetting) 
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
-// EnableTorMiddleware enables/disables the tor hidden service for the middleware based on the passed ToggleSettingEnable/Disable argument
+// EnableTorMiddleware enables/disables the tor hidden service for the middleware based on the passed ToggleSettingArgsEnable/Disable argument
 // and returns a ErrorResponse indicating if the call was successful.
-func (middleware *Middleware) EnableTorMiddleware(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
+func (middleware *Middleware) EnableTorMiddleware(toggleAction rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse {
 	log.Printf("Executing 'Enable Tor for middleware: %t' via the config script.\n", toggleAction)
 	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "tor_bbbmiddleware"})
 	if err != nil {
@@ -435,9 +435,9 @@ func (middleware *Middleware) EnableTorMiddleware(toggleAction rpcmessages.Toggl
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
-// EnableTorElectrs enables/disables the tor hidden service for electrs based on the passed ToggleSettingEnable/Disable argument
+// EnableTorElectrs enables/disables the tor hidden service for electrs based on the passed ToggleSettingArgsEnable/Disable argument
 // and returns a ErrorResponse indicating if the call was successful.
-func (middleware *Middleware) EnableTorElectrs(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
+func (middleware *Middleware) EnableTorElectrs(toggleAction rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse {
 	log.Printf("Executing 'Enable Tor for electrs: %t' via the config script.\n", toggleAction)
 	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "tor_electrs"})
 	if err != nil {
@@ -452,9 +452,9 @@ func (middleware *Middleware) EnableTorElectrs(toggleAction rpcmessages.ToggleSe
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
-// EnableTorSSH enables/disables the tor hidden service for ssh based on the passed ToggleSettingEnable/Disable argument
+// EnableTorSSH enables/disables the tor hidden service for ssh based on the passed ToggleSettingArgsEnable/Disable argument
 // and returns a ErrorResponse indicating if the call was successful.
-func (middleware *Middleware) EnableTorSSH(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
+func (middleware *Middleware) EnableTorSSH(toggleAction rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse {
 	log.Printf("Executing 'Enable Tor for ssh: %t' via the config script.\n", toggleAction)
 	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "tor_ssh"})
 	if err != nil {
@@ -469,8 +469,8 @@ func (middleware *Middleware) EnableTorSSH(toggleAction rpcmessages.ToggleSettin
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
-// EnableClearnetIBD enables/disables the initial block download over clearnet based on the passed ToggleSettingEnable/Disable argument
-func (middleware *Middleware) EnableClearnetIBD(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
+// EnableClearnetIBD enables/disables the initial block download over clearnet based on the passed ToggleSettingArgsEnable/Disable argument
+func (middleware *Middleware) EnableClearnetIBD(toggleAction rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse {
 	log.Printf("Executing 'Enable clearnet IBD: %t' via the config script.\n", toggleAction)
 	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "bitcoin_ibd_clearnet"})
 	if err != nil {
@@ -558,7 +558,7 @@ func (middleware *Middleware) RebootBase() rpcmessages.ErrorResponse {
 
 // EnableRootLogin enables/disables the login via the root user/password
 // and returns a ErrorResponse indicating if the call was successful.
-func (middleware *Middleware) EnableRootLogin(toggleAction rpcmessages.ToggleSetting) rpcmessages.ErrorResponse {
+func (middleware *Middleware) EnableRootLogin(toggleAction rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse {
 	log.Printf("Executing 'Enable root login: %t' via the config script.\n", toggleAction)
 	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "root_pwlogin"})
 	if err != nil {

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -8,6 +8,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func getToggleSettingArgs(enabled bool) rpcmessages.ToggleSettingArgs {
+	return rpcmessages.ToggleSettingArgs{ToggleSetting: enabled}
+}
+
 // setupTestMiddleware middleware returns a middleware setup with testing arguments
 func setupTestMiddleware() *middleware.Middleware {
 	argumentMap := make(map[string]string)
@@ -122,12 +126,12 @@ func TestRestoreSysconfig(t *testing.T) {
 func TestEnableTor(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableTor(true)
+	responseEnable := testMiddleware.EnableTor(getToggleSettingArgs(true))
 	require.Equal(t, true, responseEnable.Success)
 	require.Equal(t, "", responseEnable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseEnable.Code)
 
-	responseDisable := testMiddleware.EnableTor(false)
+	responseDisable := testMiddleware.EnableTor(getToggleSettingArgs(false))
 	require.Equal(t, true, responseDisable.Success)
 	require.Equal(t, "", responseDisable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)
@@ -136,12 +140,12 @@ func TestEnableTor(t *testing.T) {
 func TestEnableTorMiddleware(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableTorMiddleware(true)
+	responseEnable := testMiddleware.EnableTorMiddleware(getToggleSettingArgs(true))
 	require.Equal(t, responseEnable.Success, true)
 	require.Equal(t, responseEnable.Message, "")
 	require.Equal(t, rpcmessages.ErrorCode(""), responseEnable.Code)
 
-	responseDisable := testMiddleware.EnableTorMiddleware(false)
+	responseDisable := testMiddleware.EnableTorMiddleware(getToggleSettingArgs(false))
 	require.Equal(t, true, responseDisable.Success)
 	require.Equal(t, "", responseDisable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)
@@ -150,12 +154,12 @@ func TestEnableTorMiddleware(t *testing.T) {
 func TestEnableTorElectrs(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableTorElectrs(true)
+	responseEnable := testMiddleware.EnableTorElectrs(getToggleSettingArgs(true))
 	require.Equal(t, true, responseEnable.Success)
 	require.Equal(t, "", responseEnable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseEnable.Code)
 
-	responseDisable := testMiddleware.EnableTorElectrs(false)
+	responseDisable := testMiddleware.EnableTorElectrs(getToggleSettingArgs(false))
 	require.Equal(t, true, responseDisable.Success)
 	require.Equal(t, "", responseDisable.Message, "")
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)
@@ -164,12 +168,12 @@ func TestEnableTorElectrs(t *testing.T) {
 func TestEnableClearnetIBD(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableClearnetIBD(true)
+	responseEnable := testMiddleware.EnableClearnetIBD(getToggleSettingArgs(true))
 	require.Equal(t, true, responseEnable.Success)
 	require.Equal(t, "", responseEnable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseEnable.Code)
 
-	responseDisable := testMiddleware.EnableClearnetIBD(false)
+	responseDisable := testMiddleware.EnableClearnetIBD(getToggleSettingArgs(false))
 	require.Equal(t, true, responseDisable.Success)
 	require.Equal(t, "", responseDisable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)
@@ -178,12 +182,12 @@ func TestEnableClearnetIBD(t *testing.T) {
 func TestEnableTorSSH(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableTorSSH(true)
+	responseEnable := testMiddleware.EnableTorSSH(getToggleSettingArgs(true))
 	require.Equal(t, true, responseEnable.Success)
 	require.Equal(t, "", responseEnable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseEnable.Code)
 
-	responseDisable := testMiddleware.EnableTorSSH(false)
+	responseDisable := testMiddleware.EnableTorSSH(getToggleSettingArgs(false))
 	require.Equal(t, responseDisable.Success, true)
 	require.Equal(t, "", responseDisable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)
@@ -192,12 +196,12 @@ func TestEnableTorSSH(t *testing.T) {
 func TestEnableRootLogin(t *testing.T) {
 	testMiddleware := setupTestMiddleware()
 
-	responseEnable := testMiddleware.EnableRootLogin(true)
+	responseEnable := testMiddleware.EnableRootLogin(getToggleSettingArgs(true))
 	require.Equal(t, true, responseEnable.Success)
 	require.Equal(t, "", responseEnable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseEnable.Code)
 
-	responseDisable := testMiddleware.EnableRootLogin(false)
+	responseDisable := testMiddleware.EnableRootLogin(getToggleSettingArgs(false))
 	require.Equal(t, true, responseDisable.Success, true)
 	require.Equal(t, "", responseDisable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -40,8 +40,10 @@ type SetRootPasswordArgs struct {
 	RootPassword string
 }
 
-// ToggleSetting is a generic message for settings that can be enabled or disabled
-type ToggleSetting bool
+// ToggleSettingArgs is a generic message for settings that can be enabled or disabled
+type ToggleSettingArgs struct {
+	ToggleSetting bool
+}
 
 /*
 Put Response structs below this line. They should have the format of 'RPC Method Name' + 'Response'.

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -58,14 +58,14 @@ type Middleware interface {
 	RestoreSysconfig() rpcmessages.ErrorResponse
 	RestoreHSMSecret() rpcmessages.ErrorResponse
 	SampleInfo() rpcmessages.SampleInfoResponse
-	EnableTor(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
-	EnableTorMiddleware(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
-	EnableTorElectrs(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
-	EnableTorSSH(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
-	EnableClearnetIBD(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
+	EnableTor(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
+	EnableTorMiddleware(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
+	EnableTorElectrs(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
+	EnableTorSSH(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
+	EnableClearnetIBD(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
-	EnableRootLogin(rpcmessages.ToggleSetting) rpcmessages.ErrorResponse
+	EnableRootLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
 	GetBaseInfo() rpcmessages.GetBaseInfoResponse
 	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
@@ -192,8 +192,8 @@ func (server *RPCServer) SetHostname(args *rpcmessages.SetHostnameArgs, reply *r
 // EnableTor enables/disables the tor.service and configures bitcoind and lightningd.
 // The boolean argument passed is used to for enabling and disabling.
 // It sends the middleware's ErrorResponse over rpc.
-func (server *RPCServer) EnableTor(toggleAction rpcmessages.ToggleSetting, reply *rpcmessages.ErrorResponse) error {
-	*reply = server.middleware.EnableTor(toggleAction)
+func (server *RPCServer) EnableTor(args rpcmessages.ToggleSettingArgs, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableTor(args)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }
@@ -201,8 +201,8 @@ func (server *RPCServer) EnableTor(toggleAction rpcmessages.ToggleSetting, reply
 // EnableTorMiddleware enables/disables the tor hidden service for the middleware.
 // The boolean argument passed is used to for enabling and disabling.
 // It sends the middleware's ErrorResponse over rpc.
-func (server *RPCServer) EnableTorMiddleware(toggleAction rpcmessages.ToggleSetting, reply *rpcmessages.ErrorResponse) error {
-	*reply = server.middleware.EnableTorMiddleware(toggleAction)
+func (server *RPCServer) EnableTorMiddleware(args rpcmessages.ToggleSettingArgs, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableTorMiddleware(args)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }
@@ -210,8 +210,8 @@ func (server *RPCServer) EnableTorMiddleware(toggleAction rpcmessages.ToggleSett
 // EnableTorElectrs enables/disables the tor hidden service for Electrs.
 // The boolean argument passed is used to for enabling and disabling.
 // It sends the middleware's ErrorResponse over rpc.
-func (server *RPCServer) EnableTorElectrs(toggleAction rpcmessages.ToggleSetting, reply *rpcmessages.ErrorResponse) error {
-	*reply = server.middleware.EnableTorElectrs(toggleAction)
+func (server *RPCServer) EnableTorElectrs(args rpcmessages.ToggleSettingArgs, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableTorElectrs(args)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }
@@ -219,8 +219,8 @@ func (server *RPCServer) EnableTorElectrs(toggleAction rpcmessages.ToggleSetting
 // EnableTorSSH enables/disables the tor hidden service for SSH.
 // The boolean argument passed is used to for enabling and disabling.
 // It sends the middleware's ErrorResponse over rpc.
-func (server *RPCServer) EnableTorSSH(toggleAction rpcmessages.ToggleSetting, reply *rpcmessages.ErrorResponse) error {
-	*reply = server.middleware.EnableTorSSH(toggleAction)
+func (server *RPCServer) EnableTorSSH(args rpcmessages.ToggleSettingArgs, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableTorSSH(args)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }
@@ -228,8 +228,8 @@ func (server *RPCServer) EnableTorSSH(toggleAction rpcmessages.ToggleSetting, re
 // EnableClearnetIBD enables/disables the tor hidden service for SSH.
 // The boolean argument passed is used to for enabling and disabling.
 // It sends the middleware's ErrorResponse over rpc.
-func (server *RPCServer) EnableClearnetIBD(toggleAction rpcmessages.ToggleSetting, reply *rpcmessages.ErrorResponse) error {
-	*reply = server.middleware.EnableClearnetIBD(toggleAction)
+func (server *RPCServer) EnableClearnetIBD(args rpcmessages.ToggleSettingArgs, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableClearnetIBD(args)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }
@@ -253,8 +253,8 @@ func (server *RPCServer) RebootBase(dummyArg bool, reply *rpcmessages.ErrorRespo
 // EnableRootLogin enables/disables login via the root user/password.
 // The boolean argument passed is used to for enabling and disabling.
 // It sends the middleware's ErrorResponse over rpc.
-func (server *RPCServer) EnableRootLogin(toggleAction rpcmessages.ToggleSetting, reply *rpcmessages.ErrorResponse) error {
-	*reply = server.middleware.EnableRootLogin(toggleAction)
+func (server *RPCServer) EnableRootLogin(args rpcmessages.ToggleSettingArgs, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableRootLogin(args)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func getToggleSettingArgs(enabled bool) rpcmessages.ToggleSettingArgs {
+	return rpcmessages.ToggleSettingArgs{ToggleSetting: enabled}
+}
+
 type rpcConn struct {
 	readChan  <-chan []byte
 	writeChan chan<- []byte
@@ -137,51 +141,51 @@ func TestRPCServer(t *testing.T) {
 	require.Equal(t, true, restoreSysconfigReply.Success)
 
 	var enableTorReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTor", true, &enableTorReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTor", getToggleSettingArgs(true), &enableTorReply)
 	require.Equal(t, true, enableTorReply.Success)
 
 	var disableTorReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTor", false, &disableTorReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTor", getToggleSettingArgs(false), &disableTorReply)
 	require.Equal(t, true, disableTorReply.Success)
 
 	var enableTorMiddlewareReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorMiddleware", true, &enableTorMiddlewareReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorMiddleware", getToggleSettingArgs(true), &enableTorMiddlewareReply)
 	require.Equal(t, true, enableTorMiddlewareReply.Success)
 
 	var disableTorMiddlewareReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorMiddleware", false, &disableTorMiddlewareReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorMiddleware", getToggleSettingArgs(false), &disableTorMiddlewareReply)
 	require.Equal(t, true, disableTorMiddlewareReply.Success)
 
 	var enableTorElectrsReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorElectrs", true, &enableTorElectrsReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorElectrs", getToggleSettingArgs(true), &enableTorElectrsReply)
 	require.Equal(t, true, enableTorElectrsReply.Success)
 
 	var disableTorElectrsReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorElectrs", false, &disableTorElectrsReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorElectrs", getToggleSettingArgs(false), &disableTorElectrsReply)
 	require.Equal(t, true, disableTorElectrsReply.Success)
 
 	var enableTorSSHReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorSSH", true, &enableTorSSHReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorSSH", getToggleSettingArgs(true), &enableTorSSHReply)
 	require.Equal(t, true, enableTorSSHReply.Success)
 
 	var disableTorSSHReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorSSH", false, &disableTorSSHReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableTorSSH", getToggleSettingArgs(false), &disableTorSSHReply)
 	require.Equal(t, true, disableTorSSHReply.Success)
 
 	var enableClearnetIBDReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableClearnetIBD", true, &enableClearnetIBDReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableClearnetIBD", getToggleSettingArgs(true), &enableClearnetIBDReply)
 	require.Equal(t, true, enableClearnetIBDReply.Success)
 
 	var disableClearnetIBDReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableClearnetIBD", false, &disableClearnetIBDReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableClearnetIBD", getToggleSettingArgs(false), &disableClearnetIBDReply)
 	require.Equal(t, true, disableClearnetIBDReply.Success)
 
 	var enableRootLoginReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", true, &enableRootLoginReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", getToggleSettingArgs(true), &enableRootLoginReply)
 	require.Equal(t, true, enableRootLoginReply.Success)
 
 	var disableRootLoginReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", false, &disableRootLoginReply)
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", getToggleSettingArgs(false), &disableRootLoginReply)
 	require.Equal(t, true, disableRootLoginReply.Success)
 
 	userAuthenticateArg := rpcmessages.UserAuthenticateArgs{Username: "admin", Password: "ICanHasPassword?"}

--- a/middleware/src/util.go
+++ b/middleware/src/util.go
@@ -158,8 +158,8 @@ func handleBBBScriptErrorCode(outputLines []string, err error, possibleErrors []
 }
 
 // determineEnableValue returns a string (either "enable" or "disable") used as parameter for the bbb-config.sh script for a given ToggleSetting
-func determineEnableValue(enable rpcmessages.ToggleSetting) string {
-	if enable {
+func determineEnableValue(enable rpcmessages.ToggleSettingArgs) string {
+	if enable.ToggleSetting {
 		return "enable"
 	}
 	return "disable"


### PR DESCRIPTION
Each rpc call's arguments should now be inside a struct such that they are easily extensible for additional fields, like an authentication cookie.

I had to add a couple of global variables to the middleware and rpcserver tests and subsequently removed the globals check in golangci. No globals in actual source files are in my opinion something that can be enforced by proper review.