### PR TITLE
middleware/hsm: increase read timeout

### DIFF
--- a/middleware/src/hsm/hsm.go
+++ b/middleware/src/hsm/hsm.go
@@ -40,9 +40,10 @@ func NewHSM(serialPort string) *HSM {
 
 // openSerial opens the serial port. This operation is cheap (file descriptor open/close), so it can
 // be done before every use. readTimeout is the timeout when waiting for a response of the HSM (this
-// function does not block on this!). If nil, defaults to 5 seconds.
+// function does not block on this!). If nil, defaults to 20 minutes, which is large enough so
+// blocking operations like verifying the pairing will hopefully not timeout.
 func (hsm *HSM) openSerial(readTimeout *time.Duration) (*serial.Port, error) {
-	readTimeoutOrDefault := 5 * time.Second
+	readTimeoutOrDefault := 20 * time.Minute
 	if readTimeout != nil {
 		readTimeoutOrDefault = *readTimeout
 	}


### PR DESCRIPTION
There are blocking operations like verifying the pairing code on the
HSM, which should not timeout in 5s.

A proper fix is to have the HSM timeout itself by default after a
defined period, and have the client read timeout be larger than this.

For now we just increase the timeout to give enough time hopefully.