### PR TITLE
enable Tor for BITCOIN_IBD_CLEARNET if necessary

### DIFF
--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -162,10 +162,9 @@ case "${COMMAND}" in
             BITCOIN_IBD_CLEARNET)
                 checkMockMode
 
-                # don't set option if Tor is disabled globally
+                # enable Tor first if it is disabled globally
                 if [[ ${ENABLE} -eq 1 ]] && [ "$(redis_get 'tor:base:enabled')" -eq 0 ]; then
-                    echo "ERR: Tor service is already disabled for the whole system, cannot enable BITCOIN_IBD_CLEARNET"
-                    errorExit ENABLE_CLEARNETIBD_TOR_ALREADY_DISABLED
+                    bbb-config.sh enable tor
                 fi
 
                 # configure bitcoind to run over IPv4 while in IBD mode

--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -653,7 +653,6 @@ func (middleware *Middleware) EnableClearnetIBD(toggleAction rpcmessages.ToggleS
 	if err != nil {
 		errorCode := handleBBBScriptErrorCode(out, err, []rpcmessages.ErrorCode{
 			rpcmessages.ErrorSetNeedsTwoArguments,
-			rpcmessages.ErrorEnableClearnetIBDTorAlreadyDisabled,
 		})
 
 		return rpcmessages.ErrorResponse{

--- a/middleware/src/rpcmessages/errorcodes.go
+++ b/middleware/src/rpcmessages/errorcodes.go
@@ -108,12 +108,6 @@ const (
 	// Not to be confused with ErrorCmdScriptInvalidArg for the bbb-cmd script.
 	ErrorConfigScriptInvalidArg ErrorCode = "CONFIG_SCRIPT_INVALID_ARG"
 
-	/* bbb-config.sh enable bitcoin_ibd_clearnet
-	--------------------------------------------*/
-
-	// ErrorEnableClearnetIBDTorAlreadyDisabled is thrown if the tor service is already disabled for the whole system, cannot enable IBD over clearnet.
-	ErrorEnableClearnetIBDTorAlreadyDisabled ErrorCode = "ENABLE_CLEARNETIBD_TOR_ALREADY_DISABLED"
-
 	/* bbb-config.sh set <key> <value>
 	-----------------------------------*/
 


### PR DESCRIPTION
fixes https://github.com/shiftdevices/bitbox-base-internal/issues/355

The script bbb-config.sh expects Tor to be enabled when enabling the BITCOIN_IBD_CLEARNET option, and give the error ENABLE_CLEARNETIBD_TOR_ALREADY_DISABLED otherwise.

This should not really be a prerequisite and Tor can just be enabled if necessary.

This commit:
* makes the command BITCOIN_IBD_CLEARNET enable Tor if necessary
* Remove Go error ErrorEnableClearnetIBDTorAlreadyDisabled