### PR TITLE
allow unsigned firmware upgrades

### DIFF
--- a/armbian/base/config/mender/mender.conf
+++ b/armbian/base/config/mender/mender.conf
@@ -1,5 +1,0 @@
-{
-  "ArtifactVerifyKey": "/opt/shift/config/signatures/artifact-verify-key-DEV.pem",
-  "RootfsPartA": "/dev/mmcblk1p2",
-  "RootfsPartB": "/dev/mmcblk1p3"
-}

--- a/armbian/base/config/redis/factorysettings.txt
+++ b/armbian/base/config/redis/factorysettings.txt
@@ -8,6 +8,7 @@ SET base:wifi:enabled 0
 SET base:wifi:ssid none
 SET base:wifi:password none
 SET base:hostname bitbox-base
+SET base:update:allow-unsigned 0
 SET base:updating 0
 
 SET tor:base:enabled 1

--- a/armbian/base/config/templates/mender.conf.template
+++ b/armbian/base/config/templates/mender.conf.template
@@ -1,0 +1,6 @@
+{{ #output: /etc/mender/mender.conf }}
+{
+  "ArtifactVerifyKey": "/opt/shift/config/signatures/artifact-verify-key-DEV.pem",    {{ base:update:allow-unsigned #rmLineTrue }}
+  "RootfsPartA": "/dev/mmcblk1p2",
+  "RootfsPartB": "/dev/mmcblk1p3"
+}

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -16,7 +16,7 @@ assumes Redis database running to be used with 'redis-cli'
 possible commands:
   enable    <bitcoin_incoming|bitcoin_ibd|bitcoin_ibd_clearnet|dashboard_hdmi|
              dashboard_web|wifi|autosetup_ssd|tor|tor_bbbmiddleware|tor_ssh|
-             tor_electrum|overlayroot|root_pwlogin>
+             tor_electrum|overlayroot|root_pwlogin|unsigned_updates>
 
   disable   any 'enable' argument
 
@@ -282,6 +282,13 @@ case "${COMMAND}" in
                     exec_overlayroot all-layers "passwd -l root"
                 fi
                 redis_set "base:rootpasslogin:enabled" "${ENABLE}"
+                ;;
+
+            UNSIGNED_UPDATES)
+                checkMockMode
+
+                redis_set "base:update:allow-unsigned" "${ENABLE}"
+                generateConfig "mender.conf.template"
                 ;;
 
             *)

--- a/armbian/base/scripts/systemd-update-checks.sh
+++ b/armbian/base/scripts/systemd-update-checks.sh
@@ -67,6 +67,7 @@ else
         generateConfig "bbbmiddleware.conf.template"
         generateConfig "bashrc-custom.template"
         generateConfig "grafana.ini.template"
+        generateConfig "mender.conf.template"
         generateConfig "torrc.template"
 
         if [[ $(redis_get "base:wifi:enabled") -eq 1 ]]; then


### PR DESCRIPTION
Because:

* Power users and developers should be able to run firmware images
  built by themselves, independently from a Shift signature

This commit:

* introduces Redis key 'base:update:allow-unsigned' with default 0
* replaces the static /etc/mender/mender.conf file with a template
* adds the bbb-config.sh command 'enable/disable unsigned_updates'
* restores this setting on update