### PR TITLE
build: don't use bbbmiddleware.conf

### DIFF
--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -600,7 +600,10 @@ fi
 if [ -f /opt/shift/bin/go/bbbmiddleware ]; then
   cp /opt/shift/bin/go/bbbmiddleware /usr/local/sbin/
   mkdir -p /etc/bbbmiddleware/
-  generateConfig "bbbmiddleware.conf.template" # --> /etc/bbbmiddleware/bbbmiddleware.conf
+
+  # currently, no configuration required, can be added again if needed
+  #generateConfig "bbbmiddleware.conf.template" # --> /etc/bbbmiddleware/bbbmiddleware.conf
+
   chmod -R u+rw,g+r,g-w,o-rwx /etc/bbbmiddleware
   importFile "/etc/systemd/system/bbbmiddleware.service"
   systemctl enable bbbmiddleware.service


### PR DESCRIPTION
Related to https://github.com/digitalbitbox/bitbox-base/pull/255

After removing the necessity of /etc/bbbmiddleware/bbbmiddleware.conf, the build script must no longer import it as a template.

This commit:
* updates the broken build script