### PR TITLE
Add factory reset framework and implement authentication reset

### DIFF
--- a/armbian/base/scripts/systemd-update-checks.sh
+++ b/armbian/base/scripts/systemd-update-checks.sh
@@ -37,6 +37,57 @@ redis_set "base:version" "${VERSION}"
 # update onion addresses in Redis
 updateTorOnions
 
+# check for reset triggers on flashdrive
+if FLASHDRIVE="$(/opt/shift/scripts/bbb-cmd.sh flashdrive check)"; then
+    echo "RESET: device ${FLASHDRIVE} detected"
+    if /opt/shift/scripts/bbb-cmd.sh flashdrive mount "${FLASHDRIVE}"; then
+        echo "RESET: flashdrive mounted"
+
+        # are all necessary files for a reset present?
+        if [[ -f /mnt/backup/.reset-token ]] && [[ -f /data/reset-token-hashes ]]; then
+            FLASHDRIVE_TOKEN_HASH="$(sha256sum /mnt/backup/.reset-token | cut -f 1 -d " ")"
+            echo "RESET: reset token present on flashdrive, hashed value: ${FLASHDRIVE_TOKEN_HASH}"
+
+            # is hashed reset token present on Base?
+            if grep -q "${FLASHDRIVE_TOKEN_HASH}" /data/reset-token-hashes; then
+                echo "RESET: valid reset token found"
+
+                if [[ -f /mnt/backup/reset-base-auth ]]; then
+                    echo "RESET: trigger file 'reset-base-auth' found, initiating reset of authentication"
+                    /opt/shift/scripts/bbb-cmd.sh reset auth --assume-yes
+                    mv /mnt/backup/reset-base-auth /mnt/backup/reset-base-auth.done
+                fi
+
+                if [[ -f /mnt/backup/reset-base-config ]]; then
+                    echo "RESET: trigger file 'reset-base-config' found. Feature not implemented yet."
+                    mv /mnt/backup/reset-base-config /mnt/backup/reset-base-config.done
+                fi
+
+                if [[ -f /mnt/backup/reset-base-ssd ]]; then
+                    echo "RESET: trigger file 'reset-base-ssd' found. Feature not implemented yet."
+                    mv /mnt/backup/reset-base-ssd /mnt/backup/reset-base-ssd.done
+                fi
+
+                if [[ -f /mnt/backup/reset-base-image ]]; then
+                    echo "RESET: trigger file 'reset-base-image' found. Feature not implemented yet."
+                    mv /mnt/backup/reset-base-image /mnt/backup/reset-base-image.done
+                fi
+            else
+                echo "RESET: reset token on flashdrive does not match authorized tokens on the Base"
+            fi
+        else
+            echo "RESET: not all files for a reset present, doing nothing."
+        fi
+
+        umount /mnt/backup
+
+    else
+        echo "RESET: warning, could not mount flashdrive ${FLASHDRIVE}"
+    fi
+else
+    echo "RESET: no flashdrive detected."
+fi
+
 # check if booting after update
 # valid status codes of 'base:updating'
 #    0: no update in progress


### PR DESCRIPTION
Implements shiftdevices/bitbox-base-internal#308

**Add 'reset' features for authentication**
* Users need to be able to reset various aspects of the Base config.
* With `bbb-cmd.sh reset <auth|config|image|ssd>` different components can be reset to factory settings.
* When run manually, user needs to confirm the reset by typing `YES`. For non-interactive usage, the flag `--assume-yes` can be used.

The commit
* adds the overall framework for all 'reset' commands, without adding the specific functionality.
* Implements the first reset command `bbb-cmd.sh reset auth`

**Check reset trigger / token on flashdrive when booting**
* User must be able to reset a forgotten password.
* The App is of not much use, because the user can no longer access the Base using the App.
* On boot, the Base checks if a flashdrive is present and looks for certain trigger files (e.g. `reset-base-auth`)
* As a password reset gives full access to the Base, the flashdrive must contain a reset token that is created on backup.
* The hashed reset token is compared with the hash that is stored on the Base and if they match, the reset actions are triggered.

The commit
* extends `bbb-cmd.sh backup sysconfig` to also store a restore token on the flashdrive, and keep the hashed token on the Base
* mounts flashdrive on boot in `systemd-update-checks.sh`, checks if a valid reset token is present and triggers reset actions