### PR TITLE
wording: use 'Base image' instead of 'firmware'

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ By building the BitBox Base, we want to achieve the following goals:
 * As a networked appliance, remote attack surface is minimized by exposing as little ports as possible.
 * The hardware platform uses best-in-class components, built for performance and resilience.
 * With the integrated BitBox secure module, the node offers functionality previously not possible with hardware wallets.
-* Atomic upgrades allows seamless and reliable firmware upgrades with fallback.
+* Atomic upgrades allows seamless and reliable Base image upgrades with fallback.
 * Expert settings allow access to low-level configuration.
 
 ## Buy or Build

--- a/armbian/base/rootfs/etc/grafana/dashboards/grafana_bitbox_base.json
+++ b/armbian/base/rootfs/etc/grafana/dashboards/grafana_bitbox_base.json
@@ -1041,7 +1041,7 @@
           ],
           "timeFrom": null,
           "timeShift": null,
-          "title": "firmware version",
+          "title": "Base image",
           "type": "text"
         },
         {

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -159,7 +159,7 @@ sed -i 's/#overlayroot:swapfile#//g' /etc/fstab
 mount -a
 swapon /mnt/ssd/swapfile || true
 
-# Firmware updates
+# Base image updates
 # ------------------------------------------------------------------------------
 # initialize mender configuration
 if [[ -f /etc/mender/mender.conf ]] && ! grep -q '/shift/' /etc/mender/mender.conf ; then

--- a/armbian/base/scripts/systemd-update-checks.sh
+++ b/armbian/base/scripts/systemd-update-checks.sh
@@ -30,7 +30,7 @@ source /opt/shift/scripts/include/updateTorOnions.sh.inc
 
 redis_require
 
-# update hardcoded firmware version
+# update hardcoded Base image version
 VERSION=$(head -n1 /opt/shift/config/version)
 redis_set "base:version" "${VERSION}"
 
@@ -109,7 +109,7 @@ else
                 echo "INFO: service verification try ${run} of 100 unsuccessful, retrying in 10 seconds"
                 sleep 2
             else
-                echo "ERR: service verification try ${run} of 100 unsuccessful, falling back to previous firmware version"
+                echo "ERR: service verification try ${run} of 100 unsuccessful, falling back to previous Base image version"
                 redis_set "base:updating" 90
                 /opt/shift/scripts/bbb-cmd.sh base restart
                 errorExit MENDER_UPDATE_SYSCONFIG_FAILED

--- a/docs/customapps/helper-scripts.md
+++ b/docs/customapps/helper-scripts.md
@@ -60,14 +60,14 @@ possible commands:
 
 The following commands are available:
 
-* **setup**: 
+* **setup**:
   * **datadir**: called on boot to check if the persistent data directory is already set up, and initializes it if necessary. Multiple scenarios need to be considered:
-    * read/write disk, without Mender (likely a development image)  
+    * read/write disk, without Mender (likely a development image)
       the `/data` directory can be created directly, copying the initial content from the source directory `/data_source`
     * read-only disk, without Mender (e.g. a DIY image)
       image is build using `OVERLAYROOT` option, so all changes written to the root filesystem are volatile due to the tmpfs overlay. To preserve changes in `/data`, the directory is created as a symbolic link to `/mnt/ssd/data` on the SSD
     * read-only disk, with Mender (BitBox Base production image)
-      the `/data` directory is mounted from a separate, persistent partition that is not overwritten on update. Initial content is copied once from `/data_src` into that partition. 
+      the `/data` directory is mounted from a separate, persistent partition that is not overwritten on update. Initial content is copied once from `/data_src` into that partition.
 
 * **base**: does exactly what it says, but could contain custom commands before powering down in the future
   * **restart**: restarts the device
@@ -85,15 +85,15 @@ The following commands are available:
 
 * **backup**
   * **sysconfig**: copies the Redis datastore `/data/redis/bitboxbase.rdb` to a mounted flashdrive
-  * **hsm_secret**: stores the c-lightning on-chain seed `/mnt/ssd/bitcoin/.lightning/hsm_secret` into Redis, encoded as base64  
+  * **hsm_secret**: stores the c-lightning on-chain seed `/mnt/ssd/bitcoin/.lightning/hsm_secret` into Redis, encoded as base64
 
 * **restore**
   * **sysconfig**: restores the Redis datastore `/data/redis/bitboxbase.rdb` from a mounted flashdrive and restarts Redis
   * **hsm_secret**: saves the c-lightning on-chain seed from Redis into `/mnt/ssd/bitcoin/.lightning/hsm_secret`
 
 * **mender-update**
-  * **install**: expects a firmware version and downloads/verifies/installs the Mender update artefact into the inactive partition. A reboot is required to boot into the updated system.
-  * **commit**: commits an update to become persistent. If it is not committed, the device falls back to the previous firmware on reboot.  
+  * **install**: expects a Base image version and downloads/verifies/installs the Mender update artefact into the inactive partition. A reboot is required to boot into the updated system.
+  * **commit**: commits an update to become persistent. If it is not committed, the device falls back to the previous Base image on reboot.
 
 ### [**bbb-systemctl.sh**](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/scripts/bbb-systemctl.sh): manage and check systemd units in batch
 Batch control all systemd units at once, e.g. for getting an overall status or stop all services.

--- a/docs/hardware/components.md
+++ b/docs/hardware/components.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Components
-parent: Hardware 
+parent: Hardware
 nav_order: 100
 ---
 ## Components
@@ -24,13 +24,13 @@ During normal operation, the board does not need to be cooled actively, running 
 
 For speed, resilience and silent operations the BitBox Base uses an **SSD M.2 drive** that can be mounted on a PCIe adapter which connects directly to the PCIe slog on the board. As no adapter was available that minimizes the height once mounted, we produced our own SSD adapter to not waste any space. Standard adapter work as well.
 
-Additional components are a 16GB **eMMC module** and a **power supply**, which surprisingly can be quite low-powered (e.g. 12V/3A) due to the humble SSD drive. 
+Additional components are a 16GB **eMMC module** and a **power supply**, which surprisingly can be quite low-powered (e.g. 12V/3A) due to the humble SSD drive.
 
 ### Security
 
 A networked device can never be viewed as truly secure. Therefore, adding a secure module can drastically improve the security for use-cases that depend on trusted information or a need to safeguard secrets. An **integrated BitBox secure module**, an adapted version of the [BitBox02 hardware wallet](https://shiftcrypto.ch/bitbox02/), will drive a **trusted screen and capacitive touch buttons**. The PCB with the 2.4" OLED (128x64 px) screen is optimized for mounting behind glass.
 
-This component, running a modified Bitcoin-only BitBox firmware, allows for new use-cases like automatic signing for transaction that meet certain criteria, without exposing the private keys to the networked device itself. The display itself will also be able to display "untrusted" information from the Armbian firmware, but that needs to follow certain rules and be made clearly visible. Additionally, LEDs on the secure module can allow for a quick way to show additional information like the overall status of the Base.
+This component, running a modified Bitcoin-only BitBox firmware, allows for new use-cases like automatic signing for transaction that meet certain criteria, without exposing the private keys to the networked device itself. The display itself will also be able to display "untrusted" information from the Armbian Base image, but that needs to follow certain rules and be made clearly visible. Additionally, LEDs on the secure module can allow for a quick way to show additional information like the overall status of the Base.
 
 ### Case
 

--- a/docs/os/upgrade.md
+++ b/docs/os/upgrade.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Firmware upgrade
+title: Base image upgrade
 parent: Operating System
 nav_order: 150
 ---
-## Firmware upgrades
+## Base image upgrades
 
 For any modern device with evolving features, especially in a security-critical environment, regular updates are an absolute must.
 Providing new features, improvements and timely security-patches is a key focus of our project.
@@ -19,7 +19,7 @@ In terms of upgrading a system, there are several approaches:
 
 ### Our approach: atomic disk image updates
 
-We are working towards the goal to build the BitBox Base as an appliance with firmware, not as a small Linux server.
+We are working towards the goal to build the BitBox Base as an appliance with 'firmware', not as a small Linux server.
 This is why we decided to implement a full disk image update process, using the [Mender](https://mender.io/) open-source solution.
 
 This solution has the following features:
@@ -27,12 +27,12 @@ This solution has the following features:
 * **enterprise-grade**: despite being open-source and free to use, Mender is a professional solution with its own Deployment Management server and a robust client update daemon.
 * **full disk image**: the whole operating system including all applications are updated together, resulting in a clearly defined state of the system.
 * **atomic**: the update process is atomic, as it either succeeds in full (including custom application tests), or not at all. In case of failure, a full rollback is performed.
-* **on-demand**: the BitBox App will prompt you when an update is available, but you're not forced to upgrade. 
+* **on-demand**: the BitBox App will prompt you when an update is available, but you're not forced to upgrade.
 * **secure**: all upgrades are provided over a secure TLS communication connection and are cryptographically signed by Shift Cryptosecurity. By default, no unsigned updates are accepted by the device.
 * **efficient**: update images are compressed and are streamed directly to the device. As of today, a full update (operating system and all applications) is ~300 MB in size.
 * **minimal downtime**: the update is performed in the background, while applications continue to run. Only a single reboot is necessary to start the updated configuration.
 * **persistent data**: the eMMC contains multiple partitions, one of which is used to store persistent data like the device configuration.
-* **custom firmware**: more in the #reckless category, updating custom-built firmware can be enabled through the BitBox App.
+* **custom Base image**: more in the #reckless category, updating custom-built Base image can be enabled through the BitBox App.
 
 ### Upgrade process
 
@@ -63,5 +63,5 @@ This process makes it very unlikely that a device will end up in a state that ca
 
 ![Mender update process](upgrade_mender_process.png)
 
-See additional information on <https://mender.io/overview/solution>  
+See additional information on <https://mender.io/overview/solution>
 Images (c) 2019 by [Northern.tech AS](https://northern.tech/)

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -26,7 +26,7 @@ Running your own Bitcoin node in combination with a hardware wallet is still to 
 * As a networked appliance, remote attack surface is minimized by exposing as little ports as possible.
 * The hardware platform uses best-in-class components, built for performance and resilience.
 * With the integrated BitBox secure module, the node offers functionality previously not possible with hardware wallets.
-* Atomic upgrades allows seamless and reliable firmware upgrades with fallback.
+* Atomic upgrades allows seamless and reliable Base image upgrades with fallback.
 * Expert settings allow access to low-level configuration.
 
 ## Buy or Build

--- a/docs/overview/architecture.md
+++ b/docs/overview/architecture.md
@@ -30,7 +30,7 @@ Building a solution platform that focuses on security and performance, the BitBo
 
 ### Operating system
 
-The operating system is custom-built as a minimal firmware, running in read-only mode and allowing atomic updates with fallback.
+The operating system is a custom-built Armbian image, with minimal functionality, running in read-only mode and allowing atomic updates with fallback.
 
 * [Armbian](https://www.armbian.com/): custom built Linux operating system, mounted as read-only with tmpfs overlayfs from eMMC storage
 * [Mender.io](https://mender.io/): Over-the-air update management solution, enabling atomic full diskimage updates, using dual partitions for fallback
@@ -52,7 +52,7 @@ Additional noteworthy components on the BitBox Base:
 
 * [Base Supervisor](https://github.com/digitalbitbox/bitbox-base/tree/master/tools/bbbsupervisor): custom daemon for operational monitoring and control, providing system health information and node configuration
 * [Tor](https://www.torproject.org/): external network connections exclusively use the privacy-focused Tor network
-* [Redis](https://redis.io/): in-memory key/value datastore, acting as central configuration repository 
+* [Redis](https://redis.io/): in-memory key/value datastore, acting as central configuration repository
 * [Prometheus](https://prometheus.io/): monitoring of system and software components
 * [Grafana](https://grafana.com/): visualization of system and network performance metrics
 
@@ -61,7 +61,7 @@ Additional noteworthy components on the BitBox Base:
 Connectivity from the Bitcoin wallet application to the node backend is a challenge. We provide the following complementary options to allow for privacy and ease-of-use:
 
 1. Local network: automatic detection using mDNS within the local network.
-2. Tor network: private connectivity without any router configuration, needs Tor installed on client device.  
+2. Tor network: private connectivity without any router configuration, needs Tor installed on client device.
 3. Shift Connect: zero-knowledge Tor/Web proxy operated by Shift for use with any client device
 
 Overall, we strive to make using our BitBox products as simple as possible.

--- a/middleware/src/rpcmessages/errorcodes.go
+++ b/middleware/src/rpcmessages/errorcodes.go
@@ -82,10 +82,10 @@ const (
 	// ErrorMenderUpdateInstallFailed is thrown if `mender -install` failed.
 	ErrorMenderUpdateInstallFailed ErrorCode = "MENDER_UPDATE_INSTALL_FAILED"
 
-	// ErrorMenderUpdateNoVersion thrown if no firmware version passed to the script.
+	// ErrorMenderUpdateNoVersion thrown if no Base image version passed to the script.
 	ErrorMenderUpdateNoVersion ErrorCode = "MENDER_UPDATE_NO_VERSION"
 
-	// ErrorMenderUpdateInvalidVersion is thrown if an invalid firmware version passed to the script.
+	// ErrorMenderUpdateInvalidVersion is thrown if an invalid Base image version passed to the script.
 	ErrorMenderUpdateInvalidVersion ErrorCode = "MENDER_UPDATE_INVALID_VERSION"
 
 	// ErrorMenderUpdateAlreadyInProgress is thrown by the middleware, if an update is already in progress.

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -288,7 +288,7 @@ func (server *RPCServer) GetServiceInfo(dummyArg bool, reply *rpcmessages.GetSer
 	return nil
 }
 
-// UpdateBase updates the Base firmeware and sends a ErrorResponse over RPC
+// UpdateBase updates the Base image and sends a ErrorResponse over RPC
 func (server *RPCServer) UpdateBase(args rpcmessages.UpdateBaseArgs, reply *rpcmessages.ErrorResponse) error {
 	*reply = server.middleware.UpdateBase(args)
 	log.Printf("sent reply %v: ", reply)


### PR DESCRIPTION
To avoid confusion, the software running on the HSM is called 'firmware' and the Armbian operating system is called 'Base image'.

Addresses https://github.com/digitalbitbox/bitbox-base/pull/235#issuecomment-547012303

This commit
* replaces 'firmware' throughout the project where used wrongly.