### PR TITLE
build: create Base image tarball

### DIFF
--- a/armbian/mender-convert.sh
+++ b/armbian/mender-convert.sh
@@ -71,12 +71,16 @@ case ${ACTION} in
 		rm "output/${TEMP_NAME}.ext4"
 
 		mkdir -p "../../bin/img-mender/${VERSION}"
-		mv "output/${TEMP_NAME}.sdimg" "output/${TARGET_NAME}.img"
-		mv "output/${TEMP_NAME}.mender" "output/${TARGET_NAME}.base-unsigned"
-		mv output/"${TARGET_NAME}"* "../../bin/img-mender/${VERSION}/"
+
+		cd output
+		mv "${TEMP_NAME}.sdimg" "${TARGET_NAME}.img"
+		tar -czf "${TARGET_NAME}.tar.gz" "${TARGET_NAME}.img"
+		mv "${TEMP_NAME}.mender" "${TARGET_NAME}.base-unsigned"
+		mv "${TARGET_NAME}"* "../../../bin/img-mender/${VERSION}/"
+		cd ..
 
 		echo "Mender files ready for provisioning:"
-		stat -c "%y %s %n" "../../bin/img-mender/${VERSION}/${TARGET_NAME}"*
+		ls -lh "../../bin/img-mender/${VERSION}/${TARGET_NAME}"*
 		echo
 		echo "Write to eMMC with the following command (check target device /dev/sdX first!):"
 		echo "dd if=./bin/img-mender/${VERSION}/${TARGET_NAME}.img of=/dev/sdX bs=4M conv=sync status=progress && sync"


### PR DESCRIPTION
https://github.com/shiftdevices/bitbox-base-internal/issues/263
https://github.com/shiftdevices/bitbox-base-signing/pull/1

When signing official releases, the uncompressed 8 GB Base image is cumbersome to process in Tails.

This pull request extends the build process to provide a compressed Base image named as `BitBoxBase-vX.X.X-RockPro64.tar.gz`