### PR TITLE
middleware/hsm: use blocking call over timeout (for now)

### DIFF
--- a/middleware/src/hsm/hsm.go
+++ b/middleware/src/hsm/hsm.go
@@ -40,10 +40,9 @@ func NewHSM(serialPort string) *HSM {
 
 // openSerial opens the serial port. This operation is cheap (file descriptor open/close), so it can
 // be done before every use. readTimeout is the timeout when waiting for a response of the HSM (this
-// function does not block on this!). If nil, defaults to 20 minutes, which is large enough so
-// blocking operations like verifying the pairing will hopefully not timeout.
+// function does not block on this!). If nil, defaults to blocking (no timeout).
 func (hsm *HSM) openSerial(readTimeout *time.Duration) (*serial.Port, error) {
-	readTimeoutOrDefault := 20 * time.Minute
+	readTimeoutOrDefault := 0 * time.Second // blocking
 	if readTimeout != nil {
 		readTimeoutOrDefault = *readTimeout
 	}


### PR DESCRIPTION
The serial package's max timeout is silently capped at 25.5s:

https://github.com/tarm/serial/blob/98f6abe2eb07edd42f6dfa2a934aea469acc29b7/serial.go#L158

We need longer for the blocking HSM operations to be able to finish.

We might add a shorter timeout and a repeater in the future, to still
abort after a (long) time, but unless we fully go async, all those
solutions are suboptimal.