### PR TITLE
scripts: fix startup check mender.conf

### DIFF
--- a/armbian/base/scripts/systemd-startup-after-redis.sh
+++ b/armbian/base/scripts/systemd-startup-after-redis.sh
@@ -87,8 +87,18 @@ else
 fi
 
 
+# Base image updates
+# ------------------------------------------------------------------------------
+# initialize mender configuration
+if [[ -f /etc/mender/mender.conf ]] && ! grep -q '/shift/' /etc/mender/mender.conf ; then
+    exec_overlayroot all-layers 'rm -f /etc/mender/mender.* /etc/mender/server.crt || true'
+    generateConfig mender.conf.template # -->  /etc/mender/mender.conf
+fi
+
+
 # update onion addresses in Redis
 updateTorOnions
+
 
 # check if rpcauth credentials exist, or create new ones
 RPCAUTH="$(redis_get 'bitcoind:rpcauth')"

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -170,11 +170,3 @@ sed -i 's/#overlayroot:swapfile#//g' /etc/fstab
 ## mount potentially updated /etc/fstab, activate swapfile
 mount -a
 swapon /mnt/ssd/swapfile || true
-
-# Base image updates
-# ------------------------------------------------------------------------------
-# initialize mender configuration
-if [[ -f /etc/mender/mender.conf ]] && ! grep -q '/shift/' /etc/mender/mender.conf ; then
-    exec_overlayroot all-layers 'rm -f /etc/mender/mender.* /etc/mender/server.crt || true'
-    exec_overlayroot all-layers 'cp -f /opt/shift/config/mender/mender.conf /etc/mender/'
-fi


### PR DESCRIPTION
Because:
* The startup checks try to copy the static mender.conf file, that
  has been removed in commit 79f6bd9f50e92f79d4f3c3cc2dd7bd47f7b13df9

This commit:
* moves these checks to the startup-after-redis script to generate
  the mender.conf dynamically from the template