### PR TITLE
enable Bitcoin services only after setup

### DIFF
--- a/armbian/base/build.conf
+++ b/armbian/base/build.conf
@@ -17,6 +17,9 @@
 # WARNING: existing data on external drive is deleted!
 #BASE_AUTOSETUP_SSD="true"
 
+# Enable Bitcoin-related services before App Setup
+#BASE_ENABLE_BITCOIN_SERVICES="false"
+
 # Manual root password, 8 characters min, with numbers
 # WARNING: very unsafe, for DEVELOPMENT ONLY!
 #BASE_LOGINPW="your-development-password"

--- a/armbian/base/config/redis/factorysettings.txt
+++ b/armbian/base/config/redis/factorysettings.txt
@@ -13,6 +13,7 @@ SET base:hostname bitbox-base
 SET base:update:allow-unsigned 0
 SET base:updating 0
 SET base:setup 0
+SET base:bitcoind-services:enabled 0
 
 SET middleware:passwordSetup 0
 

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -43,6 +43,8 @@ CONFIGURATION:
     SSH ROOT LOGIN:     ${BASE_SSH_ROOT_LOGIN}
     SSH PASSWORD LOGIN: ${BASE_SSH_PASSWORD_LOGIN}
     AUTOSETUP SSD:      ${BASE_AUTOSETUP_SSD}
+    BITCOIN SERVICES ENABLED:
+                        ${BASE_ENABLE_BITCOIN_SERVICES}
 
 ================================================================================
 BUILD OPTIONS:
@@ -129,6 +131,7 @@ BASE_MINIMAL=${BASE_MINIMAL:-"true"}
 BASE_HOSTNAME=${BASE_HOSTNAME:-"bitbox-base"}
 BASE_BITCOIN_NETWORK=${BASE_BITCOIN_NETWORK:-"mainnet"}
 BASE_AUTOSETUP_SSD=${BASE_AUTOSETUP_SSD:-"false"}
+BASE_ENABLE_BITCOIN_SERVICES=${BASE_ENABLE_BITCOIN_SERVICES:-"false"}
 BASE_WIFI_SSID=${BASE_WIFI_SSID:-""}
 BASE_WIFI_PW=${BASE_WIFI_PW:-""}
 BASE_SSH_ROOT_LOGIN=${BASE_SSH_ROOT_LOGIN:-"false"}
@@ -467,7 +470,6 @@ generateConfig "bitcoin.conf.template" # --> /etc/bitcoin/bitcoin.conf
 chown -R root:bitcoin /etc/bitcoin
 chmod -R u+rw,g+r,g-w,o-rwx /etc/bitcoin
 importFile "/etc/systemd/system/bitcoind.service"
-systemctl enable bitcoind.service
 
 redis-cli SET bitcoind:version "${BITCOIN_VERSION}"
 
@@ -519,7 +521,6 @@ generateConfig "lightningd.conf.template" # --> /etc/lightningd/lightningd.conf
 chown -R root:bitcoin /etc/lightningd
 chmod -R u+rw,g+r,g-w,o-rwx /etc/lightningd
 importFile "/etc/systemd/system/lightningd.service"
-systemctl enable lightningd.service
 
 
 # ELECTRS ----------------------------------------------------------------------
@@ -542,7 +543,6 @@ generateConfig "electrs.conf.template" # --> /etc/electrs/electrs.conf
 chown -R root:bitcoin /etc/electrs
 chmod -R u+rw,g+r,g-w,o-rwx /etc/electrs
 importFile "/etc/systemd/system/electrs.service"
-systemctl enable electrs.service
 
 redis-cli SET electrs:version "${ELECTRS_VERSION}"
 
@@ -746,6 +746,11 @@ fi
 if [ "${BASE_AUTOSETUP_SSD}" == "true" ]; then
   /opt/shift/scripts/bbb-config.sh enable autosetup_ssd
 fi
+
+if [ "${BASE_ENABLE_BITCOIN_SERVICES}" == "true" ]; then
+  /opt/shift/scripts/bbb-config.sh enable bitcoin_services
+fi
+
 
 ## Freeze /rootfs with overlayroot (Ubuntu only)
 if [ "${BASE_OVERLAYROOT}" == "true" ]; then

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -14,7 +14,7 @@ usage: bbb-config.sh [--version] [--help]
 assumes Redis database running to be used with 'redis-cli'
 
 possible commands:
