### PR TITLE
bbbmiddleware: don't use systemd EnvironmentFile

### DIFF
--- a/armbian/base/rootfs/etc/systemd/system/bbbmiddleware.service
+++ b/armbian/base/rootfs/etc/systemd/system/bbbmiddleware.service
@@ -7,7 +7,7 @@ After=multi-user.target bitcoind.service
 # Service execution
 ###################
 
-EnvironmentFile=/etc/bbbmiddleware/bbbmiddleware.conf
+#EnvironmentFile=/etc/bbbmiddleware/bbbmiddleware.conf
 ExecStartPre=/opt/shift/scripts/systemd-bbbmiddleware-startpre.sh
 ExecStart=/usr/local/sbin/bbbmiddleware \
     -datadir=/data/bbbmiddleware


### PR DESCRIPTION
After removing the bbbmiddleware.conf, the systemd unit must no longer try to load it.

This commit:
* fixes the systemd unit bbbmiddleware.service