### PR TITLE
Password settings: harmonize script and RPCs

### DIFF
--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -346,7 +346,7 @@ rm -f /etc/ssh/ssh_host_*
 
 ## optionally, enable ssh password login
 if [ "$BASE_SSH_PASSWORD_LOGIN" == "true" ]; then
-  /opt/shift/scripts/bbb-config.sh enable pwlogin
+  /opt/shift/scripts/bbb-config.sh enable sshpwlogin
 fi
 
 ## set hostname

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -20,7 +20,7 @@ possible commands:
 
   disable   any 'enable' argument
 
-  set       <hostname|root_pw|wifi_ssid|wifi_pw>
+  set       <hostname|loginpw|wifi_ssid|wifi_pw>
             bitcoin_network         <mainnet|testnet>
             bitcoin_dbcache         int (MB)
             other arguments         string
@@ -429,7 +429,7 @@ case "${COMMAND}" in
                 fi
                 ;;
 
-            ROOT_PW)
+            LOGINPW)
                 checkMockMode
 
                 exec_overlayroot all-layers "echo 'root:${3}' | chpasswd"

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -16,7 +16,7 @@ assumes Redis database running to be used with 'redis-cli'
 possible commands:
   enable    <bitcoin_incoming|bitcoin_ibd|bitcoin_ibd_clearnet|dashboard_hdmi|
              dashboard_web|wifi|autosetup_ssd|tor|tor_bbbmiddleware|tor_ssh|
-             tor_electrum|overlayroot|pwlogin|rootlogin|unsigned_updates>
+             tor_electrum|overlayroot|sshpwlogin|rootlogin|unsigned_updates>
 
   disable   any 'enable' argument
 
@@ -286,7 +286,7 @@ case "${COMMAND}" in
                 systemctl restart sshd.service
                 ;;
 
-            PWLOGIN)
+            SSHPWLOGIN)
                 checkMockMode
 
                 if [[ ${ENABLE} -eq 1 ]]; then

