### PR TITLE
Service info fix

### DIFF
--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -1052,12 +1052,6 @@ func (middleware *Middleware) GetBaseInfo() rpcmessages.GetBaseInfoResponse {
 		return rpcmessages.GetBaseInfoResponse{ErrorResponse: &errResponse}
 	}
 
-	lightningActiveChannels, err := middleware.prometheusClient.GetInt(prometheus.LightningActiveChannels)
-	if err != nil {
-		errResponse := middleware.prometheusClient.ConvertErrorToErrorResponse(err)
-		return rpcmessages.GetBaseInfoResponse{ErrorResponse: &errResponse}
-	}
-
 	totalDiskspace, err := middleware.prometheusClient.GetInt(prometheus.BaseTotalDiskspace)
 	if err != nil {
 		errResponse := middleware.prometheusClient.ConvertErrorToErrorResponse(err)
@@ -1099,7 +1093,6 @@ func (middleware *Middleware) GetBaseInfo() rpcmessages.GetBaseInfoResponse {
 		MiddlewareTorOnion:        middlewareTorOnion,
 		IsTorEnabled:              isTorEnabled,
 		IsBitcoindListening:       isBitcoindListening,
-		LightningActiveChannels:   lightningActiveChannels,
 		IsSSHPasswordLoginEnabled: isSSHPasswordLoginEnabled,
 		FreeDiskspace:             freeDiskspace,
 		TotalDiskspace:            totalDiskspace,

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -138,7 +138,6 @@ type GetBaseInfoResponse struct {
 	IsTorEnabled              bool   `json:"isTorEnabled"`
 	IsBitcoindListening       bool   `json:"isBitcoindListening"`
 	IsSSHPasswordLoginEnabled bool   `json:"IsSSHPasswordLoginEnabled"`
-	LightningActiveChannels   int64  `json:"lightningActiveChannels"`
 	FreeDiskspace             int64  `json:"freeDiskspace"`  // in Byte
 	TotalDiskspace            int64  `json:"totalDiskspace"` // in Byte
 	BaseVersion               string `json:"baseVersion"`
@@ -156,6 +155,7 @@ type GetServiceInfoResponse struct {
 	BitcoindPeers                int64          `json:"bitcoindPeers"`
 	BitcoindIBD                  bool           `json:"bitcoindIBD"`
 	LightningdBlocks             int64          `json:"lightningdBlocks"`
+	LightningActiveChannels      int64          `json:"lightningActiveChannels"`
 	ElectrsBlocks                int64          `json:"electrsBlocks"`
 }
 

--- a/middleware/src/util.go
+++ b/middleware/src/util.go
@@ -206,14 +206,12 @@ func (middleware *Middleware) didServiceInfoChange() (changed bool) {
 func (middleware *Middleware) getServiceInfo() rpcmessages.GetServiceInfoResponse {
 	bitcoindBlocks, err := middleware.prometheusClient.GetInt(prometheus.BitcoinBlockCount)
 	if err != nil {
-		errResponse := middleware.prometheusClient.ConvertErrorToErrorResponse(err)
-		return rpcmessages.GetServiceInfoResponse{ErrorResponse: &errResponse}
+		bitcoindBlocks = 0
 	}
 
 	bitcoindHeaders, err := middleware.prometheusClient.GetInt(prometheus.BitcoinHeaderCount)
 	if err != nil {
-		errResponse := middleware.prometheusClient.ConvertErrorToErrorResponse(err)
-		return rpcmessages.GetServiceInfoResponse{ErrorResponse: &errResponse}
+		bitcoindHeaders = 0
 	}
 
 	bitcoindVerificationProgress, err := middleware.prometheusClient.GetFloat(prometheus.BitcoinVerificationProgress)
@@ -237,20 +235,17 @@ func (middleware *Middleware) getServiceInfo() rpcmessages.GetServiceInfoRespons
 
 	lightningdBlocks, err := middleware.prometheusClient.GetInt(prometheus.LightningBlocks)
 	if err != nil {
-		errResponse := middleware.prometheusClient.ConvertErrorToErrorResponse(err)
-		return rpcmessages.GetServiceInfoResponse{ErrorResponse: &errResponse}
+		lightningdBlocks = 0
 	}
 
 	lightningActiveChannels, err := middleware.prometheusClient.GetInt(prometheus.LightningActiveChannels)
 	if err != nil {
-		errResponse := middleware.prometheusClient.ConvertErrorToErrorResponse(err)
-		return rpcmessages.GetServiceInfoResponse{ErrorResponse: &errResponse}
+		lightningActiveChannels = 0
 	}
 
 	electrsBlocks, err := middleware.prometheusClient.GetInt(prometheus.ElectrsBlocks)
 	if err != nil {
-		errResponse := middleware.prometheusClient.ConvertErrorToErrorResponse(err)
-		return rpcmessages.GetServiceInfoResponse{ErrorResponse: &errResponse}
+		electrsBlocks = 0
 	}
 
 	return rpcmessages.GetServiceInfoResponse{

--- a/middleware/src/util.go
+++ b/middleware/src/util.go
@@ -241,6 +241,12 @@ func (middleware *Middleware) getServiceInfo() rpcmessages.GetServiceInfoRespons
 		return rpcmessages.GetServiceInfoResponse{ErrorResponse: &errResponse}
 	}
 
+	lightningActiveChannels, err := middleware.prometheusClient.GetInt(prometheus.LightningActiveChannels)
+	if err != nil {
+		errResponse := middleware.prometheusClient.ConvertErrorToErrorResponse(err)
+		return rpcmessages.GetServiceInfoResponse{ErrorResponse: &errResponse}
+	}
+
 	electrsBlocks, err := middleware.prometheusClient.GetInt(prometheus.ElectrsBlocks)
 	if err != nil {
 		errResponse := middleware.prometheusClient.ConvertErrorToErrorResponse(err)
@@ -257,6 +263,7 @@ func (middleware *Middleware) getServiceInfo() rpcmessages.GetServiceInfoRespons
 		BitcoindPeers:                bitcoindPeers,
 		BitcoindIBD:                  bitcoindIBD,
 		LightningdBlocks:             lightningdBlocks,
+		LightningActiveChannels:      lightningActiveChannels,
 		ElectrsBlocks:                electrsBlocks,
 	}
 }


### PR DESCRIPTION
- Move active lightning channels from base to service info
- return 0 instead of error for some unavailable values

Because:
* Certain values such as lightning and electrs blocks will not be
  available until bitcoin is fully synced. We still want to return
  useful information during the syncing process.
* Zeroes in this case make sense

This commit:
* return a 0 for bitcoindBlocks, bitcoindHeaders, lightningdBlocks,
  lightningActiveChannels, and electrsBlocks instead of an error
  when these are not available