### PR TITLE
scripts: remove base:bitcoind-services:enabled

### DIFF
--- a/armbian/base/config/redis/factorysettings.txt
+++ b/armbian/base/config/redis/factorysettings.txt
@@ -13,7 +13,6 @@ SET base:hostname bitbox-base
 SET base:update:allow-unsigned 0
 SET base:updating 0
 SET base:setup 0
-SET base:bitcoind-services:enabled 0
 
 SET middleware:passwordSetup 0
 

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -117,7 +117,8 @@ case "${COMMAND}" in
                     exec_overlayroot all-layers "systemctl disable prometheus-bitcoind.service"
                 fi
                 echo "Setting bitcoind configuration for 'active initial sync'."
-                redis_set "base:bitcoind-services:enabled" "${ENABLE}"
+                redis_set "base:setup" "${ENABLE}"
+
                 ;;
 
             BITCOIN_INCOMING)


### PR DESCRIPTION
The Redis key 'base:bitcoind-services:enabled' was set after enabling the bitcoin-related services after the Setup Wizard. It was never checked anywhere else, though, all scripts are using 'base:setup' to decide whether to start these services.

This commit:
* removes key 'base:bitcoind-services:enabled'
* sets the key 'base:setup' to 1 also after manually enabling the bitcoin-related services with 'bbb-config.sh enable bitcoin-services' to ensure the services are started after IBD
* if the sync method should be changed after that (tor/clearnet/resync ect...), this can be triggered from the app.