### PR TITLE
add: read IPC notifications from a named pipe

### DIFF
--- a/middleware/cmd/middleware/main.go
+++ b/middleware/cmd/middleware/main.go
@@ -30,6 +30,7 @@ func main() {
 	redisPort := flag.String("redisport", "6379", "Port of the Redis server")
 	redisMock := flag.Bool("redismock", false, "Mock redis for development instead of connecting to a redis server, default is 'false', use 'true' as an argument to mock")
 	imageUpdateInfoURL := flag.String("updateinfourl", "https://shiftcrypto.ch/updates/base.json", "URL to query information about updates from (defaults to https://shiftcrypto.ch/updates/base.json)")
+	notificationNamedPipePath := flag.String("notificationNamedPipePath", "/tmp/middleware-notification.pipe", "notificationNamedPipe specifies the path where the Middleware creates a named pipe to receive notifications from other processes on the BitBoxBase (defaults to /tmp/middleware-notification.pipe)")
 	flag.Parse()
 
 	argumentMap := make(map[string]string)
@@ -45,6 +46,7 @@ func main() {
 	argumentMap["prometheusURL"] = *prometheusURL
 	argumentMap["redisPort"] = *redisPort
 	argumentMap["imageUpdateInfoURL"] = *imageUpdateInfoURL
+	argumentMap["notificationNamedPipePath"] = *notificationNamedPipePath
 	argumentMap["middlewareVersion"] = version
 
 	logBeforeExit := func() {
@@ -56,6 +58,7 @@ func main() {
 		}
 	}
 	defer logBeforeExit()
+
 	middleware, err := middleware.NewMiddleware(argumentMap, *redisMock)
 	if err != nil {
 		log.Fatalf("error starting the middleware: %s . Is redis connected? \nIf you are running the middleware outside of the base consider setting the redis mock flag to true: '-redismock true' .", err.Error())

--- a/middleware/src/ipcnotification/ipcnotification.go
+++ b/middleware/src/ipcnotification/ipcnotification.go
@@ -1,0 +1,136 @@
+// Package ipcnotification reads notifications from a named pipe and passes them
+// into a channel.
+package ipcnotification
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"syscall"
+)
+
+// Notification represents an IPC notification that is passed via a named pipe.
+type Notification struct {
+	Version int         `json:"version"`
+	Topic   string      `json:"topic"`
+	Payload interface{} `json:"payload"`
+}
+
+func (notification *Notification) String() string {
+	return fmt.Sprintf("[Version: %d, Topic: %s, Payload: %v]", notification.Version, notification.Topic, notification.Payload)
+}
+
+// Reader reads IPCNotifications from a named pipe into a channel.
+type Reader struct {
+	notifications chan Notification
+	closing       bool
+	filePath      string
+	namedPipe     *os.File
+}
+
+// NewReader returns a new Reader that starts reading from the named pipe passed.
+func NewReader(filepath string) (*Reader, error) {
+	reader := &Reader{
+		notifications: make(chan Notification),
+		filePath:      filepath,
+		namedPipe:     nil,
+		closing:       false,
+	}
+
+	_, err := os.Stat(reader.filePath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			log.Printf("Could not find named pipe '%s'. Creating new named pipe.", reader.filePath)
+			// The file permission 0622 are set, so that everybody can write into the
+			// pipe, but only the middleware can read.
+			err := syscall.Mkfifo(reader.filePath, 0600)
+			if err != nil {
+				return nil, fmt.Errorf("could not create a new named pipe '%s': %w", reader.filePath, err)
+			}
+		} else {
+			return nil, fmt.Errorf("could not stat the named pipe '%s': %w", reader.filePath, err)
+		}
+	} else {
+		log.Printf("Using existing named pipe '%s' for IPC notifications.", reader.filePath)
+	}
+
+	// os.OpenFile opens (or creates and opens if not present) the named pipe.
+	// Due to a quirk in the Unix named pipe implementation os.O_RDWR has to be
+	// used instead of os.O_RDONLY. O_RDONLY blocks unit the pipe is written to.
+	// https://stackoverflow.com/a/5782778/8896600
+	namedPipe, err := os.OpenFile(reader.filePath, os.O_RDWR, os.ModeNamedPipe)
+	if err != nil {
+		return nil, fmt.Errorf("could not open the named pipe in '%s': %w", reader.filePath, err)
+	}
+	reader.namedPipe = namedPipe
+
+	go reader.read()
+	return reader, nil
+}
+
+func (reader *Reader) read() {
+	defer func() {
+		err := reader.namedPipe.Close()
+		if err != nil {
+			log.Printf("Could not close named pipe: %s", err)
+		}
+	}()
+	scanner := bufio.NewScanner(reader.namedPipe)
+
+	for {
+		if scanner.Scan() {
+			notificationBytes := scanner.Bytes()
+			notificationText := scanner.Text()
+
+			// A write to a named pipe is only atomic if less than {PIPE_BUF} bytes
+			// are written. {PIPE_BUF} for Linux is 4096. This is enforced by dropping
+			// IPC notifications that are longer than 4096 byte.
+			if len(notificationBytes) >= 4096 {
+				log.Printf("IPC notification dropped: longer than 4095 byte (%d byte).\n", len(notificationBytes))
+				continue
+			}
+
+			notification := Notification{}
+			err := json.Unmarshal(notificationBytes, &notification)
+			if err != nil {
+				log.Printf("IPC notification dropped: could not unmarshal as JSON '%s': %s.\n", notificationText, err)
+				continue
+			}
+
+			reader.notifications <- notification
+		} else {
+			err := scanner.Err()
+
+			// handle EOF
+			if err == nil {
+				break
+			}
+
+			// handle file is closed after Stop() was called
+			if errors.Is(err, os.ErrClosed) && reader.closing {
+				break
+			}
+
+			log.Printf("Could not read from named pipe %s", err)
+			break
+		}
+	}
+}
+
+// Notifications returns the notification channel for the Reader.
+func (reader *Reader) Notifications() chan Notification {
+	return reader.notifications
+}
+
+// Close closes the reader.
+func (reader *Reader) Close() error {
+	reader.closing = true
+	err := reader.namedPipe.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/middleware/src/system/system.go
+++ b/middleware/src/system/system.go
@@ -3,19 +3,20 @@ package system
 
 // Environment provides some information on the system we are running on.
 type Environment struct {
-	middlewarePort     string
-	Network            string `json:"network"`
-	ElectrsRPCPort     string `json:"electrsRPCPort"`
-	bitcoinRPCUser     string
-	bitcoinRPCPassword string
-	bitcoinRPCPort     string
-	lightningRPCPath   string
-	bbbConfigScript    string
-	bbbCmdScript       string
-	prometheusURL      string
-	redisPort          string
-	middlewareVersion  string
-	imageUpdateInfoURL string
+	middlewarePort            string
+	Network                   string `json:"network"`
+	ElectrsRPCPort            string `json:"electrsRPCPort"`
+	bitcoinRPCUser            string
+	bitcoinRPCPassword        string
+	bitcoinRPCPort            string
+	lightningRPCPath          string
+	bbbConfigScript           string
+	bbbCmdScript              string
+	prometheusURL             string
+	redisPort                 string
+	middlewareVersion         string
+	imageUpdateInfoURL        string
+	notificationNamedPipePath string
 }
 
 // NewEnvironment returns a new Environment instance.
@@ -23,19 +24,20 @@ type Environment struct {
 func NewEnvironment(argumentMap map[string]string) Environment {
 	// TODO(TheCharlatan) Instead of just accepting a long list of arguments, use a map here and check if the arguments can be read from a system config.
 	environment := Environment{
-		middlewarePort:     argumentMap["middlewarePort"],
-		bitcoinRPCUser:     argumentMap["bitcoinRPCUser"],
-		bitcoinRPCPassword: argumentMap["bitcoinRPCPassword"],
-		bitcoinRPCPort:     argumentMap["bitcoinRPCPort"],
-		lightningRPCPath:   argumentMap["lightningRPCPath"],
-		ElectrsRPCPort:     argumentMap["electrsRPCPort"],
-		Network:            argumentMap["network"],
-		bbbConfigScript:    argumentMap["bbbConfigScript"],
-		bbbCmdScript:       argumentMap["bbbCmdScript"],
-		prometheusURL:      argumentMap["prometheusURL"],
-		redisPort:          argumentMap["redisPort"],
-		middlewareVersion:  argumentMap["middlewareVersion"],
-		imageUpdateInfoURL: argumentMap["imageUpdateInfoURL"],
+		middlewarePort:            argumentMap["middlewarePort"],
+		bitcoinRPCUser:            argumentMap["bitcoinRPCUser"],
+		bitcoinRPCPassword:        argumentMap["bitcoinRPCPassword"],
+		bitcoinRPCPort:            argumentMap["bitcoinRPCPort"],
+		lightningRPCPath:          argumentMap["lightningRPCPath"],
+		ElectrsRPCPort:            argumentMap["electrsRPCPort"],
+		Network:                   argumentMap["network"],
+		bbbConfigScript:           argumentMap["bbbConfigScript"],
+		bbbCmdScript:              argumentMap["bbbCmdScript"],
+		prometheusURL:             argumentMap["prometheusURL"],
+		redisPort:                 argumentMap["redisPort"],
+		middlewareVersion:         argumentMap["middlewareVersion"],
+		imageUpdateInfoURL:        argumentMap["imageUpdateInfoURL"],
+		notificationNamedPipePath: argumentMap["notificationNamedPipePath"],
 	}
 	return environment
 }
@@ -93,4 +95,9 @@ func (environment *Environment) GetMiddlewarePort() string {
 // GetImageUpdateInfoURL is a getter for the URL that specifies where the middleware queries the update info.
 func (environment *Environment) GetImageUpdateInfoURL() string {
 	return environment.imageUpdateInfoURL
+}
+
+// GetNotificationNamedPipePath is a getter for the path where the middleware creates and looks for the
+func (environment *Environment) GetNotificationNamedPipePath() string {
+	return environment.notificationNamedPipePath
 }

--- a/middleware/src/system/system_test.go
+++ b/middleware/src/system/system_test.go
@@ -21,6 +21,7 @@ func TestSystem(t *testing.T) {
 	argumentMap["redisPort"] = "6379"
 	argumentMap["middlewareVersion"] = "0.0.1"
 	argumentMap["middlewarePort"] = "8085"
+	argumentMap["notificationNamedPipePath"] = "/tmp/middleware-notification.pipe"
 
 	environmentInstance := system.NewEnvironment(argumentMap)
 	// TODO: refactor require.Equal() to take (t, <expected>, <actual>). It's currently <actual> <expected>.
@@ -36,6 +37,7 @@ func TestSystem(t *testing.T) {
 	require.Equal(t, "6379", environmentInstance.GetRedisPort())
 	require.Equal(t, "0.0.1", environmentInstance.GetMiddlewareVersion())
 	require.Equal(t, "8085", environmentInstance.GetMiddlewarePort())
+	require.Equal(t, "/tmp/middleware-notification.pipe", environmentInstance.GetNotificationNamedPipePath())
 
 	//test unhappy path
 	argumentMap = make(map[string]string)


### PR DESCRIPTION
This defines IPC notifications and adds a IPC notification reader,
which creates and opens a named pipe. Other processes, for example
shell or python scripts, can write notifications into the named pipe.

Notifications are sent in a JSON encoded string. The protocol in
version 1 requires notifications to have a version, topic and a
payload. Notifications can have a maximum length of 4096-1 byte.

Can be tested with:
```shell
echo '{"version": 1, "topic": "sampletopic", "payload": {"testInt":123,"testString": "string", "testBool": true}}' >> /tmp/middleware-notification.pipe
``` 