### PR TITLE
docs: add 'Tinkering' section

### DIFF
--- a/docs/applications/bitcoin-core.md
+++ b/docs/applications/bitcoin-core.md
@@ -59,8 +59,8 @@ Some notes about this specific configuration:
 
 * **Network options**
   * `mainnet`/`testnet`: the build script defaults to building a mainnet node, but can be reconfigured by:
-    * specifying the corresponding build parameter in [`build.conf`](../../armbian/base/build/build.conf)
-    * or running the command `bbb-config.sh set bitcoin_network testnet` manually on the BitBoxBase (see [Operating System/Helper Scripts](../os/helper-scripts.md)).
+    * specifying the corresponding build parameter in [`build.conf`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/build.conf)
+    * or running the command `bbb-config.sh set bitcoin_network testnet` manually on the BitBoxBase (see [Operating System/Helper Scripts](../customapps/helper-scripts.md)).
 
 * **Server options**
   * `server`: enables the RPC interface
@@ -90,7 +90,7 @@ Some notes about this specific configuration:
 
 ### Service management
 
-The bitcoind service is managed by systemd. Relevant parameters are specified in the unit file `bitcoind.service` shown below. Please check the most current initial configuration in [`customize-armbian-rockpro64.sh`](../../armbian/base/build/customize-armbian-rockpro64.sh).
+The bitcoind service is managed by systemd. Relevant parameters are specified in the unit file `bitcoind.service` shown below. Please check the most current initial configuration in [`customize-armbian-rockpro64.sh`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/customize-armbian-rockpro64.sh).
 
 ```console
 [Unit]

--- a/docs/customapps/go-build.md
+++ b/docs/customapps/go-build.md
@@ -6,7 +6,7 @@ parent: Custom applications
 ---
 ## Building Go binaries
 
-The BitBoxBase runs custom software written in Go that has to be compiled and become part of [the Armbian image](/os/armbian-build.md).
+The BitBoxBase runs custom software written in Go that has to be compiled and become part of [the Armbian image](../os/armbian-build.md).
 This page describes the process used to build those images.
 
 The top-level [`Makefile`](https://github.com/digitalbitbox/bitbox-base/blob/master/Makefile) for the repository has two targets:
@@ -14,6 +14,6 @@ The top-level [`Makefile`](https://github.com/digitalbitbox/bitbox-base/blob/mas
 - `make docker-build-go`: build the Go applications inside a Docker container
 - `make build-go`: build the Go applications on the host
 
-The default `make` target invokes the `make docker-build-go` target to produce Go binaries compiled for the target CPU architecture in the `bin/go` directory, and then builds [the Armbian image](/os/armbian-build.md), using the `bin/go` contents as inputs.
+The default `make` target invokes the `make docker-build-go` target to produce Go binaries compiled for the target CPU architecture in the `bin/go` directory, and then builds [the Armbian image](../os/armbian-build.md), using the `bin/go` contents as inputs.
 
 For users that have the Go toolchain installed on the host system, `make build-go` should also work fine, and if the Go environment is not configured correctly, the command should produce some useful information to debug the issue.

--- a/docs/customapps/helper-scripts.md
+++ b/docs/customapps/helper-scripts.md
@@ -32,6 +32,34 @@ possible commands:
             other arguments         string
 ```
 
