### PR TITLE
Middleware: update GetBaseInfo 

### DIFF
--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -1017,16 +1017,19 @@ func (middleware *Middleware) GetBaseInfo() rpcmessages.GetBaseInfoResponse {
 
 	middlewarePort := middleware.environment.GetMiddlewarePort()
 
-	middlewareTorOnion, err := middleware.redisClient.GetString(redis.MiddlewareOnion)
+	isTorEnabled, err := middleware.redisClient.GetBool(redis.TorEnabled)
 	if err != nil {
 		errResponse := middleware.redisClient.ConvertErrorToErrorResponse(err)
 		return rpcmessages.GetBaseInfoResponse{ErrorResponse: &errResponse}
 	}
 
-	isTorEnabled, err := middleware.redisClient.GetBool(redis.TorEnabled)
-	if err != nil {
-		errResponse := middleware.redisClient.ConvertErrorToErrorResponse(err)
-		return rpcmessages.GetBaseInfoResponse{ErrorResponse: &errResponse}
+	var middlewareTorOnion string
+	if isTorEnabled {
+		middlewareTorOnion, err = middleware.redisClient.GetString(redis.MiddlewareOnion)
+		if err != nil {
+			errResponse := middleware.redisClient.ConvertErrorToErrorResponse(err)
+			return rpcmessages.GetBaseInfoResponse{ErrorResponse: &errResponse}
+		}
 	}
 
 	isBitcoindListening, err := middleware.redisClient.GetBool(redis.BitcoindListen)

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -1078,9 +1078,8 @@ func (middleware *Middleware) GetBaseInfo() rpcmessages.GetBaseInfoResponse {
 		Status:              "-PLACEHOLDER-", // FIXME: This is a placeholder.
 		Hostname:            hostname,
 		MiddlewareLocalIP:   middlewareIP,
-		MiddlewareLocalPort: middlewarePort,
+		MiddlewarePort:      middlewarePort,
 		MiddlewareTorOnion:  middlewareTorOnion,
-		MiddlewareTorPort:   "-PLACEHOLDER-", // FIXME: This is a placeholder.
 		IsTorEnabled:        isTorEnabled,
 		IsBitcoindListening: isBitcoindListening,
 		FreeDiskspace:       freeDiskspace,

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -1044,6 +1044,12 @@ func (middleware *Middleware) GetBaseInfo() rpcmessages.GetBaseInfoResponse {
 		return rpcmessages.GetBaseInfoResponse{ErrorResponse: &errResponse}
 	}
 
+	lightningActiveChannels, err := middleware.prometheusClient.GetInt(prometheus.LightningActiveChannels)
+	if err != nil {
+		errResponse := middleware.prometheusClient.ConvertErrorToErrorResponse(err)
+		return rpcmessages.GetBaseInfoResponse{ErrorResponse: &errResponse}
+	}
+
 	totalDiskspace, err := middleware.prometheusClient.GetInt(prometheus.BaseTotalDiskspace)
 	if err != nil {
 		errResponse := middleware.prometheusClient.ConvertErrorToErrorResponse(err)
@@ -1078,19 +1084,20 @@ func (middleware *Middleware) GetBaseInfo() rpcmessages.GetBaseInfoResponse {
 		ErrorResponse: &rpcmessages.ErrorResponse{
 			Success: true,
 		},
-		Status:              "-PLACEHOLDER-", // FIXME: This is a placeholder.
-		Hostname:            hostname,
-		MiddlewareLocalIP:   middlewareIP,
-		MiddlewarePort:      middlewarePort,
-		MiddlewareTorOnion:  middlewareTorOnion,
-		IsTorEnabled:        isTorEnabled,
-		IsBitcoindListening: isBitcoindListening,
-		FreeDiskspace:       freeDiskspace,
-		TotalDiskspace:      totalDiskspace,
-		BaseVersion:         baseVersion,
-		BitcoindVersion:     bitcoindVersion,
-		LightningdVersion:   lightningdVersion,
-		ElectrsVersion:      electrsVersion,
+		Status:                  "-PLACEHOLDER-", // FIXME: This is a placeholder.
+		Hostname:                hostname,
+		MiddlewareLocalIP:       middlewareIP,
+		MiddlewarePort:          middlewarePort,
+		MiddlewareTorOnion:      middlewareTorOnion,
+		IsTorEnabled:            isTorEnabled,
+		IsBitcoindListening:     isBitcoindListening,
+		LightningActiveChannels: lightningActiveChannels,
+		FreeDiskspace:           freeDiskspace,
+		TotalDiskspace:          totalDiskspace,
+		BaseVersion:             baseVersion,
+		BitcoindVersion:         bitcoindVersion,
+		LightningdVersion:       lightningdVersion,
+		ElectrsVersion:          electrsVersion,
 	}
 }
 

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -1032,6 +1032,14 @@ func (middleware *Middleware) GetBaseInfo() rpcmessages.GetBaseInfoResponse {
 		}
 	}
 
+	var isSSHPasswordLoginEnabled bool
+	isSSHPasswordLoginEnabledSetting, err := middleware.redisClient.GetString(redis.BaseSSHDPasswordLogin)
+	if err != nil {
+		errResponse := middleware.redisClient.ConvertErrorToErrorResponse(err)
+		return rpcmessages.GetBaseInfoResponse{ErrorResponse: &errResponse}
+	}
+	isSSHPasswordLoginEnabled = isSSHPasswordLoginEnabledSetting == "yes"
+
 	isBitcoindListening, err := middleware.redisClient.GetBool(redis.BitcoindListen)
 	if err != nil {
 		errResponse := middleware.redisClient.ConvertErrorToErrorResponse(err)
@@ -1084,20 +1092,21 @@ func (middleware *Middleware) GetBaseInfo() rpcmessages.GetBaseInfoResponse {
 		ErrorResponse: &rpcmessages.ErrorResponse{
 			Success: true,
 		},
-		Status:                  "-PLACEHOLDER-", // FIXME: This is a placeholder.
-		Hostname:                hostname,
-		MiddlewareLocalIP:       middlewareIP,
-		MiddlewarePort:          middlewarePort,
-		MiddlewareTorOnion:      middlewareTorOnion,
-		IsTorEnabled:            isTorEnabled,
-		IsBitcoindListening:     isBitcoindListening,
-		LightningActiveChannels: lightningActiveChannels,
-		FreeDiskspace:           freeDiskspace,
-		TotalDiskspace:          totalDiskspace,
-		BaseVersion:             baseVersion,
-		BitcoindVersion:         bitcoindVersion,
-		LightningdVersion:       lightningdVersion,
-		ElectrsVersion:          electrsVersion,
+		Status:                    "-PLACEHOLDER-", // FIXME: This is a placeholder.
+		Hostname:                  hostname,
+		MiddlewareLocalIP:         middlewareIP,
+		MiddlewarePort:            middlewarePort,
+		MiddlewareTorOnion:        middlewareTorOnion,
+		IsTorEnabled:              isTorEnabled,
+		IsBitcoindListening:       isBitcoindListening,
+		LightningActiveChannels:   lightningActiveChannels,
+		IsSSHPasswordLoginEnabled: isSSHPasswordLoginEnabled,
+		FreeDiskspace:             freeDiskspace,
+		TotalDiskspace:            totalDiskspace,
+		BaseVersion:               baseVersion,
+		BitcoindVersion:           bitcoindVersion,
+		LightningdVersion:         lightningdVersion,
+		ElectrsVersion:            electrsVersion,
 	}
 }
 

--- a/middleware/src/prometheus/queries.go
+++ b/middleware/src/prometheus/queries.go
@@ -17,4 +17,5 @@ const (
 	BaseTotalDiskspace          BasePrometheusQuery = "node_filesystem_size_bytes{fstype=\"ext4\", mountpoint=\"/mnt/ssd\"}"
 	LightningBlocks             BasePrometheusQuery = "lightning_node_blockheight"
 	ElectrsBlocks               BasePrometheusQuery = "electrs_index_height"
+	LightningActiveChannels     BasePrometheusQuery = "sum(lightning_peer_channels) or vector(0)"
 )

--- a/middleware/src/redis/keys.go
+++ b/middleware/src/redis/keys.go
@@ -18,4 +18,5 @@ const (
 	MiddlewarePasswordSet BaseRedisKey = "middleware:passwordSetup"
 	MiddlewareAuth        BaseRedisKey = "middleware:auth"
 	BaseSetupDone         BaseRedisKey = "base:setup"
+	BaseSSHDPasswordLogin BaseRedisKey = "base:sshd:passwordlogin"
 )

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -129,21 +129,22 @@ type GetBaseUpdateProgressResponse struct {
 
 // GetBaseInfoResponse is the struct that gets sent by the RPC server during a GetBaseInfo RPC call
 type GetBaseInfoResponse struct {
-	ErrorResponse           *ErrorResponse
-	Status                  string `json:"status"`
-	Hostname                string `json:"hostname"`
-	MiddlewareLocalIP       string `json:"middlewareLocalIP"`
-	MiddlewarePort          string `json:"middlewarePort"`
-	MiddlewareTorOnion      string `json:"middlewareTorOnion"`
-	IsTorEnabled            bool   `json:"isTorEnabled"`
-	IsBitcoindListening     bool   `json:"isBitcoindListening"`
-	LightningActiveChannels int64  `json:"lightningActiveChannels"`
-	FreeDiskspace           int64  `json:"freeDiskspace"`  // in Byte
-	TotalDiskspace          int64  `json:"totalDiskspace"` // in Byte
-	BaseVersion             string `json:"baseVersion"`
-	BitcoindVersion         string `json:"bitcoindVersion"`
-	LightningdVersion       string `json:"lightningdVersion"`
-	ElectrsVersion          string `json:"electrsVersion"`
+	ErrorResponse             *ErrorResponse
+	Status                    string `json:"status"`
+	Hostname                  string `json:"hostname"`
+	MiddlewareLocalIP         string `json:"middlewareLocalIP"`
+	MiddlewarePort            string `json:"middlewarePort"`
+	MiddlewareTorOnion        string `json:"middlewareTorOnion"`
+	IsTorEnabled              bool   `json:"isTorEnabled"`
+	IsBitcoindListening       bool   `json:"isBitcoindListening"`
+	IsSSHPasswordLoginEnabled bool   `json:"IsSSHPasswordLoginEnabled"`
+	LightningActiveChannels   int64  `json:"lightningActiveChannels"`
+	FreeDiskspace             int64  `json:"freeDiskspace"`  // in Byte
+	TotalDiskspace            int64  `json:"totalDiskspace"` // in Byte
+	BaseVersion               string `json:"baseVersion"`
+	BitcoindVersion           string `json:"bitcoindVersion"`
+	LightningdVersion         string `json:"lightningdVersion"`
+	ElectrsVersion            string `json:"electrsVersion"`
 }
 
 // GetServiceInfoResponse is the struct that gets sent by the RPC server during a GetServiceInfo RPC call

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -129,20 +129,21 @@ type GetBaseUpdateProgressResponse struct {
 
 // GetBaseInfoResponse is the struct that gets sent by the RPC server during a GetBaseInfo RPC call
 type GetBaseInfoResponse struct {
-	ErrorResponse       *ErrorResponse
-	Status              string `json:"status"`
-	Hostname            string `json:"hostname"`
-	MiddlewareLocalIP   string `json:"middlewareLocalIP"`
-	MiddlewarePort      string `json:"middlewarePort"`
-	MiddlewareTorOnion  string `json:"middlewareTorOnion"`
-	IsTorEnabled        bool   `json:"isTorEnabled"`
-	IsBitcoindListening bool   `json:"isBitcoindListening"`
-	FreeDiskspace       int64  `json:"freeDiskspace"`  // in Byte
-	TotalDiskspace      int64  `json:"totalDiskspace"` // in Byte
-	BaseVersion         string `json:"baseVersion"`
-	BitcoindVersion     string `json:"bitcoindVersion"`
-	LightningdVersion   string `json:"lightningdVersion"`
-	ElectrsVersion      string `json:"electrsVersion"`
+	ErrorResponse           *ErrorResponse
+	Status                  string `json:"status"`
+	Hostname                string `json:"hostname"`
+	MiddlewareLocalIP       string `json:"middlewareLocalIP"`
+	MiddlewarePort          string `json:"middlewarePort"`
+	MiddlewareTorOnion      string `json:"middlewareTorOnion"`
+	IsTorEnabled            bool   `json:"isTorEnabled"`
+	IsBitcoindListening     bool   `json:"isBitcoindListening"`
+	LightningActiveChannels int64  `json:"lightningActiveChannels"`
+	FreeDiskspace           int64  `json:"freeDiskspace"`  // in Byte
+	TotalDiskspace          int64  `json:"totalDiskspace"` // in Byte
+	BaseVersion             string `json:"baseVersion"`
+	BitcoindVersion         string `json:"bitcoindVersion"`
+	LightningdVersion       string `json:"lightningdVersion"`
+	ElectrsVersion          string `json:"electrsVersion"`
 }
 
 // GetServiceInfoResponse is the struct that gets sent by the RPC server during a GetServiceInfo RPC call

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -133,9 +133,8 @@ type GetBaseInfoResponse struct {
 	Status              string `json:"status"`
 	Hostname            string `json:"hostname"`
 	MiddlewareLocalIP   string `json:"middlewareLocalIP"`
-	MiddlewareLocalPort string `json:"middlewareLocalPort"`
+	MiddlewarePort      string `json:"middlewarePort"`
 	MiddlewareTorOnion  string `json:"middlewareTorOnion"`
-	MiddlewareTorPort   string `json:"middlewareTorPort"`
 	IsTorEnabled        bool   `json:"isTorEnabled"`
 	IsBitcoindListening bool   `json:"isBitcoindListening"`
 	FreeDiskspace       int64  `json:"freeDiskspace"`  // in Byte


### PR DESCRIPTION
This is the second iteration of GetBaseInfo. 

- change: merge OnionPort & LocalPort into one
This change merges the MiddlewareLocalPort and MiddlewareOnionPort
from the GetBaseInfoResponse into one MiddlewarePort, since they are
the same for now.

- change: only return Onion if Tor is enabled
This change leaves the MiddlewareTorOnion emtpy ("") if Tor is not
enabled on the Base. This helps showing the correct values in the
node management.

- add: active lightning channels to BaseInfo
This adds the number of active lightning channels to the GetBaseInfo-
Response.

- add: isSSHPasswordLoginEnabled bool to BaseInfo
This adds a boolean indicating if SSH password login is enabled to
the GetBaseInfoResponse.