### PR TITLE
Fix / improve build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,12 +35,14 @@ docker-build-go: dockerinit
 build-all: docker-build-go
 	@echo "Building Armbian.."
 	$(MAKE) -C armbian
+	$(MAKE) mender-artefacts -C armbian
 
 # build Armbian disk image, use cached binaries and update customization only
 # see configuration: armbian/base/build/build.conf
-update: docker-build-go
+update-all: docker-build-go
 	@echo "Updating Armbian build.."
 	$(MAKE) update -C armbian
+	$(MAKE) mender-artefacts -C armbian
 
 # create a Mender-enabled disk image out of an Armbian image
 mender-artefacts:

--- a/armbian/Makefile
+++ b/armbian/Makefile
@@ -16,7 +16,7 @@ mender-artefacts:
 # update Armbian image and create new Mender.io artefacts in one go
 update-mender: update mender-artefacts
 
-# execute configuration script directly on the device, starting 
+# execute configuration script directly on the device, starting
 # with a stock Armbian image
 build-ondevice:
 	bash $(MAKE_PATH)/armbian-build.sh ondevice

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -156,7 +156,7 @@ BASE_DISTRIBUTION=${BASE_DISTRIBUTION:-"bionic"}
 BASE_MINIMAL=${BASE_MINIMAL:-"true"}
 BASE_HOSTNAME=${BASE_HOSTNAME:-"bitbox-base"}
 BASE_BITCOIN_NETWORK=${BASE_BITCOIN_NETWORK:-"mainnet"}
-BASE_AUTOSETUP_SSD=${BASE_AUTOSETUP_SSD:-"false"}
+BASE_AUTOSETUP_SSD=${BASE_AUTOSETUP_SSD:-"true"}
 BASE_ENABLE_BITCOIN_SERVICES=${BASE_ENABLE_BITCOIN_SERVICES:-"false"}
 BASE_WIFI_SSID=${BASE_WIFI_SSID:-""}
 BASE_WIFI_PW=${BASE_WIFI_PW:-""}
@@ -288,7 +288,7 @@ fi
 
 ## install required software packages
 apt install -y --no-install-recommends \
-  git openssl network-manager net-tools fio libnss-mdns avahi-daemon avahi-discover avahi-utils fail2ban acl rsync smartmontools curl
+  git openssl network-manager net-tools fio libnss-mdns avahi-daemon avahi-utils fail2ban acl rsync smartmontools curl libfontconfig
 apt install -y --no-install-recommends ifmetric
 apt install -y iptables-persistent
 
@@ -730,7 +730,6 @@ if [[ "${BASE_ENABLE_BITCOIN_SERVICES}" == "true" ]]; then
 fi
 
 redis-cli save
-set +x
 
 ## remove temporary symlink /data --> /data_source, unless building on the device without overlayroot
 if [[ "${BASE_BUILDMODE}" != "ondevice" ]] || [[ "${BASE_OVERLAYROOT}" == "true" ]]; then
@@ -746,6 +745,8 @@ if [[ "${BASE_OVERLAYROOT}" == "true" ]]; then
     echo "ERR: overlayroot is only supported in Ubuntu Bionic."
   fi
 fi
+
+set +x
 
 if [[ "${BASE_BUILDMODE}" == "ondevice" ]]; then
   echoArguments "Setup script finished. Please reboot device and login as user 'base'."

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -235,7 +235,7 @@ case "${COMMAND}" in
                 checkMockMode
 
                 if [[ ${ENABLE} -eq 1 ]]; then
-                    touch /opt/shift/config/.autosetup-ssd
+                    exec_overlayroot all-layers "touch /opt/shift/config/.autosetup-ssd"
                 else
                     exec_overlayroot all-layers "rm /opt/shift/config/.autosetup-ssd"
                 fi

--- a/armbian/base/scripts/systemd-startup-checks.sh
+++ b/armbian/base/scripts/systemd-startup-checks.sh
@@ -14,6 +14,9 @@ set -eu
 # include function: exec_overlayroot()
 source /opt/shift/scripts/include/exec_overlayroot.sh.inc
 
+# include errorExit() function
+source /opt/shift/scripts/include/errorExit.sh.inc
+
 # ------------------------------------------------------------------------------
 
 # SSD configuration


### PR DESCRIPTION
Armbian changed the build process and renamed their git branches. This pull-request fixes this, addresses some minor build improvements and extends the top-most `make` command.

**build fixes / improvements**
* switches to Armbian branch 'legacy' (fix)
* sets the .autosetup-ssd trigger as default and commits it also in overlayroot (bug)
* prompts for 'build.conf' when building ondevice
* optionally, run cleanup-loop-devices.sh before compilation
* source errorExit include in systemd-startup-checks.sh (bug)

**Makefile changes**
* extends 'make build-all' to include Mender postprocessing
* renames 'update' to 'update-all' and includes Mender postprocessing