+* **`enable`** or **`disable`** the following options:
+
+  * `bitcoin_incoming`: Bitcoin Core accepts incoming connections
+  * `bitcoin_ibd`: system is configured for Bitcoin initial block download (IBD) mode, setting `dbcache` to 2 GB and disabling `lightningd.service` and `electrs.service`.
+  * `bitcoin_ibd_clearnet`: Bitcoin Core uses public internet for IBD and then automatically switch to Tor
+  * `dashboard_hdmi`: Grafana system monitoring dashboard on the HDMI output. This feature is experimental and currently not available in official images, as the option BASE_HDMI_BUILD must also be enabled in [build.conf](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/build.conf) when building the Armbian image.
+  * `dashboard_web`: Grafana system monitoring dashboard available as website, e.g. under http://bitbox-base.local. For development only, off by default.
+  * `wifi`: support for Wifi (experimental)
+  * `autosetup_ssd`: detect an empty drive (ssd or hd, USB or PCIe) on boot and set it up automatically. See script [`autosetup-ssd.sh`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/scripts/autosetup-ssd.sh) for details.
+  * `tor`: Tor service, used for Bitcoin Core and c-lightning.
+  * `tor_bbbmiddleware`: Tor hidden service for the BitBoxBase middleware, to connect from BitBoxApp, needs `tor` enabled
+  * `tor_ssh`: Tor hidden service for SSH login, needs `tor` enabled
+  * `tor_electrum`: Tor hidden service for Electrs, needs `tor` enabled
+  * `overlayroot`: using `overlayrootfs`, mounting the root filesystem as read-only, with a ephemeral tmpfs overlay. Needs restart.
+  * Insecure development options (see section [Tinkering](../tinkering)):
+    * `sshpwlogin`: SSH login with password
+    * `rootlogin`: SSH login as root user
+    * `unsigned_updates`: allow updating from unsigned Mender images
+
+* **set** the following option:
+
+  * `hostname`: set hostname persistently
+  * `loginpw`: change login/sudo password for both users `base` and `root`, will be overwritten when running the BitBoxApp Setup Wizard again
+  * `wifi_ssid`: [experimental] SSID for wifi
+  * `wifi_pw`: [experimental] PW for wifi
+  * `bitcoin_network`: Bitcoin network, either `mainnet` or `testnet`
+  * `bitcoin_dbcache`: set `dbcache` option for Bitcoin Core
+
 ### [**bbb-cmd.sh**](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/scripts/bbb-cmd.sh): execution of standard commands
 
 Similar to the configuration script, the [`bbb-cmd.sh`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/scripts/bbb-cmd.sh) script acts as the central repository for standard commands, mainly to be called from the Middleware.
@@ -60,10 +88,6 @@ The following commands are available:
     * read-only disk, with Mender (BitBoxBase production image)
       the `/data` directory is mounted from a separate, persistent partition that is not overwritten on update. Initial content is copied once from `/data_src` into that partition.
 
-* **base**: does exactly what it says, but could contain custom commands before powering down in the future
-  * **restart**: restarts the device
-  * **shutdown**: shuts down the device
-
 * **bitcoind**
   * **reindex**: deletes the Bitcoin Core chainstate (UTXO set) and the Electrs indices, but not the raw blockchain data. Bitcoin Core is restarted to reindex the whole existing blockchain, thus building up a new UTXO set and validating the whole blockchain from Genesis.
   * **resync**: in addition to *reindex*, this command also deletes the raw blockchain data. After restarting Bitcoin Core, the whole blockchain data (~250 GB) are downloaded before a full validation is conducted.
@@ -83,7 +107,7 @@ The following commands are available:
   * **hsm_secret**: saves the c-lightning on-chain seed from Redis into `/mnt/ssd/bitcoin/.lightning/hsm_secret`
 
 * **mender-update**
-  * **install**: expects a Base image version and downloads/verifies/installs the Mender update artefact into the inactive partition. A reboot is required to boot into the updated system.
+  * **install**: expects a Base image version and downloads/verifies/installs the Mender update artefact into the inactive partition. A reboot is required to boot into the updated system. This command requireds either a version number (in the format of `x.x.x`) to fetch the release from GitHub, or `flashdrive` to load the update from a mounted usb flashdrive (update image must be available as `/mnt/backup/update.base`)
   * **commit**: commits an update to become persistent. If it is not committed, the device falls back to the previous Base image on reboot.
 
 ### [**bbb-systemctl.sh**](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/scripts/bbb-systemctl.sh): manage and check systemd units in batch

--- a/docs/operating-system.md
+++ b/docs/operating-system.md
@@ -11,4 +11,4 @@ As the BitBoxBase is designed as a networked appliance, it's important that the 
 
 The Debian-based Linux distribution Armbian also features a reliable build environment that allows to build the operating system from source, configure the resulting kernel in minute detail and customize the resulting disk image using regular bash scripts within a chroot environment.
 
-More detail on how to build the base operating image yourself will be detailed in the [Armbian build](armbian-build.md) docs.
+More detail on how to build the base operating image yourself will be detailed in the [Armbian build](os/armbian-build.md) docs.

