### PR TITLE
build: cleanup binary dependencies

### DIFF
--- a/armbian/armbian-build.sh
+++ b/armbian/armbian-build.sh
@@ -75,8 +75,7 @@ case ${ACTION} in
 			mkdir -p /opt/shift/bin/go
 			cp -aR ../bin/go/* /opt/shift/bin/go/
 		else
-			echo "ERR: Go tool dependencies missing, build them first by running 'make docker-build-go' in the repository root (requires Docker)"
-			exit 1
+			echo "INFO: binary Go dependencies missing, either build them first, otherwise they are downloading from GitHub"
 		fi
 
 		# run customization script

--- a/armbian/base/build.conf
+++ b/armbian/base/build.conf
@@ -44,11 +44,6 @@
 # Enable web dashboard output
 #BASE_DASHBOARD_WEB_ENABLED="false"
 
-# Build c-lightning from source (true), or use prebuilt binary (false)
-# the prebuilt binary speeds up the image build process and is meant for development only
-# https://github.com/digitalbitbox/bitbox-base-deps
-#BASE_BUILD_LIGHTNINGD="true"
-
 # Remove unnecessary packages (takes a while, but reduces image size by 50%)
 #BASE_MINIMAL="true"
 


### PR DESCRIPTION
When building the BitBoxBase on an existing device, binary Go application dependencies might not have been built from source.

This pull-request allows to download the binary dependencies from GitHub as one tarball and make them available in bin/go. 

A new CONFIG section on top of the customize-armbian script specifies all application and binary dependencies versions.

* collects all application VERSION variables in a CONFIG section
* retrieves all Go binaries in a single command
* removes individual binary handling for custom Go apps
* removes build option BASE_BUILD_LIGHTNINGD (must always build from source)

Tested both in Armbian build system and on a vanilla Ayufan distribution (`make build-ondevice`).