### PR TITLE
Deprecate old command line arguments of the middleware

### DIFF
--- a/armbian/base/config/templates/bbbmiddleware.conf.template
+++ b/armbian/base/config/templates/bbbmiddleware.conf.template
@@ -1,5 +1,0 @@
-{{ #output: /etc/bbbmiddleware/bbbmiddleware.conf }}
-BITCOIN_RPCUSER={{      bitcoind:rpcuser                #default: base }}
-BITCOIN_RPCPASSWORD={{  bitcoind:rpcpassword            #rmLine }}
-BITCOIN_RPCPORT={{      bitcoind:rpcport                #default: 8332 }}
-LIGHTNING_RPCPATH={{    lightningd:lightning-dir        #default: /mnt/ssd/bitcoin/.lightning }}/lightning-rpc

--- a/armbian/base/rootfs/etc/systemd/system/bbbmiddleware.service
+++ b/armbian/base/rootfs/etc/systemd/system/bbbmiddleware.service
@@ -10,10 +10,6 @@ After=multi-user.target bitcoind.service
 EnvironmentFile=/etc/bbbmiddleware/bbbmiddleware.conf
 ExecStartPre=/opt/shift/scripts/systemd-bbbmiddleware-startpre.sh
 ExecStart=/usr/local/sbin/bbbmiddleware \
-    -rpcuser=${BITCOIN_RPCUSER} \
-    -rpcpassword=${BITCOIN_RPCPASSWORD} \
-    -rpcport=${BITCOIN_RPCPORT} \
-    -lightning-rpc-path=${LIGHTNING_RPCPATH} \
     -datadir=/data/bbbmiddleware
 
 # Process management

--- a/middleware/README.md
+++ b/middleware/README.md
@@ -54,29 +54,33 @@ tools)
 
 ## Running
 
-The middleware accepts some command line arguments to connect to c-lightning
-and bitcoind. The arguments are expected to be passed in the following fashion:
+The middleware accepts some command line arguments to get some information about its environment.
+The arguments are expected to be passed in the following fashion:
 
-    ./bbbmiddleware -rpcuser rpcuser -rpcpassword rpcpassword -rpcport 18332 -lightning-rpc-path /home/bitcoin/.lightning/lightning-rpc
+    middleware -electrsport 60401
 
-Running `./bbbmiddleware -h` will print the following help:
+Running `middleware -h` will print the following help:
 
+  -bbbcmdscript string
+    Path to the bbb-cmd file that allows executing system commands (default "/opt/shift/scripts/bbb-cmd.sh")
   -bbbconfigscript string
-    	Path to the bbb-config file that allows setting system configuration (default "/opt/shift/scripts/bbb-config.sh")
+    Path to the bbb-config file that allows setting system configuration (default "/opt/shift/scripts/bbb-config.sh")
   -datadir string
-    	Directory where middleware persistent data like noise keys is stored (default ".base")
+    Directory where middleware persistent data like noise keys is stored (default ".base")
   -electrsport string
-    	Electrs rpc port (default "51002")
-  -lightning-rpc-path string
-    	Path to the lightning rpc unix socket (default "/home/bitcoin/.lightning/lightning-rpc")
+    Electrs rpc port (default "51002")
+  -middlewareport string
+    Port the middleware should listen on (default 8845) (default "8845")
   -network string
-    	Indicate wether running bitcoin on regtest, testnet or mainnet (default "testnet")
-  -rpcpassword string
-    	Bitcoin rpc password (default "rpcpassword")
-  -rpcport string
-    	Bitcoin rpc port, localhost is assumed as an address (default "18332")
-  -rpcuser string
-    	Bitcoin rpc user name (default "rpcuser")
+    Indicate wether running bitcoin on testnet or mainnet (default "testnet")
+  -prometheusurl string
+    Url of the prometheus server in the form of 'http://localhost:9090' (default "http://localhost:9090")
+  -redismock
+    Mock redis for development instead of connecting to a redis server, default is 'false', use 'true' as an argument to mock
+  -redisport string
+    Port of the Redis server (default "6379")
+  -updateinfourl string
+    URL to query information about updates from (defaults to https://shiftcrypto.ch/updates/base.json) (default "https://shiftcrypto.ch/updates/base.json")
 
 ## Testing
 
@@ -116,7 +120,7 @@ e.g. run from the `integration_test` directory:
 
 ## For the middleware run:
 
-    middleware -rpcport=18443 -rpcpassword=rpcpass -rpcuser=rpcuser -electrsport=60401 -lightning-rpc-path=integration_test/volumes/clightning1/lightning-rpc
+    middleware -electrsport=60401
 
 ## To connect clightning1 with clightning2:
   The two c-lightning instances allow communication between each other.

--- a/middleware/cmd/middleware/main.go
+++ b/middleware/cmd/middleware/main.go
@@ -17,10 +17,6 @@ const version string = "0.0.1"
 
 func main() {
 	middlewarePort := flag.String("middlewareport", "8845", "Port the middleware should listen on (default 8845)")
-	bitcoinRPCUser := flag.String("rpcuser", "rpcuser", "Bitcoin rpc user name")
-	bitcoinRPCPassword := flag.String("rpcpassword", "rpcpassword", "Bitcoin rpc password")
-	bitcoinRPCPort := flag.String("rpcport", "18332", "Bitcoin rpc port, localhost is assumed as an address")
-	lightningRPCPath := flag.String("lightning-rpc-path", "/home/bitcoin/.lightning/lightning-rpc", "Path to the lightning rpc unix socket")
 	electrsRPCPort := flag.String("electrsport", "51002", "Electrs rpc port")
 	dataDir := flag.String("datadir", ".base", "Directory where middleware persistent data like noise keys is stored")
 	network := flag.String("network", "testnet", "Indicate wether running bitcoin on testnet or mainnet")
@@ -35,10 +31,6 @@ func main() {
 
 	argumentMap := make(map[string]string)
 	argumentMap["middlewarePort"] = *middlewarePort
-	argumentMap["bitcoinRPCUser"] = *bitcoinRPCUser
-	argumentMap["bitcoinRPCPassword"] = *bitcoinRPCPassword
-	argumentMap["bitcoinRPCPort"] = *bitcoinRPCPort
-	argumentMap["lightningRPCPath"] = *lightningRPCPath
 	argumentMap["electrsRPCPort"] = *electrsRPCPort
 	argumentMap["network"] = *network
 	argumentMap["bbbConfigScript"] = *bbbConfigScript

--- a/middleware/src/handlers/handlers_test.go
+++ b/middleware/src/handlers/handlers_test.go
@@ -24,10 +24,6 @@ const (
 
 func TestRootHandler(t *testing.T) {
 	argumentMap := make(map[string]string)
-	argumentMap["bitcoinRPCUser"] = "user"
-	argumentMap["bitcoinRPCPassword"] = "password"
-	argumentMap["bitcoinRPCPort"] = "8332"
-	argumentMap["lightningRPCPath"] = "/home/bitcoin/.lightning"
 	argumentMap["electrsRPCPort"] = "18442"
 	argumentMap["network"] = "testnet"
 	argumentMap["bbbConfigScript"] = "/home/bitcoin/script.sh"
@@ -45,10 +41,6 @@ func TestRootHandler(t *testing.T) {
 
 func TestWebsocketHandler(t *testing.T) {
 	argumentMap := make(map[string]string)
-	argumentMap["bitcoinRPCUser"] = "user"
-	argumentMap["bitcoinRPCPassword"] = "password"
-	argumentMap["bitcoinRPCPort"] = "8332"
-	argumentMap["lightningRPCPath"] = "/home/bitcoin/.lightning"
 	argumentMap["electrsRPCPort"] = "18442"
 	argumentMap["network"] = "testnet"
 	argumentMap["bbbConfigScript"] = "/home/bitcoin/script.sh"

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -15,10 +15,6 @@ func getToggleSettingArgs(enabled bool) rpcmessages.ToggleSettingArgs {
 // setupTestMiddleware middleware returns a middleware setup with testing arguments
 func setupTestMiddleware(t *testing.T) *middleware.Middleware {
 	argumentMap := make(map[string]string)
-	argumentMap["bitcoinRPCUser"] = "user"
-	argumentMap["bitcoinRPCPassword"] = "password"
-	argumentMap["bitcoinRPCPort"] = "8332"
-	argumentMap["lightningRPCPath"] = "/home/bitcoin/.lightning"
 	argumentMap["electrsRPCPort"] = "18442"
 	argumentMap["network"] = "testnet"
 

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -50,10 +50,6 @@ func NewTestingRPCServer() TestingRPCServer {
 		clientReadChan:  make(chan []byte),
 	}
 	argumentMap := make(map[string]string)
-	argumentMap["bitcoinRPCUser"] = "user"
-	argumentMap["bitcoinRPCPassword"] = "password"
-	argumentMap["bitcoinRPCPort"] = "8332"
-	argumentMap["lightningRPCPath"] = "/home/bitcoin/.lightning"
 	argumentMap["electrsRPCPort"] = "18442"
 	argumentMap["network"] = "testnet"
 

--- a/middleware/src/system/system.go
+++ b/middleware/src/system/system.go
@@ -6,10 +6,6 @@ type Environment struct {
 	middlewarePort            string
 	Network                   string `json:"network"`
 	ElectrsRPCPort            string `json:"electrsRPCPort"`
-	bitcoinRPCUser            string
-	bitcoinRPCPassword        string
-	bitcoinRPCPort            string
-	lightningRPCPath          string
 	bbbConfigScript           string
 	bbbCmdScript              string
 	prometheusURL             string
@@ -20,15 +16,10 @@ type Environment struct {
 }
 
 // NewEnvironment returns a new Environment instance.
-//func NewEnvironment(bitcoinRPCUser, bitcoinRPCPassword, bitcoinRPCPort, lightningRPCPath, electrsRPCPort, network string) Environment {
 func NewEnvironment(argumentMap map[string]string) Environment {
 	// TODO(TheCharlatan) Instead of just accepting a long list of arguments, use a map here and check if the arguments can be read from a system config.
 	environment := Environment{
 		middlewarePort:            argumentMap["middlewarePort"],
-		bitcoinRPCUser:            argumentMap["bitcoinRPCUser"],
-		bitcoinRPCPassword:        argumentMap["bitcoinRPCPassword"],
-		bitcoinRPCPort:            argumentMap["bitcoinRPCPort"],
-		lightningRPCPath:          argumentMap["lightningRPCPath"],
 		ElectrsRPCPort:            argumentMap["electrsRPCPort"],
 		Network:                   argumentMap["network"],
 		bbbConfigScript:           argumentMap["bbbConfigScript"],
@@ -40,26 +31,6 @@ func NewEnvironment(argumentMap map[string]string) Environment {
 		notificationNamedPipePath: argumentMap["notificationNamedPipePath"],
 	}
 	return environment
-}
-
-// GetBitcoinRPCUser is a getter for bitcoinRPCUser
-func (environment *Environment) GetBitcoinRPCUser() string {
-	return environment.bitcoinRPCUser
-}
-
-// GetBitcoinRPCPassword is a getter for the bitcoinRPCPassword
-func (environment *Environment) GetBitcoinRPCPassword() string {
-	return environment.bitcoinRPCPassword
-}
-
-// GetBitcoinRPCPort is a getter for the bitcoinRPCPort
-func (environment *Environment) GetBitcoinRPCPort() string {
-	return environment.bitcoinRPCPort
-}
-
-// GetLightningRPCPath is a getter for the lightningRPCPath
-func (environment *Environment) GetLightningRPCPath() string {
-	return environment.lightningRPCPath
 }
 
 // GetBBBConfigScript is a getter for the location of the bbb config script

--- a/middleware/src/system/system_test.go
+++ b/middleware/src/system/system_test.go
@@ -9,10 +9,6 @@ import (
 
 func TestSystem(t *testing.T) {
 	argumentMap := make(map[string]string)
-	argumentMap["bitcoinRPCUser"] = "user"
-	argumentMap["bitcoinRPCPassword"] = "password"
-	argumentMap["bitcoinRPCPort"] = "8332"
-	argumentMap["lightningRPCPath"] = "/home/bitcoin/.lightning"
 	argumentMap["electrsRPCPort"] = "18442"
 	argumentMap["network"] = "testnet"
 	argumentMap["bbbConfigScript"] = "/home/bitcoin/config-script.sh"
@@ -25,10 +21,6 @@ func TestSystem(t *testing.T) {
 
 	environmentInstance := system.NewEnvironment(argumentMap)
 	// TODO: refactor require.Equal() to take (t, <expected>, <actual>). It's currently <actual> <expected>.
-	require.Equal(t, environmentInstance.GetBitcoinRPCPort(), "8332")
-	require.Equal(t, environmentInstance.GetBitcoinRPCUser(), "user")
-	require.Equal(t, environmentInstance.GetBitcoinRPCPassword(), "password")
-	require.Equal(t, environmentInstance.GetLightningRPCPath(), "/home/bitcoin/.lightning")
 	require.Equal(t, environmentInstance.GetBBBConfigScript(), "/home/bitcoin/config-script.sh")
 	require.Equal(t, environmentInstance.GetBBBCmdScript(), "/home/bitcoin/cmd-script.sh")
 	require.Equal(t, environmentInstance.Network, "testnet")
@@ -43,9 +35,9 @@ func TestSystem(t *testing.T) {
 	argumentMap = make(map[string]string)
 	argumentMap["lel"] = "1"
 	environmentInstance = system.NewEnvironment(argumentMap)
-	require.Equal(t, environmentInstance.GetBitcoinRPCPort(), "")
+	require.Equal(t, environmentInstance.GetBBBConfigScript(), "")
 
 	argumentMap = make(map[string]string)
 	environmentInstance = system.NewEnvironment(argumentMap)
-	require.Equal(t, environmentInstance.GetBitcoinRPCPort(), "")
+	require.Equal(t, environmentInstance.GetBBBConfigScript(), "")
 }


### PR DESCRIPTION
The bitcoin and lightning rpc command line arguments for the middleware
were originally added to get some sample information and serve as
guidance on how to architecture the middleware. These direct methods to
lightning and bitcoind have since been deprecated, meaning the command
line arguments are also no longer needed.

This also removes the configuration from the systemd config templates
and the arguments from the systemd unit.

There are probably more occasions of the bitcoin and lightning rpc environment variables left to be cleaned up. Can you have a quick look at that @Stadicus?

Addresses https://github.com/shiftdevices/bitbox-base-internal/issues/332