### PR TITLE
bbb-cmd: improve 'flashdrive mount'

### DIFF
--- a/armbian/base/scripts/bbb-cmd.sh
+++ b/armbian/base/scripts/bbb-cmd.sh
@@ -233,6 +233,12 @@ case "${MODULE}" in
                 # ensure mountpoint is available
                 mkdir -p /mnt/backup
 
+                # detect flashdrive if no device is provided
+                if [[ -z "${ARG}" ]]; then
+                    ARG="$(/opt/shift/scripts/bbb-cmd.sh flashdrive check)"
+                    echo "INFO: autodetected device ${ARG}"
+                fi
+
                 # check if ARG is valid flashdrive
                 if ! lsblk "${ARG}" > /dev/null 2>&1; then
                     echo "FLASHDRIVE MOUNT: device ${ARG} not found."
@@ -241,9 +247,6 @@ case "${MODULE}" in
                 elif [ "$(lsblk -o NAME,SIZE,FSTYPE -abrnp -I 8 "${ARG}" | wc -l)" -ne 1 ]; then
                     echo "FLASHDRIVE MOUNT: device ${ARG} is not unique and/or has partitions."
                     errorExit FLASHDRIVE_MOUNT_NOT_UNIQUE
-
-                elif mountpoint /mnt/backup -q; then
-                    echo "FLASHDRIVE MOUNT: mountpoint /mnt/backup is already in use. Assuming prior mount, no error."
 
                 else
                     if mountpoint /mnt/backup -q; then


### PR DESCRIPTION
Because:
* Currently, the device (e.g. /dev/sdc1) needs to be provided to mount a backup flashdrive with 'flashdrive mount'.
* This info is available with 'flashdrive check'.

This commit:
* allows calling 'flashdrive mount' without argument and implicitely gets the information from 'flashdrive check'. This method still exits the command if any issue occurs with the correct error message.
* fixes error handling when mountpoint is already is in use and unmounts the usb drive first.