### PR TITLE
docker: update dockerfile to use latest go1.13.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # The docker image produced by this config provides the build environment
 # for BitBoxBase.
 #
-FROM golang:1.13.1-stretch as bitbox-base
+FROM golang:1.13.4-stretch as bitbox-base
 RUN apt-get update && apt-get install -y --no-install-recommends \
     clang \
     gcc \
@@ -31,7 +31,7 @@ COPY tools/. tools/.
 RUN make -C "tools"
 
 # Final
-FROM golang:1.13.1-stretch as final
+FROM golang:1.13.4-stretch as final
 
 COPY --from=middleware-builder /go/src/github.com/digitalbitbox/bitbox-base/bin/go/. /opt/build/.
 COPY --from=middleware-tools /go/src/github.com/digitalbitbox/bitbox-base/bin/go/. /opt/build/.


### PR DESCRIPTION
This is used to build tools/... and probably middleware/... I believe.
I suggest subscribing to https://groups.google.com/group/golang-announce to stay up to date with the regular and out of schedule releases. 