### PR TITLE
scripts: use POSIX-compatible uppercase method

### DIFF
--- a/armbian/base/scripts/bbb-cmd.sh
+++ b/armbian/base/scripts/bbb-cmd.sh
@@ -80,8 +80,8 @@ MODULE="${1:-}"
 COMMAND="${2:-}"
 ARG="${3:-}"
 
-MODULE="${MODULE^^}"
-COMMAND="${COMMAND^^}"
+MODULE="$(tr '[:lower:]' '[:upper:]' <<< "${MODULE}")"
+COMMAND="$(tr '[:lower:]' '[:upper:]' <<< "${COMMAND}")"
 
 case "${MODULE}" in
     SETUP)
@@ -474,7 +474,8 @@ case "${MODULE}" in
                 errorExit CMD_SCRIPT_INVALID_ARG
         fi
 
-        if [[ "${ARG^^}" != "--ASSUME-YES" ]]; then
+        ARG="$(tr '[:lower:]' '[:upper:]' <<< "${ARG}")"
+        if [[ "${ARG}" != "--ASSUME-YES" ]]; then
             printf "\nThis will reset the BitBoxBase with command '%s'. Continue?\nType: YES or abort with Ctrl-C\n> " "${COMMAND}"
             read -r ask_confirmation
 

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -89,8 +89,9 @@ if [[ $MOCKMODE -ne 1 ]] && [[ ${UID} -ne 0 ]]; then
     errorExit SCRIPT_NOT_RUN_AS_SUPERUSER
 fi
 
-COMMAND="${1}"
-SETTING="${2^^}"
+COMMAND="${1:-}"
+SETTING="${2:-}"
+SETTING="$(tr '[:lower:]' '[:upper:]' <<< "${SETTING}")"
 
 # parse COMMAND: enable, disable, get, set
 case "${COMMAND}" in


### PR DESCRIPTION
Using the method `${VAR^^}` to set variables to uppercase is only supported from BASH 4.0 on. Running the regtest environment on Macs leads to script errors.

This commit:
* Makes sure all arguments are initialized like `VAR="${1:-}"`
* Uses POSIX-compatible 'tr' syntax to set variables to uppercase:
  `VAR="$(tr '[:lower:]' '[:upper:]' <<< "${VAR}")"`