### PR TITLE
creating empty bbbmiddleware.conf

### DIFF
--- a/armbian/base/config/templates/bbbmiddleware.conf.template
+++ b/armbian/base/config/templates/bbbmiddleware.conf.template
@@ -1,0 +1,1 @@
+{{ #output: /etc/bbbmiddleware/bbbmiddleware.conf }}

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -600,10 +600,7 @@ fi
 if [ -f /opt/shift/bin/go/bbbmiddleware ]; then
   cp /opt/shift/bin/go/bbbmiddleware /usr/local/sbin/
   mkdir -p /etc/bbbmiddleware/
-
-  # currently, no configuration required, can be added again if needed
-  #generateConfig "bbbmiddleware.conf.template" # --> /etc/bbbmiddleware/bbbmiddleware.conf
-
+  generateConfig "bbbmiddleware.conf.template" # --> /etc/bbbmiddleware/bbbmiddleware.conf
   chmod -R u+rw,g+r,g-w,o-rwx /etc/bbbmiddleware
   importFile "/etc/systemd/system/bbbmiddleware.service"
   systemctl enable bbbmiddleware.service


### PR DESCRIPTION
related to https://github.com/digitalbitbox/bitbox-base/pull/255

Because:
* The bbbmiddleware.conf.template and the created file are used by many scripts.
* It was removed in pr255, which breaks both build and operations.

This commit:
* adds an empty bbbmiddleware.conf.template that can be recreated at will, sourced from systemd as environment file etc. without breaking the configuration.

Future configuration can be added here again.