### PR TITLE
update: re-enable bitcoin services

### DIFF
--- a/armbian/base/scripts/systemd-startup-after-redis.sh
+++ b/armbian/base/scripts/systemd-startup-after-redis.sh
@@ -90,7 +90,6 @@ fi
 # update onion addresses in Redis
 updateTorOnions
 
-
 # check if rpcauth credentials exist, or create new ones
 RPCAUTH="$(redis_get 'bitcoind:rpcauth')"
 REFRESH_RPCAUTH="$(redis_get 'bitcoind:refresh-rpcauth')"
@@ -102,4 +101,11 @@ if [ ${#RPCAUTH} -lt 90 ] || [ "${REFRESH_RPCAUTH}" -eq 1 ] || [ "${REFRESH_RPCA
     /opt/shift/scripts/bbb-cmd.sh bitcoind refresh_rpcauth
 else
     echo "INFO: found bitcoind rpc credentials, no action taken"
+fi
+
+# make sure Bitcoin-related services are enabled and started if setup is finished
+if [[ $(redis_get "base:setup") -eq 1 ]] && ! systemctl is-enabled bitcoind.service; then
+    echo "WARN: setup is completed, but Bitcoin-related services are not enabled. Enabling and starting them now..."
+    /opt/shift/scripts/bbb-config.sh enable bitcoin_services
+    /opt/shift/scripts/bbb-systemctl.sh start-bitcoin-services
 fi

--- a/armbian/base/scripts/systemd-update-checks.sh
+++ b/armbian/base/scripts/systemd-update-checks.sh
@@ -91,6 +91,10 @@ else
     if [[ $(redis_get "base:updating") -eq 20 ]]; then
         for run in {1..100}; do
             if  /opt/shift/scripts/bbb-systemctl.sh verify; then
+
+                # after running services are verified, enable them
+                /opt/shift/scripts/bbb-config.sh enable bitcoin_services
+
                 redis_set "base:updating" 30
                 break
             fi


### PR DESCRIPTION
In the update image, bitcoin-related services are disabled. They are started after boot to check if all services are working correctly, but aren't enabled. The effect is that everything runs fine, until after the next reboot when bitcoind, lightningd and electrs do not start.

Services should always be enabled on update, and no check for the finished Setup Wizard is necessary, as it is not a feasible scenario that the Base is updated without being set up first.

This commit:
* enables the bitcoin-related services during the update process
* adds a check on every boot if Redis key 'base:setup' is 1 and
  enables the services if needed