### PR TITLE
Middleware: handle `mender-update` notification and queue if no client connected

### DIFF
--- a/middleware/src/ipcnotification/payloads.go
+++ b/middleware/src/ipcnotification/payloads.go
@@ -1,0 +1,17 @@
+package ipcnotification
+
+/* This file holds the payload definitions for different notification topics */
+
+// ParseMenderUpdatePayload parses payloads from notifications with the topic
+// `mender-update`. The payload should have the following JSON structure:
+//  {"success": true}
+func ParseMenderUpdatePayload(payload interface{}) (menderUpdateSuccess bool, ok bool) {
+	if payloadMap, ok := payload.(map[string]interface{}); ok {
+		if val, ok := payloadMap["success"]; ok {
+			if success, ok := val.(bool); ok {
+				return success, true
+			}
+		}
+	}
+	return false, false
+}

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -12,8 +12,12 @@ const (
 	OpServiceInfoChanged = "s"
 	// OpBaseUpdateProgressChanged notifies when the BaseUpdateProgress changes while performing a Base Update.
 	OpBaseUpdateProgressChanged = "u"
-	// OpBaseUpdateIsAvailable notifies when a firmeware update is available for the Base.
+	// OpBaseUpdateIsAvailable notifies when a image update is available for the Base.
 	OpBaseUpdateIsAvailable = "x"
+	// OpBaseUpdateSuccess notifies when the Base image update succeeded.
+	OpBaseUpdateSuccess = "a"
+	// OpBaseUpdateFailure notifies when the Base image update failed.
+	OpBaseUpdateFailure = "b"
 )
 
 /*

--- a/middleware/src/util.go
+++ b/middleware/src/util.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/digitalbitbox/bitbox-base/middleware/src/handlers"
 	"github.com/digitalbitbox/bitbox-base/middleware/src/prometheus"
 	"github.com/digitalbitbox/bitbox-base/middleware/src/redis"
 	"github.com/digitalbitbox/bitbox-base/middleware/src/rpcmessages"
@@ -294,7 +295,10 @@ func parseBaseUpdateStdout(outputLine string) (containsUpdateProgressInfo bool, 
 
 func (middleware *Middleware) setBaseUpdateStateAndNotify(state rpcmessages.BaseUpdateState) {
 	middleware.baseUpdateProgress.State = state
-	middleware.events <- []byte(rpcmessages.OpBaseUpdateProgressChanged)
+	middleware.events <- handlers.Event{
+		Identifier:      []byte(rpcmessages.OpBaseUpdateProgressChanged),
+		QueueIfNoClient: true,
+	}
 }
 
 // checkMiddlewareSetup checks if the middleware password has been set yet and if the user is done with the base


### PR DESCRIPTION
Events passed from the Middleware to the handlers are now typed. The type `Event` now includes a boolean which indicates if the event should be queued until a client (App in our case) is available.

Handling for the `mender-update` notification is add, that is send by a shell script after the mender update commit finishes.

For testing:

```
# success case:
echo '{"version": 1, "topic": "mender-update", "payload": {"success": true}}' >> /tmp/middleware-notification.pipe

# failure case:
echo '{"version": 1, "topic": "mender-update", "payload": {"success": false}}' >> /tmp/middleware-notification.pipe
```
 