--- a/docs/overview/diy.md
+++ b/docs/overview/diy.md
@@ -58,7 +58,7 @@ We assume that running Docker requires `sudo`, therefore `sudo make` is needed. 
   sudo make update
   ```
 
-See [Building the Armbian base image](/os/armbian-build.md) and related pages for more details.
+See [Building the Armbian base image](../os/armbian-build.md) and related pages for more details.
 
 **Create Mender.io update artefacts**
 

--- a/docs/tinkering.md
+++ b/docs/tinkering.md
@@ -1,0 +1,139 @@
+---
+layout: default
+title: Tinkering
+nav_order: 800
+---
+# BitBoxBase: Tinkering
+
+For **advanced users**, full root access and the possibility to validate and customize the BitBoxBase configuration is a must. This section explains how to work with the device on a operating-system level. Be aware that you could easily break stuff and might not be able to recover the factory settings easily.
+
+## SSH access
+
+SSH access is disabled by default. Once enabled, you should always log in with the user `base` that has sudo privileges. The user password corresponds to the one set in the BitBoxApp setup wizard.
+
+There are multiple ways to gain access, some usable for production, others only suitable to be used for development:
+
+* **SSH keys**: if SSH keys are present in `/home/base/.ssh/authorized_keys`, SSH login is possible over regular IP address, the mDNS domain (e.g. `ssh base@bitbox-base.local`) or even a Tor hidden service (if enabled).
+
+  Currently, the keys need to be added manually, either by logging in locally or after login in with a password (see next option). We plan to allow users to add SSH keys from the BitBoxApp.
+* **Password login**: this authentication method is not secure and should not be enabled for longer periods on a production device.
+
+  It can be enabled in the BitBoxApp node management under "Advanced options". Alternatively, you can run `sudo bbb-config.sh enable sshpwlogin` directly on the command line. After enabling, you can log in with the user `base` using the password set in the Setup wizard.
+* **Root login**: SSH access for the `root` user is disabled by default. For development, it can be enabled from the command line, e.g. to copy updated scripts directly into system folders that require root access. On the BitBoxBase, logged in with user `base`, run `sudo bbb-config.sh enable rootlogin`.
+
+If you build the BitBoxBase image yourself, you can configure the options `BASE_LOGINPW` (initial login password, overwritten by the Setup Wizard) and `BASE_SSH_PASSWORD_LOGIN` in [build.conf](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/build.conf).
+
+## Disable overlayroot filesystem
+
+You must be aware that the whole **root filesystem is mounted as read-only**, and a temporary in-memory filesystem is used as an overlay. That means that you can change anything you want on the rootfs of the BitBoxBase (not the SSD, though!), but **on reboot, all changes are gone**.
+
+This is great for resilience, eg. no corruption can occur on a sudden power outage, but it's not great for tinkering with your device.
+
+For quick changes to the read-only filesystem, you can chroot into it:
+
+```
+$ sudo overlayroot-chroot
+INFO: Chrooting into [/media/root-ro]
+...
+# do your stuff
+...
+$ exit
+```
+
+To deactivate the overlay root filesystem, run `sudo bbb-config.sh disable overlayrootfs` from the command line. After a reboot, the rootfs is mounted regularly and all changes are persistent. You can always `enable` the overlayrootfs again, using the same script. Each official update overwrites the whole rootfs, however.
+
+If you build the BitBoxBase image yourself, you can configure the option `BASE_OVERLAYROOT` in [build.conf](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/build.conf).
+
+## Configuration: bbb-config.sh
+
+Most configuration options can be enabled, disabled or set using the script [`bbb-config.sh`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/scripts/bbb-config.sh). It must be run with sudo privileges and is the central repository to make persistent configuration changes, as it also writes into the read-only rootfs when necessary.
+
+```
+$ bbb-config.sh
+
+BitBox Base: system configuration utility
+usage: bbb-config.sh [--version] [--help]
+                     <command> [<args>]
+
+assumes Redis database running to be used with 'redis-cli'
+
+possible commands:
+  enable    <bitcoin_incoming|bitcoin_ibd|bitcoin_ibd_clearnet|dashboard_hdmi|
+             dashboard_web|wifi|autosetup_ssd|tor|tor_bbbmiddleware|tor_ssh|
+             tor_electrum|overlayroot|sshpwlogin|rootlogin|unsigned_updates>
+
+  disable   any 'enable' argument
+
+  set       <hostname|loginpw|wifi_ssid|wifi_pw>
+            bitcoin_network         <mainnet|testnet>
+            bitcoin_dbcache         int (MB)
+            other arguments         string
+```
+
+See section [Custom applications / Helper scripts](helper-scripts.md#bbb-configsh-configuration-management) for more information.
+
+## Commands: bbb-cmd.sh
+
+Recurring commands are available in the central repository [`bbb-cmd.sh`](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/scripts/bbb-cmd.sh). Run it with sudo directly from the command line.
+
+```
+$ bbb-cmd.sh
+
+BitBox Base: system commands repository
+usage: bbb-cmd.sh [--version] [--help] <command>
+
+possible commands:
+  setup         <datadir>
+  bitcoind      <reindex|resync|refresh_rpcauth>
+  flashdrive    <check|mount|umount>
+  backup        <sysconfig|hsm_secret>
+  restore       <sysconfig|hsm_secret>
+  reset         <auth|config|image|ssd>
+  mender-update <install|commit>
+```
+
+See section [Custom applications / Helper scripts](helper-scripts.md#bbb-cmdsh-execution-of-standard-commands) for more information.
+
+## Redis configuration management
+
+The scripts above manipulate the configuration management database that is provided by [Redis](applications/redis.md). You can manually read and set the value of Redis keys using its command line application:
+
+```
+$ redis-cli get bitcoind:txindex
+"0"
+$ redis-cli set bitcoind:txindex 1
+OK
+```
+
+All keys that are used are listed in the [Redis factory settings](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/config/redis/factorysettings.txt). Keys that are populated on first boot are listed with the value `xxx`.
+
+## Configuration templates
+
+While the Middleware and some scripts query Redis directly, most keys need to be written into configuration files to take effect. All files that contain changing values are available as templates located in [`/opt/shift/config/templates/`](https://github.com/digitalbitbox/bitbox-base/tree/master/armbian/base/config/templates) and can be regenerated with the [BitBoxBase Confgen](customapps/bbbconfgen.md).
+
+In the above example, the Bitcoin Core transaction index is configured, but not yet written to the file `/etc/bitcoin/bitcoin.conf`. The file [`bitcoin.conf.template`] contains references to the target location and all relevant Redis keys. To recreate the configuration file, run the following command:
+
+```
+$ bbbconfgen --template /opt/shift/config/templates/bitcoin.conf.template
+
+connected to Redis
+opened template config file /opt/shift/config/templates/bitcoin.conf.template
+writing into output file /etc/bitcoin/bitcoin.conf
+written 28 lines
+placeholders: 19 replaced, 0 kept, 0 deleted, 0 lines deleted, 1 set to default
+checks: 4 lines dropped, 4 lines kept
+```
+
+If the overlay root filesystem is enabled, you need to make sure that the configuration file is not only written into the tmpfs overlay. Either disable overlayrootfs (and reboot first), or use `overlayroot-chroot`.
+
+## Factory reset
+
+It is possible to reset various aspects the BitBoxBase to factory settings, either through the BitBoxApp (not implemented yet) or by creating a trigger file on the backup USB flashdrive.
+
+In case of a forgotten password (set in the BitBoxApp Setup Wizard), it can be reset as follows:
+
+* On the backup flashdrive, create a file named `reset-base-auth`.
+* The flashdrive must contain a valid reset token, created on initial setup or subsequent backups
+* Plug the flashdrive into the BitBoxBase
+* Restart the device
+* The authentication is now reset, run the BitBoxApp Setup Wizard again to set a new password.


### PR DESCRIPTION
Beta testers working with the device should have a good first explanation of the steps we are using in development regularly, but could be hard to figure out without guidance.

* adds a 'Tinkering' section to the technical documentation
* extends the 'Helper scripts' docs with additional details for
  'bbb-config.sh'
* fixes some broken links