--- a/docs/applications/redis.md
+++ b/docs/applications/redis.md
@@ -56,11 +56,11 @@ always-show-logo no
 
 The Redis datastore is already used within the Armbian build process and populated with the factory configuration settings.
 All values are imported from [`armbian/base/config/redis/factorysettings.txt`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/config/redis/factorysettings.txt) using the [Redis mass insertion protocol](https://redis.io/topics/mass-insert) with the helper script [`armbian/base/scripts/redis-pipe.sh`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/scripts/redis-pipe.sh).
+Keys with value `xxx` are replaced on the running system and are added for documenation only.
 
 ```
 SET base:version xxx
 SET base:overlayroot:enabled 1
-SET base:rootpasslogin:enabled 0
 SET base:dashboard:web:enabled 1
 SET base:dashboard:hdmi:enabled 0
 SET base:autosetupssd:enabled 1
@@ -73,7 +73,7 @@ SET tor:base:enabled 1
 SET tor:ssh:enabled 0
 SET tor:electrs:enabled 1
 SET tor:bbbmiddleware:enabled 1
-                        
+
 SET bitcoind:ibd 1
 SET bitcoind:ibd-clearnet 0
 SET bitcoind:network mainnet

--- a/docs/customapps/helper-scripts.md
+++ b/docs/customapps/helper-scripts.md
@@ -22,7 +22,7 @@ usage: bbb-config.sh [--version] [--help]
 possible commands:
   enable    <bitcoin_incoming|bitcoin_ibd|bitcoin_ibd_clearnet|dashboard_hdmi|
              dashboard_web|wifi|autosetup_ssd|tor|tor_bbbmiddleware|tor_ssh|
-             tor_electrum|overlayroot|pwlogin|rootlogin|unsigned_updates>
+             tor_electrum|overlayroot|sshpwlogin|rootlogin|unsigned_updates>
 
   disable   any 'enable' argument
 

--- a/docs/customapps/helper-scripts.md
+++ b/docs/customapps/helper-scripts.md
@@ -20,24 +20,16 @@ usage: bbb-config.sh [--version] [--help]
                     <command> [<args>]
 
 possible commands:
-  enable    <dashboard_hdmi|dashboard_web|wifi|autosetup_ssd|
-            tor_ssh|tor_electrum|overlayroot>
+  enable    <bitcoin_incoming|bitcoin_ibd|bitcoin_ibd_clearnet|dashboard_hdmi|
+             dashboard_web|wifi|autosetup_ssd|tor|tor_bbbmiddleware|tor_ssh|
+             tor_electrum|overlayroot|pwlogin|rootlogin|unsigned_updates>
 
   disable   any 'enable' argument
 
-  set       <bitcoin_network|hostname|root_pw|wifi_ssid|wifi_pw>
-            bitcoin_network     <mainnet|testnet>
-            bitcoin_ibd         <true|false>
-            bitcoin_dbcache     int (MB)
-            other arguments     string
-
-  get       any 'enable' or 'set' argument, or
-            <all|tor_ssh_onion|tor_electrum_onion>
-
-  apply     no argument, applies all configuration settings to the system
-            [not yet implemented]
-
-  exec      <bitcoin_reindex>
+  set       <hostname|loginpw|wifi_ssid|wifi_pw>
+            bitcoin_network         <mainnet|testnet>
+            bitcoin_dbcache         int (MB)
+            other arguments         string
 ```
 
 ### [**bbb-cmd.sh**](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/scripts/bbb-cmd.sh): execution of standard commands
@@ -50,7 +42,6 @@ usage: bbb-cmd.sh [--version] [--help] <command>
 
 possible commands:
   setup         <datadir>
-  base          <restart|shutdown>
   bitcoind      <reindex|resync|refresh_rpcauth>
   flashdrive    <check|mount|umount>
   backup        <sysconfig|hsm_secret>

--- a/docs/os/configuration.md
+++ b/docs/os/configuration.md
@@ -12,7 +12,7 @@ Here we describe how to set the initial configuration on build, control it inter
 
 ### Initial configuration on build
 
-The initial system configuration is set on build and can be altered by setting build options in the file [`armbian/base/build.conf`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/build.conf).  
+The initial system configuration is set on build and can be altered by setting build options in the file [`armbian/base/build.conf`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/build.conf).
 
 Available options are described directly in the file and are set to default values.
 A few examples of build options you can set:
@@ -42,18 +42,16 @@ usage: bbb-config.sh [--version] [--help]
 assumes Redis database running to be used with 'redis-cli'
 
 possible commands:
-  enable    <bitcoin_ibd_clearnet|dashboard_hdmi|dashboard_web|wifi|autosetup_ssd|
-             tor|tor_bbbmiddleware|tor_ssh|tor_electrum|overlayroot|root_pwlogin>
+  enable    <bitcoin_incoming|bitcoin_ibd|bitcoin_ibd_clearnet|dashboard_hdmi|
+             dashboard_web|wifi|autosetup_ssd|tor|tor_bbbmiddleware|tor_ssh|
+             tor_electrum|overlayroot|pwlogin|rootlogin|unsigned_updates>
 
   disable   any 'enable' argument
 
-  set       <bitcoin_network|hostname|root_pw|wifi_ssid|wifi_pw>
-            bitcoin_network     <mainnet|testnet>
-            bitcoin_ibd         <true|false>
-            bitcoin_dbcache     int (MB)
-            other arguments     string
-
-  get       <tor_ssh_onion|tor_electrum_onion>
+  set       <hostname|loginpw|wifi_ssid|wifi_pw>
+            bitcoin_network         <mainnet|testnet>
+            bitcoin_dbcache         int (MB)
+            other arguments         string
 ```
 
 ### *bbb-cmd.sh*: execution of standard commands
@@ -76,7 +74,7 @@ possible commands:
 
 ### *Redis*: storage of configuration values
 
-The [Redis](https://redis.io/) key/value datastore is used to manage configuration data. 
+The [Redis](https://redis.io/) key/value datastore is used to manage configuration data.
 It can be queried from all software components, be it from the command line, Bash, Python or Go with minimal overhead.
 
 * from the terminal, Redis can be used with its command-line utility [`redis-cli`](https://redis.io/topics/rediscli)
@@ -100,9 +98,9 @@ electrs:db_dir        /mnt/ssd/electrs/db
 
 ### *bbbconfgen*: Updating of configuration files
 
-Configuration files are created dynamically using [`bbbconfgen`](https://github.com/digitalbitbox/bitbox-base/tree/master/tools/bbbconfgen), with the templates located in [`armbian/base/config/templates/`](https://github.com/digitalbitbox/bitbox-base/tree/master/armbian/base/config/templates): 
+Configuration files are created dynamically using [`bbbconfgen`](https://github.com/digitalbitbox/bitbox-base/tree/master/tools/bbbconfgen), with the templates located in [`armbian/base/config/templates/`](https://github.com/digitalbitbox/bitbox-base/tree/master/armbian/base/config/templates):
 
-This application parses a template, populates it with the corresponding Redis values, and stores it to the system (even into the read-only filesystem, if applicable). 
+This application parses a template, populates it with the corresponding Redis values, and stores it to the system (even into the read-only filesystem, if applicable).
 
 * during build, the bash function `generateConfig()` is used within the Armbian customizing script.
 * in regular operation, changes to Redis values and the regeneration of config files are typically executed through the `bbb-config.sh` or `bbb-cmd.sh` scripts.

--- a/docs/os/configuration.md
+++ b/docs/os/configuration.md
@@ -44,7 +44,7 @@ assumes Redis database running to be used with 'redis-cli'
 possible commands:
   enable    <bitcoin_incoming|bitcoin_ibd|bitcoin_ibd_clearnet|dashboard_hdmi|
              dashboard_web|wifi|autosetup_ssd|tor|tor_bbbmiddleware|tor_ssh|
-             tor_electrum|overlayroot|pwlogin|rootlogin|unsigned_updates>
+             tor_electrum|overlayroot|sshpwlogin|rootlogin|unsigned_updates>
 
   disable   any 'enable' argument
 

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -38,6 +38,7 @@ type Middleware interface {
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
 	EnableRootLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
+	EnablePasswordLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
 	UpdateBase(rpcmessages.UpdateBaseArgs) rpcmessages.ErrorResponse
 	GetBaseUpdateProgress() rpcmessages.GetBaseUpdateProgressResponse
 	GetBaseInfo() rpcmessages.GetBaseInfoResponse

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -38,7 +38,7 @@ type Middleware interface {
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
 	EnableRootLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
-	EnablePasswordLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
+	EnableSSHPasswordLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
 	UpdateBase(rpcmessages.UpdateBaseArgs) rpcmessages.ErrorResponse
 	GetBaseUpdateProgress() rpcmessages.GetBaseUpdateProgressResponse
 	GetBaseInfo() rpcmessages.GetBaseInfoResponse

--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -43,7 +43,7 @@ type Middleware interface {
 	GetBaseUpdateProgress() rpcmessages.GetBaseUpdateProgressResponse
 	GetBaseInfo() rpcmessages.GetBaseInfoResponse
 	GetServiceInfo() rpcmessages.GetServiceInfoResponse
-	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse
+	SetLoginPassword(rpcmessages.SetLoginPasswordArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.UserAuthenticateResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -885,7 +885,7 @@ func (middleware *Middleware) UpdateBase(args rpcmessages.UpdateBaseArgs) rpcmes
 // EnableRootLogin enables/disables the ssh login of the root user
 // and returns a ErrorResponse indicating if the call was successful.
 func (middleware *Middleware) EnableRootLogin(toggleAction rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse {
-	log.Printf("Executing 'Enable root login: %t' via the config script.\n", toggleAction)
+	log.Printf("Executing 'Enable root login: %t' via the config script.\n", toggleAction.ToggleSetting)
 	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "rootlogin"})
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
@@ -902,7 +902,7 @@ func (middleware *Middleware) EnableRootLogin(toggleAction rpcmessages.ToggleSet
 // EnablePasswordLogin enables/disables the ssh login with a password (in addition to ssh keys)
 // and returns a ErrorResponse indicating if the call was successful.
 func (middleware *Middleware) EnablePasswordLogin(toggleAction rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse {
-	log.Printf("Executing 'Enable password login: %t' via the config script.\n", toggleAction)
+	log.Printf("Executing 'Enable password login: %t' via the config script.\n", toggleAction.ToggleSetting)
 	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "pwlogin"})
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
@@ -916,10 +916,10 @@ func (middleware *Middleware) EnablePasswordLogin(toggleAction rpcmessages.Toggl
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
-// SetRootPassword sets the system main ssh/login password
-func (middleware *Middleware) SetRootPassword(args rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse {
-	log.Println("Setting a new root password via the config script")
-	password := args.RootPassword
+// SetLoginPassword sets the system main ssh/login password
+func (middleware *Middleware) SetLoginPassword(args rpcmessages.SetLoginPasswordArgs) rpcmessages.ErrorResponse {
+	log.Println("Setting a new login password via the config script")
+	password := args.LoginPassword
 
 	// Unicode passwords are allowed, but each Unicode rune is only counted as one when comparing the length
 	// len("₿") = 3
@@ -944,7 +944,7 @@ func (middleware *Middleware) SetRootPassword(args rpcmessages.SetRootPasswordAr
 	return rpcmessages.ErrorResponse{
 		Success: false,
 		Message: "The password has to be at least 8 chars. An unicode char is counted as one.",
-		Code:    rpcmessages.ErrorSetRootPasswordTooShort,
+		Code:    rpcmessages.ErrorSetLoginPasswordTooShort,
 	}
 }
 

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -899,11 +899,11 @@ func (middleware *Middleware) EnableRootLogin(toggleAction rpcmessages.ToggleSet
 	return rpcmessages.ErrorResponse{Success: true}
 }
 
-// EnablePasswordLogin enables/disables the ssh login with a password (in addition to ssh keys)
+// EnableSSHPasswordLogin enables/disables the ssh login with a password (in addition to ssh keys)
 // and returns a ErrorResponse indicating if the call was successful.
-func (middleware *Middleware) EnablePasswordLogin(toggleAction rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse {
+func (middleware *Middleware) EnableSSHPasswordLogin(toggleAction rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse {
 	log.Printf("Executing 'Enable password login: %t' via the config script.\n", toggleAction.ToggleSetting)
-	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "pwlogin"})
+	out, err := middleware.runBBBConfigScript([]string{determineEnableValue(toggleAction), "sshpwlogin"})
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, nil)
 		return rpcmessages.ErrorResponse{

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -194,6 +194,20 @@ func TestEnableTorSSH(t *testing.T) {
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)
 }
 
+func TestEnablePasswordLogin(t *testing.T) {
+	testMiddleware := setupTestMiddleware()
+
+	responseEnable := testMiddleware.EnablePasswordLogin(getToggleSettingArgs(true))
+	require.Equal(t, true, responseEnable.Success)
+	require.Equal(t, "", responseEnable.Message)
+	require.Equal(t, rpcmessages.ErrorCode(""), responseEnable.Code)
+
+	responseDisable := testMiddleware.EnablePasswordLogin(getToggleSettingArgs(false))
+	require.Equal(t, true, responseDisable.Success, true)
+	require.Equal(t, "", responseDisable.Message)
+	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)
+}
+
 func TestEnableRootLogin(t *testing.T) {
 	testMiddleware := setupTestMiddleware(t)
 

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -194,15 +194,15 @@ func TestEnableTorSSH(t *testing.T) {
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)
 }
 
-func TestEnablePasswordLogin(t *testing.T) {
+func TestEnableSSHPasswordLogin(t *testing.T) {
 	testMiddleware := setupTestMiddleware(t)
 
-	responseEnable := testMiddleware.EnablePasswordLogin(getToggleSettingArgs(true))
+	responseEnable := testMiddleware.EnableSSHPasswordLogin(getToggleSettingArgs(true))
 	require.Equal(t, true, responseEnable.Success)
 	require.Equal(t, "", responseEnable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseEnable.Code)
 
-	responseDisable := testMiddleware.EnablePasswordLogin(getToggleSettingArgs(false))
+	responseDisable := testMiddleware.EnableSSHPasswordLogin(getToggleSettingArgs(false))
 	require.Equal(t, true, responseDisable.Success, true)
 	require.Equal(t, "", responseDisable.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -195,7 +195,7 @@ func TestEnableTorSSH(t *testing.T) {
 }
 
 func TestEnablePasswordLogin(t *testing.T) {
-	testMiddleware := setupTestMiddleware()
+	testMiddleware := setupTestMiddleware(t)
 
 	responseEnable := testMiddleware.EnablePasswordLogin(getToggleSettingArgs(true))
 	require.Equal(t, true, responseEnable.Success)
@@ -222,29 +222,29 @@ func TestEnableRootLogin(t *testing.T) {
 	require.Equal(t, rpcmessages.ErrorCode(""), responseDisable.Code)
 }
 
-func TestSetRootPassword(t *testing.T) {
+func TestSetLoginPassword(t *testing.T) {
 	testMiddleware := setupTestMiddleware(t)
 
-	// test valid root password set
-	responseValid := testMiddleware.SetRootPassword(rpcmessages.SetRootPasswordArgs{RootPassword: "iusethispasswordeverywhere"})
+	// test valid login password set
+	responseValid := testMiddleware.SetLoginPassword(rpcmessages.SetLoginPasswordArgs{LoginPassword: "iusethispasswordeverywhere"})
 	require.Equal(t, true, responseValid.Success)
 	require.Equal(t, "", responseValid.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseValid.Code)
 
-	// test invalid (too short) root password set
-	responseInvalid := testMiddleware.SetRootPassword(rpcmessages.SetRootPasswordArgs{RootPassword: "shrtone"})
+	// test invalid (too short) login password set
+	responseInvalid := testMiddleware.SetLoginPassword(rpcmessages.SetLoginPasswordArgs{LoginPassword: "shrtone"})
 	require.Equal(t, false, responseInvalid.Success)
 	require.Equal(t, "The password has to be at least 8 chars. An unicode char is counted as one.", responseInvalid.Message)
-	require.Equal(t, rpcmessages.ErrorSetRootPasswordTooShort, responseInvalid.Code)
+	require.Equal(t, rpcmessages.ErrorSetLoginPasswordTooShort, responseInvalid.Code)
 
 	// test 7 unicode's as password (too short)
-	responseUnicode7 := testMiddleware.SetRootPassword(rpcmessages.SetRootPasswordArgs{RootPassword: "₿₿₿₿₿₿₿"})
+	responseUnicode7 := testMiddleware.SetLoginPassword(rpcmessages.SetLoginPasswordArgs{LoginPassword: "₿₿₿₿₿₿₿"})
 	require.Equal(t, false, responseUnicode7.Success)
 	require.Equal(t, "The password has to be at least 8 chars. An unicode char is counted as one.", responseUnicode7.Message)
-	require.Equal(t, rpcmessages.ErrorSetRootPasswordTooShort, responseUnicode7.Code)
+	require.Equal(t, rpcmessages.ErrorSetLoginPasswordTooShort, responseUnicode7.Code)
 
 	// test 8 unicode's as password (valid)
-	responseUnicode8 := testMiddleware.SetRootPassword(rpcmessages.SetRootPasswordArgs{RootPassword: "₿😂🔥🌑🚀📈世界"})
+	responseUnicode8 := testMiddleware.SetLoginPassword(rpcmessages.SetLoginPasswordArgs{LoginPassword: "₿😂🔥🌑🚀📈世界"})
 	require.Equal(t, true, responseUnicode8.Success)
 	require.Equal(t, "", responseUnicode8.Message)
 	require.Equal(t, rpcmessages.ErrorCode(""), responseUnicode8.Code)

--- a/middleware/src/rpcmessages/errorcodes.go
+++ b/middleware/src/rpcmessages/errorcodes.go
@@ -168,6 +168,6 @@ const (
 )
 
 const (
-	// ErrorSetRootPasswordTooShort is thrown if the provided root password is too short.
-	ErrorSetRootPasswordTooShort ErrorCode = "SET_ROOTPASSWORD_PASSWORD_TOO_SHORT"
+	// ErrorSetLoginPasswordTooShort is thrown if the provided root password is too short.
+	ErrorSetLoginPasswordTooShort ErrorCode = "SET_LOGINPASSWORD_PASSWORD_TOO_SHORT"
 )

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -47,10 +47,10 @@ type SetHostnameArgs struct {
 	Token    string
 }
 
-// SetRootPasswordArgs is a struct that holds the to be set root password
-type SetRootPasswordArgs struct {
-	RootPassword string
-	Token        string
+// SetLoginPasswordArgs is a struct that holds the to be set login password
+type SetLoginPasswordArgs struct {
+	LoginPassword string
+	Token         string
 }
 
 // ToggleSettingArgs is a generic message for settings that can be enabled or disabled

--- a/middleware/src/rpcserver/mocks/Middleware.go
+++ b/middleware/src/rpcserver/mocks/Middleware.go
@@ -264,12 +264,12 @@ func (_m *Middleware) SetHostname(_a0 rpcmessages.SetHostnameArgs) rpcmessages.E
 	return r0
 }
 
-// SetRootPassword provides a mock function with given fields: _a0
-func (_m *Middleware) SetRootPassword(_a0 rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse {
+// SetLoginPassword provides a mock function with given fields: _a0
+func (_m *Middleware) SetLoginPassword(_a0 rpcmessages.SetLoginPasswordArgs) rpcmessages.ErrorResponse {
 	ret := _m.Called(_a0)
 
 	var r0 rpcmessages.ErrorResponse
-	if rf, ok := ret.Get(0).(func(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse); ok {
+	if rf, ok := ret.Get(0).(func(rpcmessages.SetLoginPasswordArgs) rpcmessages.ErrorResponse); ok {
 		r0 = rf(_a0)
 	} else {
 		r0 = ret.Get(0).(rpcmessages.ErrorResponse)

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -74,7 +74,7 @@ type Middleware interface {
 	GetBaseUpdateProgress() rpcmessages.GetBaseUpdateProgressResponse
 	GetBaseInfo() rpcmessages.GetBaseInfoResponse
 	GetServiceInfo() rpcmessages.GetServiceInfoResponse
-	SetRootPassword(rpcmessages.SetRootPasswordArgs) rpcmessages.ErrorResponse
+	SetLoginPassword(rpcmessages.SetLoginPasswordArgs) rpcmessages.ErrorResponse
 	VerificationProgress() rpcmessages.VerificationProgressResponse
 	UserAuthenticate(rpcmessages.UserAuthenticateArgs) rpcmessages.UserAuthenticateResponse
 	UserChangePassword(rpcmessages.UserChangePasswordArgs) rpcmessages.ErrorResponse
@@ -411,18 +411,18 @@ func (server *RPCServer) EnablePasswordLogin(args rpcmessages.ToggleSettingArgs,
 	return nil
 }
 
-// SetRootPassword sets the system main ssh/login password
+// SetLoginPassword sets the system main ssh/login password
 // Passwords have to be at least 8 chars in length.
 // For Unicode passwords the number of unicode chars is counted and not the byte count.
 // It sends the middleware's ErrorResponse over rpc.
-func (server *RPCServer) SetRootPassword(args rpcmessages.SetRootPasswordArgs, reply *rpcmessages.ErrorResponse) error {
+func (server *RPCServer) SetLoginPassword(args rpcmessages.SetLoginPasswordArgs, reply *rpcmessages.ErrorResponse) error {
 	err := server.middleware.ValidateToken(args.Token)
 	if err != nil {
-		*reply = server.formulateJWTError("SetRootPassword")
+		*reply = server.formulateJWTError("SetLoginPassword")
 		return nil
 	}
 
-	*reply = server.middleware.SetRootPassword(args)
+	*reply = server.middleware.SetLoginPassword(args)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -69,6 +69,7 @@ type Middleware interface {
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
 	EnableRootLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
+	EnablePasswordLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
 	UpdateBase(rpcmessages.UpdateBaseArgs) rpcmessages.ErrorResponse
 	GetBaseUpdateProgress() rpcmessages.GetBaseUpdateProgressResponse
 	GetBaseInfo() rpcmessages.GetBaseInfoResponse
@@ -386,7 +387,7 @@ func (server *RPCServer) RebootBase(args rpcmessages.AuthGenericRequest, reply *
 	return nil
 }
 
-// EnableRootLogin enables/disables login via the root user/password.
+// EnableRootLogin enables/disables the ssh login of the root user
 // The boolean argument passed is used to for enabling and disabling.
 // It sends the middleware's ErrorResponse over rpc.
 func (server *RPCServer) EnableRootLogin(args rpcmessages.ToggleSettingArgs, reply *rpcmessages.ErrorResponse) error {
@@ -401,7 +402,16 @@ func (server *RPCServer) EnableRootLogin(args rpcmessages.ToggleSettingArgs, rep
 	return nil
 }
 
-// SetRootPassword sets the systems root password.
+// EnablePasswordLogin enables/disables the ssh login with a password (in addition to ssh keys)
+// The boolean argument passed is used to for enabling and disabling.
+// It sends the middleware's ErrorResponse over rpc.
+func (server *RPCServer) EnablePasswordLogin(args rpcmessages.ToggleSettingArgs, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnablePasswordLogin(args)
+	log.Printf("sent reply %v: ", reply)
+	return nil
+}
+
+// SetRootPassword sets the system main ssh/login password
 // Passwords have to be at least 8 chars in length.
 // For Unicode passwords the number of unicode chars is counted and not the byte count.
 // It sends the middleware's ErrorResponse over rpc.

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -69,7 +69,7 @@ type Middleware interface {
 	ShutdownBase() rpcmessages.ErrorResponse
 	RebootBase() rpcmessages.ErrorResponse
 	EnableRootLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
-	EnablePasswordLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
+	EnableSSHPasswordLogin(rpcmessages.ToggleSettingArgs) rpcmessages.ErrorResponse
 	UpdateBase(rpcmessages.UpdateBaseArgs) rpcmessages.ErrorResponse
 	GetBaseUpdateProgress() rpcmessages.GetBaseUpdateProgressResponse
 	GetBaseInfo() rpcmessages.GetBaseInfoResponse
@@ -402,11 +402,11 @@ func (server *RPCServer) EnableRootLogin(args rpcmessages.ToggleSettingArgs, rep
 	return nil
 }
 
-// EnablePasswordLogin enables/disables the ssh login with a password (in addition to ssh keys)
+// EnableSSHPasswordLogin enables/disables the ssh login with a password (in addition to ssh keys)
 // The boolean argument passed is used to for enabling and disabling.
 // It sends the middleware's ErrorResponse over rpc.
-func (server *RPCServer) EnablePasswordLogin(args rpcmessages.ToggleSettingArgs, reply *rpcmessages.ErrorResponse) error {
-	*reply = server.middleware.EnablePasswordLogin(args)
+func (server *RPCServer) EnableSSHPasswordLogin(args rpcmessages.ToggleSettingArgs, reply *rpcmessages.ErrorResponse) error {
+	*reply = server.middleware.EnableSSHPasswordLogin(args)
 	log.Printf("sent reply %v: ", reply)
 	return nil
 }

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -98,7 +98,7 @@ func NewTestingRPCServer() TestingRPCServer {
 	testingRPCServer.middlewareMock.On("EnableRootLogin", rpcmessages.ToggleSettingArgs{ToggleSetting: true}).Return(rpcmessages.ErrorResponse{Success: true})
 	testingRPCServer.middlewareMock.On("EnablePasswordLogin", rpcmessages.ToggleSettingArgs{ToggleSetting: true}).Return(rpcmessages.ErrorResponse{Success: true})
 	testingRPCServer.middlewareMock.On("GetBaseInfo").Return(rpcmessages.GetBaseInfoResponse{})
-	testingRPCServer.middlewareMock.On("SetRootPassword", rpcmessages.SetRootPasswordArgs{}).Return(rpcmessages.ErrorResponse{Success: true})
+	testingRPCServer.middlewareMock.On("SetLoginPassword", rpcmessages.SetLoginPasswordArgs{}).Return(rpcmessages.ErrorResponse{Success: true})
 	testingRPCServer.middlewareMock.On("VerificationProgress").Return(rpcmessages.VerificationProgressResponse{})
 	testingRPCServer.middlewareMock.On("UserAuthenticate", rpcmessages.UserAuthenticateArgs{}).Return(
 		rpcmessages.UserAuthenticateResponse{ErrorResponse: &rpcmessages.ErrorResponse{Success: true}},

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -96,7 +96,7 @@ func NewTestingRPCServer() TestingRPCServer {
 	testingRPCServer.middlewareMock.On("ShutdownBase").Return(rpcmessages.ErrorResponse{Success: true})
 	testingRPCServer.middlewareMock.On("RebootBase").Return(rpcmessages.ErrorResponse{Success: true})
 	testingRPCServer.middlewareMock.On("EnableRootLogin", rpcmessages.ToggleSettingArgs{ToggleSetting: true}).Return(rpcmessages.ErrorResponse{Success: true})
-	testingRPCServer.middlewareMock.On("EnablePasswordLogin", rpcmessages.ToggleSettingArgs{ToggleSetting: true}).Return(rpcmessages.ErrorResponse{Success: true})
+	testingRPCServer.middlewareMock.On("EnableSSHPasswordLogin", rpcmessages.ToggleSettingArgs{ToggleSetting: true}).Return(rpcmessages.ErrorResponse{Success: true})
 	testingRPCServer.middlewareMock.On("GetBaseInfo").Return(rpcmessages.GetBaseInfoResponse{})
 	testingRPCServer.middlewareMock.On("SetLoginPassword", rpcmessages.SetLoginPasswordArgs{}).Return(rpcmessages.ErrorResponse{Success: true})
 	testingRPCServer.middlewareMock.On("VerificationProgress").Return(rpcmessages.VerificationProgressResponse{})
@@ -196,9 +196,9 @@ func TestRPCServer(t *testing.T) {
 	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", getToggleSettingArgs(), &enableRootLoginReply)
 	require.Equal(t, true, enableRootLoginReply.Success)
 
-	var enablePasswordLoginReply rpcmessages.ErrorResponse
-	testingRPCServer.RunRPCCall(t, "RPCServer.EnablePasswordLogin", getToggleSettingArgs(), &enablePasswordLoginReply)
-	require.Equal(t, true, enablePasswordLoginReply.Success)
+	var enableSSHPasswordLoginReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnableSSHPasswordLogin", getToggleSettingArgs(), &enableSSHPasswordLoginReply)
+	require.Equal(t, true, enableSSHPasswordLoginReply.Success)
 
 	userAuthenticateArg := rpcmessages.UserAuthenticateArgs{Username: "", Password: ""}
 	var userAuthenticateReply rpcmessages.UserAuthenticateResponse

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -96,6 +96,7 @@ func NewTestingRPCServer() TestingRPCServer {
 	testingRPCServer.middlewareMock.On("ShutdownBase").Return(rpcmessages.ErrorResponse{Success: true})
 	testingRPCServer.middlewareMock.On("RebootBase").Return(rpcmessages.ErrorResponse{Success: true})
 	testingRPCServer.middlewareMock.On("EnableRootLogin", rpcmessages.ToggleSettingArgs{ToggleSetting: true}).Return(rpcmessages.ErrorResponse{Success: true})
+	testingRPCServer.middlewareMock.On("EnablePasswordLogin", rpcmessages.ToggleSettingArgs{ToggleSetting: true}).Return(rpcmessages.ErrorResponse{Success: true})
 	testingRPCServer.middlewareMock.On("GetBaseInfo").Return(rpcmessages.GetBaseInfoResponse{})
 	testingRPCServer.middlewareMock.On("SetRootPassword", rpcmessages.SetRootPasswordArgs{}).Return(rpcmessages.ErrorResponse{Success: true})
 	testingRPCServer.middlewareMock.On("VerificationProgress").Return(rpcmessages.VerificationProgressResponse{})
@@ -194,6 +195,10 @@ func TestRPCServer(t *testing.T) {
 	var enableRootLoginReply rpcmessages.ErrorResponse
 	testingRPCServer.RunRPCCall(t, "RPCServer.EnableRootLogin", getToggleSettingArgs(), &enableRootLoginReply)
 	require.Equal(t, true, enableRootLoginReply.Success)
+
+	var enablePasswordLoginReply rpcmessages.ErrorResponse
+	testingRPCServer.RunRPCCall(t, "RPCServer.EnablePasswordLogin", getToggleSettingArgs(), &enablePasswordLoginReply)
+	require.Equal(t, true, enablePasswordLoginReply.Success)
 
 	userAuthenticateArg := rpcmessages.UserAuthenticateArgs{Username: "", Password: ""}
 	var userAuthenticateReply rpcmessages.UserAuthenticateResponse


### PR DESCRIPTION
When restructuring and renaming some password, minor inconsistencies have been introduced. 

This harmonizes bbb-config.sh and the Go Middelware RPC. No RPCs are renamed, changes are Middleware --> Scripts only.