### PR TITLE
Middleware: add Base firmware update check and notification

### DIFF
--- a/middleware/cmd/middleware/main.go
+++ b/middleware/cmd/middleware/main.go
@@ -29,6 +29,7 @@ func main() {
 	prometheusURL := flag.String("prometheusurl", "http://localhost:9090", "Url of the prometheus server in the form of 'http://localhost:9090'")
 	redisPort := flag.String("redisport", "6379", "Port of the Redis server")
 	redisMock := flag.Bool("redismock", false, "Mock redis for development instead of connecting to a redis server, default is 'false', use 'true' as an argument to mock")
+	imageUpdateInfoURL := flag.String("updateinfourl", "https://shiftcrypto.ch/updates/base.json", "URL to query information about updates from (defaults to https://shiftcrypto.ch/updates/base.json)")
 	flag.Parse()
 
 	argumentMap := make(map[string]string)
@@ -43,6 +44,7 @@ func main() {
 	argumentMap["bbbCmdScript"] = *bbbCmdScript
 	argumentMap["prometheusURL"] = *prometheusURL
 	argumentMap["redisPort"] = *redisPort
+	argumentMap["imageUpdateInfoURL"] = *imageUpdateInfoURL
 	argumentMap["middlewareVersion"] = version
 
 	logBeforeExit := func() {

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -40,6 +40,7 @@ type Middleware interface {
 	EnableRootLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
 	UpdateBase(rpcmessages.UpdateBaseArgs) rpcmessages.ErrorResponse
 	GetBaseUpdateProgress() rpcmessages.GetBaseUpdateProgressResponse
+	IsBaseUpdateAvaliable() rpcmessages.IsBaseUpdateAvailableResponse
 	GetBaseInfo() rpcmessages.GetBaseInfoResponse
 	GetServiceInfo() rpcmessages.GetServiceInfoResponse
 	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse

--- a/middleware/src/redis/redis_mock.go
+++ b/middleware/src/redis/redis_mock.go
@@ -50,7 +50,7 @@ func setupTestData() map[string]string {
 	mockRedisMap := make(map[string]string)
 
 	// General mock data
-	mockRedisMap[string(BaseVersion)] = "0.0.1-redis-mock"
+	mockRedisMap[string(BaseVersion)] = "0.0.1"
 	mockRedisMap[string(BaseHostname)] = "bitbox-base-redis-mock"
 	mockRedisMap[string(TorEnabled)] = "1"
 	mockRedisMap[string(BitcoindListen)] = "1"

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -16,6 +16,8 @@ const (
 	OpServiceInfoChanged = "s"
 	// OpBaseUpdateProgressChanged notifies when the BaseUpdateProgress changes while performing a Base Update.
 	OpBaseUpdateProgressChanged = "u"
+	// OpBaseUpdateIsAvailable notifies when a firmeware update is available for the Base.
+	OpBaseUpdateIsAvailable = "x"
 )
 
 /*
@@ -100,6 +102,20 @@ type VerificationProgressResponse struct {
 	Blocks               int64   `json:"blocks"`
 	Headers              int64   `json:"headers"`
 	VerificationProgress float64 `json:"verificationProgress"`
+}
+
+// UpdateInfo holds information about a available Base image update
+type UpdateInfo struct {
+	Description string `json:"description"`
+	Version     string `json:"version"`
+	Severity    string `json:"severity"`
+}
+
+// IsBaseUpdateAvailableResponse is returned as an response for an IsBaseUpdateAvaliable RPC call.
+type IsBaseUpdateAvailableResponse struct {
+	ErrorResponse   *ErrorResponse
+	UpdateAvailable bool       `json:"available"`
+	UpdateInfo      UpdateInfo `json:"info"`
 }
 
 // BaseUpdateState is the used to hold the current state for a Base update.

--- a/middleware/src/rpcserver/mocks/Middleware.go
+++ b/middleware/src/rpcserver/mocks/Middleware.go
@@ -166,6 +166,20 @@ func (_m *Middleware) GetServiceInfo() rpcmessages.GetServiceInfoResponse {
 	return r0
 }
 
+// IsBaseUpdateAvaliable provides a mock function with given fields:
+func (_m *Middleware) IsBaseUpdateAvaliable() rpcmessages.IsBaseUpdateAvailableResponse {
+	ret := _m.Called()
+
+	var r0 rpcmessages.IsBaseUpdateAvailableResponse
+	if rf, ok := ret.Get(0).(func() rpcmessages.IsBaseUpdateAvailableResponse); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(rpcmessages.IsBaseUpdateAvailableResponse)
+	}
+
+	return r0
+}
+
 // RebootBase provides a mock function with given fields:
 func (_m *Middleware) RebootBase() rpcmessages.ErrorResponse {
 	ret := _m.Called()

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -71,6 +71,7 @@ type Middleware interface {
 	EnableRootLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
 	UpdateBase(rpcmessages.UpdateBaseArgs) rpcmessages.ErrorResponse
 	GetBaseUpdateProgress() rpcmessages.GetBaseUpdateProgressResponse
+	IsBaseUpdateAvaliable() rpcmessages.IsBaseUpdateAvailableResponse
 	GetBaseInfo() rpcmessages.GetBaseInfoResponse
 	GetServiceInfo() rpcmessages.GetServiceInfoResponse
 	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse
@@ -472,6 +473,20 @@ func (server *RPCServer) GetBaseUpdateProgress(args rpcmessages.AuthGenericReque
 
 	*reply = server.middleware.GetBaseUpdateProgress()
 	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// IsBaseUpdateAvaliable sends a IsBaseUpdateAvailableResponse over RPC
+func (server *RPCServer) IsBaseUpdateAvaliable(args rpcmessages.AuthGenericRequest, reply *rpcmessages.IsBaseUpdateAvailableResponse) error {
+	err := server.middleware.ValidateToken(args.Token)
+	if err != nil {
+		errorResponse := server.formulateJWTError("IsBaseUpdateAvaliable")
+		*reply = rpcmessages.IsBaseUpdateAvailableResponse{ErrorResponse: &errorResponse}
+		return nil
+	}
+
+	*reply = server.middleware.IsBaseUpdateAvaliable()
+	log.Printf("IsBaseUpdateAvaliable reply: %v\n", reply)
 	return nil
 }
 

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -103,6 +103,7 @@ func NewTestingRPCServer() TestingRPCServer {
 		rpcmessages.UserAuthenticateResponse{ErrorResponse: &rpcmessages.ErrorResponse{Success: true}},
 	)
 	testingRPCServer.middlewareMock.On("UserChangePassword", rpcmessages.UserChangePasswordArgs{}).Return(rpcmessages.ErrorResponse{Success: true})
+	testingRPCServer.middlewareMock.On("IsBaseUpdateAvaliable").Return(rpcmessages.IsBaseUpdateAvailableResponse{ErrorResponse: &rpcmessages.ErrorResponse{Success: true}})
 
 	return testingRPCServer
 }
@@ -212,6 +213,10 @@ func TestRPCServer(t *testing.T) {
 	var rebootBaseReply rpcmessages.ErrorResponse
 	testingRPCServer.RunRPCCall(t, "RPCServer.RebootBase", authArg, &rebootBaseReply)
 	require.Equal(t, true, rebootBaseReply.Success)
+
+	var isBaseUpdateAvaliableReply rpcmessages.IsBaseUpdateAvailableResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.IsBaseUpdateAvaliable", authArg, &isBaseUpdateAvaliableReply)
+	require.Equal(t, true, isBaseUpdateAvaliableReply.ErrorResponse.Success)
 
 	/*
 		This can't be unit tested until there is a Prometheus mock.

--- a/middleware/src/system/system.go
+++ b/middleware/src/system/system.go
@@ -15,6 +15,7 @@ type Environment struct {
 	prometheusURL      string
 	redisPort          string
 	middlewareVersion  string
+	imageUpdateInfoURL string
 }
 
 // NewEnvironment returns a new Environment instance.
@@ -34,6 +35,7 @@ func NewEnvironment(argumentMap map[string]string) Environment {
 		prometheusURL:      argumentMap["prometheusURL"],
 		redisPort:          argumentMap["redisPort"],
 		middlewareVersion:  argumentMap["middlewareVersion"],
+		imageUpdateInfoURL: argumentMap["imageUpdateInfoURL"],
 	}
 	return environment
 }
@@ -86,4 +88,9 @@ func (environment *Environment) GetMiddlewareVersion() string {
 // GetMiddlewarePort is a getter for the port the middleware is listening on
 func (environment *Environment) GetMiddlewarePort() string {
 	return environment.middlewarePort
+}
+
+// GetImageUpdateInfoURL is a getter for the URL that specifies where the middleware queries the update info.
+func (environment *Environment) GetImageUpdateInfoURL() string {
+	return environment.imageUpdateInfoURL
 }

--- a/middleware/src/util/semver/semver.go
+++ b/middleware/src/util/semver/semver.go
@@ -1,0 +1,110 @@
+// Copyright 2019 Shift Devices AG
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file is copied from the bitbox-wallet-app (https://github.com/digitalbitbox/bitbox-wallet-app/blob/master/util/semver/semver.go).
+// Modifications:
+// - change errp to errors.New()
+
+package semver
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// SemVer implements Semantic Versioning according to https://semver.org.
+type SemVer struct {
+	major uint16
+	minor uint16
+	patch uint16
+}
+
+// NewSemVer creates a new SemVer from the given major, minor and patch versions.
+func NewSemVer(major uint16, minor uint16, patch uint16) *SemVer {
+	return &SemVer{major, minor, patch}
+}
+
+// NewSemVerFromString creates a new SemVer from the given version string and returns an error on
+// failure.
+func NewSemVerFromString(versionString string) (*SemVer, error) {
+	versionString = strings.TrimPrefix(versionString, "v")
+	splits := strings.Split(versionString, ".")
+	if len(splits) != 3 {
+		return nil, errors.New("the version format has to be 'major.minor.patch'")
+	}
+
+	major, err := strconv.Atoi(splits[0])
+	if err != nil {
+		return nil, errors.New("the major version is not a number'")
+	}
+
+	minor, err := strconv.Atoi(splits[1])
+	if err != nil {
+		return nil, errors.New("the minor version is not a number'")
+	}
+
+	patch, err := strconv.Atoi(splits[2])
+	if err != nil {
+		return nil, errors.New("the patch version is not a number'")
+	}
+
+	return &SemVer{major: uint16(major), minor: uint16(minor), patch: uint16(patch)}, nil
+}
+
+// AtLeast checks whether this version is equal to or higher than fromVersion.
+func (version *SemVer) AtLeast(fromVersion *SemVer) bool {
+	if version.major < fromVersion.major {
+		return false
+	}
+	if version.major == fromVersion.major && version.minor < fromVersion.minor {
+		return false
+	}
+	if version.major == fromVersion.major && version.minor == fromVersion.minor && version.patch < fromVersion.patch {
+		return false
+	}
+	return true
+}
+
+// Between checks whether this version is between the from-version (including) and the to-version
+// (excluding).
+func (version *SemVer) Between(fromVersion *SemVer, toVersion *SemVer) bool {
+	return version.AtLeast(fromVersion) && !version.AtLeast(toVersion)
+}
+
+func (version *SemVer) String() string {
+	return fmt.Sprintf("%d.%d.%d", version.major, version.minor, version.patch)
+}
+
+// MarshalJSON implements json.Marshaler.
+func (version SemVer) MarshalJSON() ([]byte, error) {
+	return json.Marshal(version.String())
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (version *SemVer) UnmarshalJSON(bytes []byte) error {
+	var input string
+	if err := json.Unmarshal(bytes, &input); err != nil {
+		return errors.New("could not unmarshal a semantic version")
+	}
+
+	decoded, err := NewSemVerFromString(input)
+	if err != nil {
+		return err
+	}
+	*version = *decoded
+	return nil
+}


### PR DESCRIPTION
This adds a periodic check for firmware updates to the middleware.
If an update is available, a the middleware sends a notification.
The App can get more information about the update by calling the
IsBaseUpdateAvailable RPC, which returns a boolean indicating if
an update is available and information about the update.

The App should call `IsBaseUpdateAvailable` after the connection is
established.
