### PR TITLE
bbbmiddleware: add hsmserialport to config

### DIFF
--- a/armbian/base/config/redis/factorysettings.txt
+++ b/armbian/base/config/redis/factorysettings.txt
@@ -15,6 +15,8 @@ SET base:updating 0
 SET base:setup 0
 
 SET middleware:passwordSetup 0
+SET middleware:datadir /data/bbbmiddleware
+SET middleware:hsmserialport /dev/ttyS2
 
 SET tor:base:enabled 1
 SET tor:ssh:enabled 0

--- a/armbian/base/config/templates/bbbmiddleware.conf.template
+++ b/armbian/base/config/templates/bbbmiddleware.conf.template
@@ -1,1 +1,3 @@
 {{ #output: /etc/bbbmiddleware/bbbmiddleware.conf }}
+DATADIR={{ middleware:datadir #default: /data/bbbmiddleware }}
+HSMSERIALPORT={{ middleware:hsmserialport #default: /dev/ttyS2 }}

--- a/armbian/base/rootfs/etc/systemd/system/bbbmiddleware.service
+++ b/armbian/base/rootfs/etc/systemd/system/bbbmiddleware.service
@@ -10,7 +10,8 @@ After=multi-user.target bitcoind.service
 EnvironmentFile=/etc/bbbmiddleware/bbbmiddleware.conf
 ExecStartPre=/opt/shift/scripts/systemd-bbbmiddleware-startpre.sh
 ExecStart=/usr/local/sbin/bbbmiddleware \
-    -datadir=/data/bbbmiddleware
+    -datadir=${DATADIR} \
+    -hsmserialport=${HSMSERIALPORT}
 
 # Process management
 ####################


### PR DESCRIPTION
The HSM serial port (default: `/dev/ttyS2`) needs to be passed by command line to the bbbmiddleware.  This is what the `/etc/bbbmiddleware/bbbmiddleware.conf` is for, so the configuration is stored in Redis and loaded as environment variable into systemd unit.

This pull request
* adds Redis keys `bbbmiddleware:datadir` and `bbbmiddleware:hsmserialport`
* adds these to the config template `bbbmiddleware.conf.template`
* loads them as env variables and passes them to the binary as cli arguments in the systemd unit

Tested successfully in new BitBoxBase image build.

![Screenshot from 2019-11-27 17-45-38](https://user-images.githubusercontent.com/19550140/69742949-e459f780-113d-11ea-87de-d2c116793cb7.png)
