### PR TITLE
Lock users on build, don't add SSH keys by default

### DIFF
--- a/armbian/base/build.conf
+++ b/armbian/base/build.conf
@@ -20,6 +20,9 @@
 # Enable Bitcoin-related services before App Setup
 #BASE_ENABLE_BITCOIN_SERVICES="false"
 
+# Add trusted SSH keys for login: <true|false>
+#BASE_ADD_SSH_KEYS="false"
+
 # Manual root password, 8 characters min, with numbers
 # WARNING: very unsafe, for DEVELOPMENT ONLY!
 #BASE_LOGINPW="your-development-password"

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -189,13 +189,19 @@ addgroup --system bitcoin
 addgroup --system system
 
 # Set root password (either from configuration or random) and lock account
-BASE_LOGINPW=${BASE_LOGINPW:-$(< /dev/urandom tr -dc A-Z-a-z-0-9 | head -c32)}
-echo "root:${BASE_LOGINPW}" | chpasswd
+BASE_LOGINPW_FINAL=${BASE_LOGINPW:-$(< /dev/urandom tr -dc A-Z-a-z-0-9 | head -c32)}
+echo "root:${BASE_LOGINPW_FINAL}" | chpasswd
 
 # create user 'base' (--gecos "" is used to prevent interactive prompting for user information)
 adduser --ingroup system --disabled-password --gecos "" base || true
 usermod -a -G sudo,bitcoin base
-echo "base:${BASE_LOGINPW}" | chpasswd
+echo "base:${BASE_LOGINPW_FINAL}" | chpasswd
+
+# lock user 'root', and user 'base' if no BASE_LOGINPW is provided
+passwd -l root
+if [[ -z "${BASE_LOGINPW}" ]]; then
+  passwd -l base
+fi
 
 # Add trusted SSH keys for login
 mkdir -p /home/base/.ssh/

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -134,6 +134,7 @@ BASE_AUTOSETUP_SSD=${BASE_AUTOSETUP_SSD:-"false"}
 BASE_ENABLE_BITCOIN_SERVICES=${BASE_ENABLE_BITCOIN_SERVICES:-"false"}
 BASE_WIFI_SSID=${BASE_WIFI_SSID:-""}
 BASE_WIFI_PW=${BASE_WIFI_PW:-""}
+BASE_ADD_SSH_KEYS=${BASE_ADD_SSH_KEYS:-"false"}
 BASE_SSH_ROOT_LOGIN=${BASE_SSH_ROOT_LOGIN:-"false"}
 BASE_SSH_PASSWORD_LOGIN=${BASE_SSH_PASSWORD_LOGIN:-"false"}
 BASE_DASHBOARD_WEB_ENABLED=${BASE_DASHBOARD_WEB_ENABLED:-"false"}
@@ -205,10 +206,10 @@ fi
 
 # Add trusted SSH keys for login
 mkdir -p /home/base/.ssh/
-if [ -f /opt/shift/config/ssh/authorized_keys ]; then
+if [[ "${BASE_ADD_SSH_KEYS}" == "true" ]] && [ -f /opt/shift/config/ssh/authorized_keys ]; then
   cp /opt/shift/config/ssh/authorized_keys /home/base/.ssh/
 else
-  echo "No SSH keys file found (base/authorized_keys), password login only."
+  echo "Option BASE_ADD_SSH_KEYS not set to 'true' or no SSH keys file found (base/authorized_keys): password login only."
 fi
 chown -R base:bitcoin /home/base/
 chmod -R u+rw,g-rwx,o-rwx /home/base/.ssh

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -314,12 +314,13 @@ case "${COMMAND}" in
 
                 if [[ ${ENABLE} -eq 1 ]]; then
                     redis_set "base:sshd:rootlogin" "yes"
+                    exec_overlayroot all-layers "passwd -u root"
                 else
                     redis_set "base:sshd:rootlogin" "no"
+                    exec_overlayroot all-layers "passwd -l root"
                 fi
                 generateConfig "sshd_config.template"
                 systemctl restart sshd.service
-                exec_overlayroot all-layers "passwd -u root"
                 ;;
 
             SSHPWLOGIN)

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -319,6 +319,7 @@ case "${COMMAND}" in
                 fi
                 generateConfig "sshd_config.template"
                 systemctl restart sshd.service
+                exec_overlayroot all-layers "passwd -u root"
                 ;;
 
             SSHPWLOGIN)
@@ -474,6 +475,7 @@ case "${COMMAND}" in
 
                 exec_overlayroot all-layers "echo 'root:${3}' | chpasswd"
                 exec_overlayroot all-layers "echo 'base:${3}' | chpasswd"
+                exec_overlayroot all-layers "passwd -u base"
                 ;;
 
             WIFI_SSID)


### PR DESCRIPTION
**build: lock users & unlock on loginpw/rootlogin**
On building the Base image, the pw for users 'root' and 'base' are set with a random password, but all images will have the same. This is why the users need to be locked on build. When setting a custom system password in the BitBoxApp advanced settings, the password is set and the user 'base' is unlocked

* lock user 'root' when building the Base image
* lock user 'base' on building, but only if no `BASE_LOGINPW` has been set
* unlocks 'base' user when calling `bbb-config.sh enable loginpw`
* unlocks/locks 'root' user when calling `bbb-config.sh enable/disable rootlogin`

**ssh keys: add flag to build without keys**
When shipping BitBoxBase devices, no development SSH keys must be included. On build, the configuration option `BASE_ADD_SSH_KEYS` is used to decide whether to include the ssh keys or not (default: `false`)

* adds the option `BASE_ADD_SSH_KEYS` to `build.conf`
  --> need to update 'build-local.conf' for development!
* checks this option and only adds ssh keys if set to true