-  enable    <bitcoin_incoming|bitcoin_ibd|bitcoin_ibd_clearnet|dashboard_hdmi|
+  enable    <bitcoin_services|bitcoin_incoming|bitcoin_ibd|bitcoin_ibd_clearnet|dashboard_hdmi|
              dashboard_web|wifi|autosetup_ssd|tor|tor_bbbmiddleware|tor_ssh|
              tor_electrum|overlayroot|sshpwlogin|rootlogin|unsigned_updates>
 
@@ -102,6 +102,24 @@ case "${COMMAND}" in
         fi
 
         case "${SETTING}" in
+            BITCOIN_SERVICES)
+                checkMockMode
+
+                if [[ ${ENABLE} -eq 1 ]]; then
+                    exec_overlayroot all-layers "systemctl enable bitcoind.service"
+                    exec_overlayroot all-layers "systemctl enable lightningd.service"
+                    exec_overlayroot all-layers "systemctl enable electrs.service"
+                    exec_overlayroot all-layers "systemctl enable prometheus-bitcoind.service"
+                else
+                    exec_overlayroot all-layers "systemctl disable bitcoind.service"
+                    exec_overlayroot all-layers "systemctl disable lightningd.service"
+                    exec_overlayroot all-layers "systemctl disable electrs.service"
+                    exec_overlayroot all-layers "systemctl disable prometheus-bitcoind.service"
+                fi
+                echo "Setting bitcoind configuration for 'active initial sync'."
+                redis_set "base:bitcoind-services:enabled" "${ENABLE}"
+                ;;
+
             BITCOIN_INCOMING)
                 checkMockMode
 

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -125,7 +125,12 @@ case "${COMMAND}" in
 
                 redis_set "bitcoind:listen" "${ENABLE}"
                 generateConfig "bitcoin.conf.template"
-                systemctl restart bitcoind.service
+
+                # only restart bitcoind if system has been configured with setup routine
+                if [[ "$(redis_get 'base:setup')" -eq 1 ]]; then
+                    echo "INFO: restarting bitcoind"
+                    systemctl restart bitcoind
+                fi
                 ;;
 
             BITCOIN_IBD)
@@ -143,9 +148,12 @@ case "${COMMAND}" in
                     echo "Setting bitcoind configuration for 'fully synced'."
                     bbb-config.sh set bitcoin_dbcache 300
                     redis_set "bitcoind:ibd" "${ENABLE}"
-                    echo "Service 'lightningd' and 'electrs' are being started..."
-                    systemctl start lightningd.service
-                    systemctl start electrs.service
+
+                    if [[ "$(redis_get 'base:setup')" -eq 1 ]]; then
+                        echo "Service 'lightningd' and 'electrs' are being started..."
+                        systemctl start lightningd.service
+                        systemctl start electrs.service
+                    fi
                 fi
                 ;;
 
@@ -163,7 +171,12 @@ case "${COMMAND}" in
                 generateConfig "iptables.rules.template"
                 generateConfig "bitcoin.conf.template"
                 systemctl start iptables-restore
-                systemctl restart bitcoind
+
+                # only restart bitcoind if system has been configured with setup routine
+                if [[ "$(redis_get 'base:setup')" -eq 1 ]]; then
+                    echo "INFO: restarting bitcoind"
+                    systemctl restart bitcoind
+                fi
                 echo "OK: bitcoind:ibd-clearnet set to ${ENABLE}"
                 ;;
 
@@ -250,8 +263,13 @@ case "${COMMAND}" in
                 echo "Restarting services..."
                 systemctl start iptables-restore
                 systemctl restart networking.service
-                systemctl restart bitcoind.service
-                systemctl restart lightningd.service || true        # allowed to fail if bitcoind is in IBD mode
+
+                # only restart bitcoind if system has been configured with setup routine
+                if [[ "$(redis_get 'base:setup')" -eq 1 ]]; then
+                    echo "INFO: restarting bitcoind"
+                    systemctl restart bitcoind.service
+                    systemctl restart lightningd.service || true        # allowed to fail if bitcoind is in IBD mode
+                fi
                 redis_set "tor:base:enabled" "${ENABLE}"
                 updateTorOnions
                 ;;
@@ -418,6 +436,11 @@ case "${COMMAND}" in
                     # check if service restart is necessary
                     if [[ "${DBCACHE_BEFORE}" == "${3}" ]]; then
                         echo "DBCACHE unchanged (${DBCACHE_BEFORE} MB to ${3} MB), no restart of bitcoind required"
