### PR TITLE
Middleware: add first version of GetServiceInfo RPC

### DIFF
--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -39,6 +39,7 @@ type Middleware interface {
 	RebootBase() rpcmessages.ErrorResponse
 	EnableRootLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
 	GetBaseInfo() rpcmessages.GetBaseInfoResponse
+	GetServiceInfo() rpcmessages.GetServiceInfoResponse
 	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse

--- a/middleware/src/prometheus/queries.go
+++ b/middleware/src/prometheus/queries.go
@@ -10,7 +10,11 @@ const (
 	BitcoinVerificationProgress BasePrometheusQuery = "bitcoin_verification_progress"
 	BitcoinBlockCount           BasePrometheusQuery = "bitcoin_blocks"
 	BitcoinHeaderCount          BasePrometheusQuery = "bitcoin_headers"
+	BitcoinPeers                BasePrometheusQuery = "bitcoin_peers"
+	BitcoinIBD                  BasePrometheusQuery = "bitcoin_ibd"
 	BaseSystemInfo              BasePrometheusQuery = "base_system_info"
 	BaseFreeDiskspace           BasePrometheusQuery = "node_filesystem_free_bytes{fstype=\"ext4\", mountpoint=\"/mnt/ssd\"}"
 	BaseTotalDiskspace          BasePrometheusQuery = "node_filesystem_size_bytes{fstype=\"ext4\", mountpoint=\"/mnt/ssd\"}"
+	LightningBlocks             BasePrometheusQuery = "lightning_node_blockheight"
+	ElectrsBlocks               BasePrometheusQuery = "electrs_index_height"
 )

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -12,6 +12,8 @@ const (
 	OpUCanHasSampleInfo = "d"
 	// OpUCanHasVerificationProgress notifies when new VerificationProgress data is available.
 	OpUCanHasVerificationProgress = "v"
+	// OpServiceInfoChanged notifies when the GetServiceInfo data changed.
+	OpServiceInfoChanged = "s"
 )
 
 /*
@@ -69,7 +71,7 @@ type VerificationProgressResponse struct {
 	VerificationProgress float64 `json:"verificationProgress"`
 }
 
-// GetBaseInfoResponse is the struct that get sent by the rpc server during a GetBaseInfo rpc call
+// GetBaseInfoResponse is the struct that gets sent by the RPC server during a GetBaseInfo RPC call
 type GetBaseInfoResponse struct {
 	ErrorResponse       *ErrorResponse
 	Status              string `json:"status"`
@@ -88,6 +90,18 @@ type GetBaseInfoResponse struct {
 	ElectrsVersion      string `json:"electrsVersion"`
 }
 
+// GetServiceInfoResponse is the struct that gets sent by the RPC server during a GetServiceInfo RPC call
+type GetServiceInfoResponse struct {
+	ErrorResponse                *ErrorResponse `json:"errorResponse"`
+	BitcoindBlocks               int64          `json:"bitcoindBlocks"`
+	BitcoindHeaders              int64          `json:"bitcoindHeaders"`
+	BitcoindVerificationProgress float64        `json:"bitcoindVerificationProgress"`
+	BitcoindPeers                int64          `json:"bitcoindPeers"`
+	BitcoindIBD                  bool           `json:"bitcoindIBD"`
+	LightningdBlocks             int64          `json:"lightningdBlocks"`
+	ElectrsBlocks                int64          `json:"electrsBlocks"`
+}
+
 // ErrorResponse is a generic RPC response indicating if a RPC call was successful or not.
 // It can be embedded into other RPC responses that return values.
 // In any case the ErrorResponse should be checked first, so that, if an error is returned, we ignore everything else in the response.
@@ -98,10 +112,10 @@ type ErrorResponse struct {
 }
 
 // Error formats the ErrorResponse in the following two formats:
-// If no error occoured:
+// If no error occurred:
 //  ErrorResponse: Success: true
 //
-// If an error occoured:
+// If an error occurred:
 // 	ErrorResponse:
 // 		Success: false
 // 		Code: <ERROR_CODE>

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -67,6 +67,7 @@ type Middleware interface {
 	RebootBase() rpcmessages.ErrorResponse
 	EnableRootLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
 	GetBaseInfo() rpcmessages.GetBaseInfoResponse
+	GetServiceInfo() rpcmessages.GetServiceInfoResponse
 	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.ErrorResponse
@@ -273,6 +274,14 @@ func (server *RPCServer) SetRootPassword(args rpcmessages.SetRootPasswordArgs, r
 // This includes information about the Base and the Middleware.
 func (server *RPCServer) GetBaseInfo(dummyArg bool, reply *rpcmessages.GetBaseInfoResponse) error {
 	*reply = server.middleware.GetBaseInfo()
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// GetServiceInfo sends the middleware's GetServiceInfoResponse over rpc.
+// This includes information about the Base and the Middleware.
+func (server *RPCServer) GetServiceInfo(dummyArg bool, reply *rpcmessages.GetServiceInfoResponse) error {
+	*reply = server.middleware.GetServiceInfo()
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }


### PR DESCRIPTION
This commit adds a first version of the GetServiceInfo RPC.

The RPC returns information about services such as bitcoind, electrs and lightningd. Information includes for example the current block height or the count of connected peers.

The App should call this RPC once it receives a notification that the serviceInfo in the middleware has changed.

This RPC will likely be extended with additional information in the future.