### PR TITLE
update 'build-ondevice' make target

### DIFF
--- a/armbian/armbian-build.sh
+++ b/armbian/armbian-build.sh
@@ -65,10 +65,19 @@ case ${ACTION} in
 		;;
 
 	ondevice)
-    	# copy custom scripts to filesystem
-    	mkdir -p /opt/shift
-    	cp -aR base/* /opt/shift
-    	chmod -R +x /opt/shift/scripts
+		# copy custom scripts to filesystem
+		mkdir -p /opt/shift
+		cp -aR base/* /opt/shift
+		chmod -R +x /opt/shift/scripts
+
+		# check dependency: Go binaries
+		if [[ -f ../bin/go/bbbmiddleware ]] && [[ -f ../bin/go/bbbconfgen ]] && [[ -f ../bin/go/bbbfancontrol ]] && [[ -f ../bin/go/bbbsupervisor ]]; then
+			mkdir -p /opt/shift/bin/go
+			cp -aR ../bin/go/* /opt/shift/bin/go/
+		else
+			echo "ERR: Go tool dependencies missing, build them first by running 'make docker-build-go' in the repository root (requires Docker)"
+			exit 1
+		fi
 
 		# run customization script
 		base/customize-armbian-rockpro64.sh ondevice

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -299,6 +299,7 @@ mkdir -p /data/redis/
 chown -R redis:redis /data/redis/
 
 ### disable standard systemd unit
+systemctl stop redis-server.service || true
 systemctl disable redis-server.service
 systemctl mask redis-server.service
 
@@ -312,6 +313,11 @@ systemctl enable redis.service
 redis-server --daemonize yes --databases 1 --dbfilename bitboxbase.rdb --dir /data/redis/
 
 ## bulk import factory settings / store build info
+if [ ! -f /opt/shift/config/redis/factorysettings.txt ]; then
+  echo "ERR: Redis factory settings not available at /opt/shift/config/redis/factorysettings.txt"
+  exit 1
+fi
+
 < /opt/shift/config/redis/factorysettings.txt sh /opt/shift/scripts/redis-pipe.sh | redis-cli --pipe
 redis-cli SET build:date "$(date +%Y-%m-%d)"
 redis-cli SET build:time "$(date +%H:%M)"
@@ -367,10 +373,13 @@ if [ ! -f /data/ssl/nginx-selfsigned.key ] && [[ "${BASE_BUILDMODE}" == "ondevic
 fi
 
 ## disable Armbian ramlog and limit logsize if overlayroot is enabled
-if [ "$BASE_OVERLAYROOT" == "true" ]; then
-  sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-ramlog
-  sed -i 's/log.hdd/log/g' /etc/logrotate.conf
-  importFile /etc/logrotate.d/rsyslog
+if [[ "$BASE_OVERLAYROOT" == "true" ]]; then
+  # allow missing files if build-ondevice (e.g. not Armbian distro)
+  if [[ -f /etc/default/armbian-ramlog ]] || [[ "${BASE_BUILDMODE}" != "ondevice" ]]; then
+    sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-ramlog
+    sed -i 's/log.hdd/log/g' /etc/logrotate.conf
+    importFile /etc/logrotate.d/rsyslog
+  fi
 fi
 
 ## retain less NGINX logs
@@ -393,12 +402,18 @@ ln -sfn /mnt/ssd/system/journal /var/log/journal
 importFile "/etc/mender/mender.conf"
 
 ## configure swap file (disable Armbian zram, configure custom swapfile on ssd)
-sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-zram-config
+if [[ -f /etc/default/armbian-zram-config ]] || [[ "${BASE_BUILDMODE}" != "ondevice" ]]; then
+  sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-zram-config
+fi
 sed -i '/vm.swappiness=/Ic\vm.swappiness=10' /etc/sysctl.conf
 
 ## startup checks
 importFile /etc/systemd/system/startup-checks.service
 systemctl enable startup-checks.service
+
+## startup checks after Redis is available
+importFile /etc/systemd/system/startup-after-redis.service
+systemctl enable startup-after-redis.service
 
 ## update checks
 importFile /etc/systemd/system/update-checks.service
@@ -715,15 +730,17 @@ importFile "/etc/systemd/system/iptables-restore.service"
 
 # FINALIZE ---------------------------------------------------------------------
 
-## Remove build-only packages
-apt -y remove git
+if [[ "${BASE_BUILDMODE}" != "ondevice" ]]; then
+  ## Remove build-only packages
+  apt -y remove git
 
-## Delete unnecessary local files
-rm -rf /usr/share/doc/*
-rm -rf /var/lib/apt/lists/*
-rm /usr/bin/test_bitcoin /usr/bin/bitcoin-qt /usr/bin/bitcoin-wallet
-find /var/log -maxdepth 1 -type f -delete
-locale-gen en_US.UTF-8
+  ## Delete unnecessary local files
+  rm -rf /usr/share/doc/*
+  rm -rf /var/lib/apt/lists/*
+  rm /usr/bin/test_bitcoin /usr/bin/bitcoin-qt /usr/bin/bitcoin-wallet
+  find /var/log -maxdepth 1 -type f -delete
+  locale-gen en_US.UTF-8
+fi
 
 ## Clean up
 apt install -f
@@ -751,6 +768,18 @@ if [ "${BASE_ENABLE_BITCOIN_SERVICES}" == "true" ]; then
   /opt/shift/scripts/bbb-config.sh enable bitcoin_services
 fi
 
+redis-cli save
+set +x
+
+if [[ "${BASE_BUILDMODE}" == "ondevice" ]]; then
+  ## execute startup-script to generate keys when building on the device
+  /opt/shift/scripts/systemd-startup-checks.sh
+
+else
+  ## remove temporary symlink /data --> /data_source, unless building on the device
+  rm /data
+  redis-cli shutdown
+fi
 
 ## Freeze /rootfs with overlayroot (Ubuntu only)
 if [ "${BASE_OVERLAYROOT}" == "true" ]; then
@@ -761,14 +790,6 @@ if [ "${BASE_OVERLAYROOT}" == "true" ]; then
   fi
 fi
 
-## remove temporary symlink /data --> /data_source, unless building on the device
-if [[ "${BASE_BUILDMODE}" != "ondevice" ]]; then
-  rm /data
-fi
-
-redis-cli shutdown save
-
-set +x
 if [[ "${BASE_BUILDMODE}" == "ondevice" ]]; then
   echoArguments "Setup script finished. Please reboot device and login as user 'base'."
 else

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -771,12 +771,8 @@ fi
 redis-cli save
 set +x
 
-if [[ "${BASE_BUILDMODE}" == "ondevice" ]]; then
-  ## execute startup-script to generate keys when building on the device
-  /opt/shift/scripts/systemd-startup-checks.sh
-
-else
-  ## remove temporary symlink /data --> /data_source, unless building on the device
+## remove temporary symlink /data --> /data_source, unless building on the device
+if [[ "${BASE_BUILDMODE}" != "ondevice" ]]; then
   rm /data
   redis-cli shutdown
 fi

--- a/armbian/base/rootfs/etc/systemd/system/startup-after-redis.service
+++ b/armbian/base/rootfs/etc/systemd/system/startup-after-redis.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=BitBoxBase startup tasks (after Redis)
+After=redis.service
+
+[Service]
+
+# Service execution
+###################
+
+ExecStart=/opt/shift/scripts/systemd-startup-after-redis.sh
+
+# Process management
+####################
+
+Type=oneshot
+
+[Install]
+WantedBy=bitboxbase.target

--- a/armbian/base/scripts/prometheus-base.py
+++ b/armbian/base/scripts/prometheus-base.py
@@ -55,10 +55,15 @@ def getIP():
 def getSystemInfo():
     rediskeys = ['base:hostname','base:version','build:date','build:time','build:commit']
     info = {}
-    # add Redis values
+        # add Redis values
     for k in rediskeys:
         infoName = k.lower().replace(":", "_")
-        infoValue = r.get(k).decode("utf-8")
+        infoValue = r.get(k)
+        if infoValue is not None:
+            infoValue = infoValue.decode("utf-8")
+        else:
+            infoValue = 'n/a'
+
         info[infoName] = infoValue
 
     info['base_ipaddress'] = getIP()

--- a/armbian/base/scripts/systemd-bbbmiddleware-startpre.sh
+++ b/armbian/base/scripts/systemd-bbbmiddleware-startpre.sh
@@ -14,7 +14,7 @@ source /opt/shift/scripts/include/redis.sh.inc
 # ------------------------------------------------------------------------------
 
 REFRESH_RPCAUTH="$(redis_get 'bitcoind:refresh-rpcauth')"
-if [ "${REFRESH_RPCAUTH}" -ne 0 ]; then
+if [ -z "${REFRESH_RPCAUTH}" ] || [ "${REFRESH_RPCAUTH}" -ne 0 ]; then
     # either Redis not ready yet or new credentials requested
     echo "INFO: bitcoind:refresh-rpcauth not 0, holding off bbbmiddleware start for bitcoind to warm up"
     sleep 15

--- a/armbian/base/scripts/systemd-bitcoind-startpre.sh
+++ b/armbian/base/scripts/systemd-bitcoind-startpre.sh
@@ -29,7 +29,7 @@ redis_require
 RPCAUTH="$(redis_get 'bitcoind:rpcauth')"
 REFRESH_RPCAUTH="$(redis_get 'bitcoind:refresh-rpcauth')"
 
-if [ ${#RPCAUTH} -lt 90 ] || [ "${REFRESH_RPCAUTH}" -eq 1 ]; then
+if [ ${#RPCAUTH} -lt 90 ] || [ -z "${REFRESH_RPCAUTH}" ] || [ "${REFRESH_RPCAUTH}" -eq 1 ]; then
     echo "INFO: creating new bitcoind rpc credentials"
     echo "INFO: old bitcoind:rpcauth was ${RPCAUTH}"
     echo "INFO: bitcoind:refresh-rpcauth is ${REFRESH_RPCAUTH}"

--- a/armbian/base/scripts/systemd-startup-after-redis.sh
+++ b/armbian/base/scripts/systemd-startup-after-redis.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+# shellcheck disable=SC1091
+
+# This script is called by the update-checks.service on boot
+# to check if update is in progress and perform configuration and
+# validation actions.
+#
+# The Redis config mgmt must available for this script.
+#
+set -eu
+
+# --- generic functions --------------------------------------------------------
+
+# include function exec_overlayroot(), to execute a command, either within overlayroot-chroot or directly
+source /opt/shift/scripts/include/exec_overlayroot.sh.inc
+
+# include functions redis_set() and redis_get()
+source /opt/shift/scripts/include/redis.sh.inc
+
+# include function generateConfig() to generate config files from templates
+source /opt/shift/scripts/include/generateConfig.sh.inc
+
+# include errorExit() function
+source /opt/shift/scripts/include/errorExit.sh.inc
+
+# include updateTorOnions() function
+source /opt/shift/scripts/include/updateTorOnions.sh.inc
+
+# ------------------------------------------------------------------------------
+
+redis_require
+
+# update hardcoded Base image version
+VERSION=$(head -n1 /opt/shift/config/version)
+redis_set "base:version" "${VERSION}"
+
+
+# check for reset triggers on flashdrive
+if FLASHDRIVE="$(/opt/shift/scripts/bbb-cmd.sh flashdrive check)"; then
+    echo "RESET: device ${FLASHDRIVE} detected"
+    if /opt/shift/scripts/bbb-cmd.sh flashdrive mount "${FLASHDRIVE}"; then
+        echo "RESET: flashdrive mounted"
+
+        # are all necessary files for a reset present?
+        if [[ -f /mnt/backup/.reset-token ]] && [[ -f /data/reset-token-hashes ]]; then
+            FLASHDRIVE_TOKEN_HASH="$(sha256sum /mnt/backup/.reset-token | cut -f 1 -d " ")"
+            echo "RESET: reset token present on flashdrive, hashed value: ${FLASHDRIVE_TOKEN_HASH}"
+
+            # is hashed reset token present on Base?
+            if grep -q "${FLASHDRIVE_TOKEN_HASH}" /data/reset-token-hashes; then
+                echo "RESET: valid reset token found"
+
+                if [[ -f /mnt/backup/reset-base-auth ]]; then
+                    echo "RESET: trigger file 'reset-base-auth' found, initiating reset of authentication"
+                    /opt/shift/scripts/bbb-cmd.sh reset auth --assume-yes
+                    mv /mnt/backup/reset-base-auth /mnt/backup/reset-base-auth.done
+                fi
+
+                if [[ -f /mnt/backup/reset-base-config ]]; then
+                    echo "RESET: trigger file 'reset-base-config' found. Feature not implemented yet."
+                    mv /mnt/backup/reset-base-config /mnt/backup/reset-base-config.done
+                fi
+
+                if [[ -f /mnt/backup/reset-base-ssd ]]; then
+                    echo "RESET: trigger file 'reset-base-ssd' found. Feature not implemented yet."
+                    mv /mnt/backup/reset-base-ssd /mnt/backup/reset-base-ssd.done
+                fi
+
+                if [[ -f /mnt/backup/reset-base-image ]]; then
+                    echo "RESET: trigger file 'reset-base-image' found. Feature not implemented yet."
+                    mv /mnt/backup/reset-base-image /mnt/backup/reset-base-image.done
+                fi
+            else
+                echo "RESET: reset token on flashdrive does not match authorized tokens on the Base"
+            fi
+        else
+            echo "RESET: not all files for a reset present, doing nothing."
+        fi
+
+        umount /mnt/backup
+
+    else
+        echo "RESET: warning, could not mount flashdrive ${FLASHDRIVE}"
+    fi
+else
+    echo "RESET: no flashdrive detected."
+fi
+
+
+# update onion addresses in Redis
+updateTorOnions
+
+
+# check if rpcauth credentials exist, or create new ones
+RPCAUTH="$(redis_get 'bitcoind:rpcauth')"
+REFRESH_RPCAUTH="$(redis_get 'bitcoind:refresh-rpcauth')"
+
+if [ ${#RPCAUTH} -lt 90 ] || [ "${REFRESH_RPCAUTH}" -eq 1 ] || [ "${REFRESH_RPCAUTH}" -eq -1 ]; then
+    echo "INFO: creating new bitcoind rpc credentials"
+    echo "INFO: old bitcoind:rpcauth was ${RPCAUTH}"
+    echo "INFO: bitcoind:refresh-rpcauth is ${REFRESH_RPCAUTH}"
+    /opt/shift/scripts/bbb-cmd.sh bitcoind refresh_rpcauth
+else
+    echo "INFO: found bitcoind rpc credentials, no action taken"
+fi

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -129,7 +129,9 @@ chown -R redis:system /data/redis/
 ifmetric eth0 10
 
 timedatectl set-ntp true
-echo "180" > /sys/class/hwmon/hwmon0/pwm1
+
+# allow failure, e.g. if not running on Armbian
+echo "180" > /sys/class/hwmon/hwmon0/pwm1 || true
 
 # check for TLS certificate and create it if missing
 if [ ! -f /data/ssl/nginx-selfsigned.key ]; then

--- a/middleware/Makefile
+++ b/middleware/Makefile
@@ -25,8 +25,8 @@ build: generate
 	go install $(REPO_ROOT)/middleware/cmd/middleware
 
 aarch64: check-go-env ci
-	GOARCH=arm64 go install $(REPO_ROOT)/middleware/cmd/middleware
-	cp ${GOPATH}/bin/linux_arm64/middleware $(REPO_ROOT)/bin/go/bbbmiddleware
+	GOARCH=arm64 go build $(REPO_ROOT)/middleware/cmd/middleware
+	cp $(REPO_ROOT)/middleware/middleware $(REPO_ROOT)/bin/go/bbbmiddleware
 
 regtest-up:
 	cd $(REPO_ROOT)/middleware/integration_test ;\

--- a/tools/bbbconfgen/Makefile
+++ b/tools/bbbconfgen/Makefile
@@ -5,9 +5,9 @@ check-go-env:
 	@echo "Checking that environment supports Go builds.."
 	@$(REPO_ROOT)/contrib/check-go-env.sh "$(REPO_ROOT)"
 
-native: check-go-env 
+native: check-go-env
 	go install $(REPO_ROOT)/tools/bbbconfgen
 
 aarch64: check-go-env
-	GOARCH=arm64 go install $(REPO_ROOT)/tools/bbbconfgen
-	cp ${GOPATH}/bin/linux_arm64/bbbconfgen $(REPO_ROOT)/bin/go/
+	GOARCH=arm64 go build $(REPO_ROOT)/tools/bbbconfgen
+	cp $(REPO_ROOT)/tools/bbbconfgen/bbbconfgen $(REPO_ROOT)/bin/go/

--- a/tools/bbbfancontrol/Makefile
+++ b/tools/bbbfancontrol/Makefile
@@ -9,5 +9,5 @@ native: check-go-env
 	go install $(REPO_ROOT)/tools/bbbfancontrol
 
 aarch64: check-go-env
-	GOARCH=arm64 go install $(REPO_ROOT)/tools/bbbfancontrol
-	cp ${GOPATH}/bin/linux_arm64/bbbfancontrol $(REPO_ROOT)/bin/go/
+	GOARCH=arm64 go build $(REPO_ROOT)/tools/bbbfancontrol
+	cp $(REPO_ROOT)/tools/bbbfancontrol/bbbfancontrol $(REPO_ROOT)/bin/go/

--- a/tools/bbbsupervisor/Makefile
+++ b/tools/bbbsupervisor/Makefile
@@ -9,5 +9,5 @@ native: check-go-env
 	go install $(REPO_ROOT)/tools/bbbsupervisor
 
 aarch64: check-go-env
-	GOARCH=arm64 go install $(REPO_ROOT)/tools/bbbsupervisor
-	cp ${GOPATH}/bin/linux_arm64/bbbsupervisor $(REPO_ROOT)/bin/go/
+	GOARCH=arm64 go build $(REPO_ROOT)/tools/bbbsupervisor
+	cp $(REPO_ROOT)/tools/bbbsupervisor/bbbsupervisor $(REPO_ROOT)/bin/go/


### PR DESCRIPTION
This pull request updates the build method to run the configuration script directly on a preinstalled Linux distribution. It's used mainly for testing of non-Armbian distributions.

**compile Go: use build instead of install in Docker**
https://github.com/shiftdevices/bitbox-base-internal/issues/326

Because:
* When cross-compiling the Go tools inside Docker, with the command
  'docker install', the binaries are put into the directory
  $GOPATH/bin/linux_arm64
* One goal is to run installation (incl. Go compilation) directly on
  the ARM device, to support other distributions. When not cross-
  compiling, the binaries are put into $GOPATH/bin/, failing the
  make process.

This commit:
* uses 'go build' instead of 'go install' to always put the binaries
  directly in the source directory and copy them from there.

**Update 'make build-ondevice'**
Because:
* Users should be able to run the BitBoxBase customization on a vanilla
  Linux installation, e.g. the Ayufan ARM distribution.
* For that to work, Go binaries need to be compiled first.
* Armbian specific changes are allowed to be skipped in that build mode

This commit:
* checks if Go tool binaries are available, or aborts
* adds some checks in customization script when running on device
* in prometheus-base.sh, check if Redis values like 'build:date' or
  'build:commit' are null and return 'n/a'.
* check if Redis factory settings are present, or abort
* outsource tasks not related to update out of systemd-update-checks.sh
  to systemd-startup-after-redis.sh