### PR TITLE
update 'build-ondevice' make target

### DIFF
--- a/armbian/armbian-build.sh
+++ b/armbian/armbian-build.sh
@@ -65,10 +65,19 @@ case ${ACTION} in
 		;;
 
 	ondevice)
-    	# copy custom scripts to filesystem
-    	mkdir -p /opt/shift
-    	cp -aR base/* /opt/shift
-    	chmod -R +x /opt/shift/scripts
+		# copy custom scripts to filesystem
+		mkdir -p /opt/shift
+		cp -aR base/* /opt/shift
+		chmod -R +x /opt/shift/scripts
+
+		# check dependency: Go binaries
+		if [[ -f ../bin/go/bbbmiddleware ]] && [[ -f ../bin/go/bbbconfgen ]] && [[ -f ../bin/go/bbbfancontrol ]] && [[ -f ../bin/go/bbbsupervisor ]]; then
+			mkdir -p /opt/shift/bin/go
+			cp -aR ../bin/go/* /opt/shift/bin/go/
+		else
+			echo "ERR: Go tool dependencies missing, build them first by running 'make docker-build-go' in the repository root (requires Docker)"
+			exit 1
+		fi
 
 		# run customization script
 		base/customize-armbian-rockpro64.sh ondevice

--- a/armbian/base/scripts/prometheus-base.py
+++ b/armbian/base/scripts/prometheus-base.py
@@ -55,10 +55,15 @@ def getIP():
 def getSystemInfo():
     rediskeys = ['base:hostname','base:version','build:date','build:time','build:commit']
     info = {}
-    # add Redis values
+        # add Redis values
     for k in rediskeys:
         infoName = k.lower().replace(":", "_")
-        infoValue = r.get(k).decode("utf-8")
+        infoValue = r.get(k)
+        if infoValue is not None:
+            infoValue = infoValue.decode("utf-8")
+        else:
+            infoValue = 'n/a'
+
         info[infoName] = infoValue
 
     info['base_ipaddress'] = getIP()

--- a/middleware/Makefile
+++ b/middleware/Makefile
@@ -25,8 +25,8 @@ build: generate
 	go install $(REPO_ROOT)/middleware/cmd/middleware
 
 aarch64: check-go-env ci
-	GOARCH=arm64 go install $(REPO_ROOT)/middleware/cmd/middleware
-	cp ${GOPATH}/bin/linux_arm64/middleware $(REPO_ROOT)/bin/go/bbbmiddleware
+	GOARCH=arm64 go build $(REPO_ROOT)/middleware/cmd/middleware
+	cp $(REPO_ROOT)/middleware/middleware $(REPO_ROOT)/bin/go/bbbmiddleware
 
 regtest-up:
 	cd $(REPO_ROOT)/middleware/integration_test ;\

--- a/tools/bbbconfgen/Makefile
+++ b/tools/bbbconfgen/Makefile
@@ -5,9 +5,9 @@ check-go-env:
 	@echo "Checking that environment supports Go builds.."
 	@$(REPO_ROOT)/contrib/check-go-env.sh "$(REPO_ROOT)"
 
-native: check-go-env 
+native: check-go-env
 	go install $(REPO_ROOT)/tools/bbbconfgen
 
 aarch64: check-go-env
-	GOARCH=arm64 go install $(REPO_ROOT)/tools/bbbconfgen
-	cp ${GOPATH}/bin/linux_arm64/bbbconfgen $(REPO_ROOT)/bin/go/
+	GOARCH=arm64 go build $(REPO_ROOT)/tools/bbbconfgen
+	cp $(REPO_ROOT)/tools/bbbconfgen/bbbconfgen $(REPO_ROOT)/bin/go/

--- a/tools/bbbfancontrol/Makefile
+++ b/tools/bbbfancontrol/Makefile
@@ -9,5 +9,5 @@ native: check-go-env
 	go install $(REPO_ROOT)/tools/bbbfancontrol
 
 aarch64: check-go-env
-	GOARCH=arm64 go install $(REPO_ROOT)/tools/bbbfancontrol
-	cp ${GOPATH}/bin/linux_arm64/bbbfancontrol $(REPO_ROOT)/bin/go/
+	GOARCH=arm64 go build $(REPO_ROOT)/tools/bbbfancontrol
+	cp $(REPO_ROOT)/tools/bbbfancontrol/bbbfancontrol $(REPO_ROOT)/bin/go/

--- a/tools/bbbsupervisor/Makefile
+++ b/tools/bbbsupervisor/Makefile
@@ -9,5 +9,5 @@ native: check-go-env
 	go install $(REPO_ROOT)/tools/bbbsupervisor
 
 aarch64: check-go-env
-	GOARCH=arm64 go install $(REPO_ROOT)/tools/bbbsupervisor
-	cp ${GOPATH}/bin/linux_arm64/bbbsupervisor $(REPO_ROOT)/bin/go/
+	GOARCH=arm64 go build $(REPO_ROOT)/tools/bbbsupervisor
+	cp $(REPO_ROOT)/tools/bbbsupervisor/bbbsupervisor $(REPO_ROOT)/bin/go/


### PR DESCRIPTION
This pull request updates the build method to run the configuration script directly on a preinstalled Linux distribution. It's used mainly for testing of non-Armbian distributions.

**compile Go: use build instead of install in Docker**
https://github.com/shiftdevices/bitbox-base-internal/issues/326

Because:
* When cross-compiling the Go tools inside Docker, with the command
  'docker install', the binaries are put into the directory
  $GOPATH/bin/linux_arm64
* One goal is to run installation (incl. Go compilation) directly on
  the ARM device, to support other distributions. When not cross-
  compiling, the binaries are put into $GOPATH/bin/, failing the
  make process.

This commit:
* uses 'go build' instead of 'go install' to always put the binaries
  directly in the source directory and copy them from there.

**Update 'make build-ondevice'**
Because:
* Users should be able to run the BitBoxBase customization on a vanilla
  Linux installation, e.g. the Ayufan ARM distribution.
* For that to work, Go binaries need to be compiled first.
* Armbian specific changes are allowed to be skipped in that build mode

This commit:
* checks if Go tool binaries are available, or aborts
* adds some checks in customization script when running on device
* in prometheus-base.sh, check if Redis values like 'build:date' or
  'build:commit' are null and return 'n/a'.