+
+                    # only restart bitcoind if system has been configured with setup routine
+                    elif [[ "$(redis_get 'base:setup')" -ne 1 ]]; then
+                        echo "DBCACHE changed (${DBCACHE_BEFORE} MB to ${3} MB), bitcoind not started due to missing setup information"
+
                     else
                         echo "DBCACHE changed (${DBCACHE_BEFORE} MB to ${3} MB), restarting bitcoind"
                         systemctl restart bitcoind.service

--- a/armbian/base/scripts/bbb-systemctl.sh
+++ b/armbian/base/scripts/bbb-systemctl.sh
@@ -17,7 +17,7 @@ source /opt/shift/scripts/include/errorExit.sh.inc
 
 function usage() {
     echo "BitBoxBase: batch control system units"
-    echo "Usage: bbb-systemctl <status|start|restart|stop|enable|disable>"
+    echo "Usage: bbb-systemctl <status|start-bitcoin-services|start|restart|stop|enable|disable>"
 }
 
 ACTION=${1:-"status"}
@@ -27,7 +27,7 @@ if [[ ${ACTION} == "-h" ]] || [[ ${ACTION} == "--help" ]]; then
     exit 0
 fi
 
-if ! [[ ${ACTION} =~ ^(status|start|restart|stop|enable|disable|verify)$ ]]; then
+if ! [[ ${ACTION} =~ ^(status|start-bitcoin-services|start|restart|stop|enable|disable|verify)$ ]]; then
     echo "bbb-systemctl.sh: unknown argument."
     echo
     usage
@@ -54,6 +54,38 @@ prometheus-base:          $(systemctl is-active prometheus-base.service)
 prometheus-bitcoind:      $(systemctl is-active prometheus-bitcoind.service)
 grafana:                  $(systemctl is-active grafana-server.service)
 " | grep --color -zP  '(failed|activating|inactive)'
+        ;;
+
+    start-bitcoin-services)
+        if ! systemctl is-active -q bitcoind.service; then
+            systemctl start bitcoind.service
+            echo "OK: bitcoind.service started"
+        else
+            echo "INFO: bitcoind.service already running"
+        fi
+
+        if ! systemctl is-active -q lightningd.service; then
+            systemctl start lightningd.service
+            echo "OK: lightningd.service started"
+        else
+            echo "INFO: lightningd.service already running"
+        fi
+
+        if ! systemctl is-active -q electrs.service; then
+            systemctl start electrs.service
+            echo "OK: electrs.service started"
+        else
+            echo "INFO: electrs.service already running"
+        fi
+
+        if ! systemctl is-active -q prometheus-bitcoind.service; then
+            systemctl start prometheus-bitcoind.service
+            echo "OK: prometheus-bitcoind.service started"
+        else
+            echo "INFO: prometheus-bitcoind.service already running"
+        fi
+
+        echo "OK: bitcoin-related services started"
         ;;
 
     start|restart|stop|enable|disable)

--- a/armbian/base/scripts/include/redis.sh.inc
+++ b/armbian/base/scripts/include/redis.sh.inc
@@ -18,6 +18,10 @@ redis_set() {
 redis_get() {
     # usage: str=$(redis_get "key")
     ok=$(redis-cli -h localhost -p 6379 -n 0 GET "${1}") || true
+    if [[ -z "${ok}" ]]; then
+      # if Redis returns "nil", return -1
+      ok=-1
+    fi
     echo "${ok}"
 }
 

--- a/armbian/base/scripts/systemd-update-checks.sh
+++ b/armbian/base/scripts/systemd-update-checks.sh
@@ -88,6 +88,12 @@ else
     echo "RESET: no flashdrive detected."
 fi
 
+# enable Bitcoin-related services if key  == 1
+if [[ $(redis_get "base:bitcoind-services:enabled") -eq 1 ]]; then
+    echo "INFO: enabling Bitcoin-related services"
+    /opt/shift/scripts/bbb-config.sh enable bitcoin_services
+fi
+
 # check if booting after update
 # valid status codes of 'base:updating'
 #    0: no update in progress


### PR DESCRIPTION
Currently, all services are enabled and as soon as the BitBoxBase has power and network it will start syncing over Tor.

As we give the user different options during the Setup Wizard, services should not start before that.

This pull-request...
* adds the build option BASE_ENABLE_BITCOIN_SERVICES (default: false)
* does not enable bitcoind, lightningd and electrs systemd units during the build process
* introduces the Redis key base:bitcoind-services:enabled
* adds the command 'bbb-config.sh enable/disable bitcoin-services' to configure systemd and set the Redis key
* script 'systemd-update-check.sh' checks the Redis key on boot and enables the services if -eq 1 (the are not disabled otherwise)