### PR TITLE
docs: improve DIY and Releases docs

### DIFF
--- a/docs/overview/diy.md
+++ b/docs/overview/diy.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Do It Yourself!
+title: Do it yourself!
 parent: Overview
 nav_order: 140
 ---
-## Do It Yourself!
+## Do it yourself!
 
 The BitBoxBase projects encourages you to build your own Bitcoin full node! It is still under heavy development and not ready for primetime, so this section will become more detailed over time.
 
@@ -16,18 +16,25 @@ Although we use custom hardware to improve our commercial product and enable add
   * [RockPRO64 4GB](https://store.pine64.org/?product=rockpro64-4gb-single-board-computer) single board computer
   * [eMMC 16 GB](https://store.pine64.org/?product=16gb-emmc) and [USB adapter](https://store.pine64.org/?product=usb-adapter-for-emmc-module)
   * [Power adapter EU](https://store.pine64.org/?product=rockpro64-12v-3a-eu-power-supply) or [US](https://store.pine64.org/?product=rockpro64-12v-3a-us-power-supply)
+
 * Case option A (internal storage)
-  * Custom case (not available yet)
-  * [PCIe SSD adapter](https://store.pine64.org/?product=rockpro64-pci-e-x4-to-m-2ngff-nvme-ssd-interface-card) + 1 TB SSD
+  * Custom case (e.g. made of acrylic like [Digital Garage's hack0](https://github.com/dgarage/hack0-hardware))
+  * PCIe SSD adapter, either our own [minimal adapter](https://shop.shiftcrypto.ch/en/products/compact-m2-to-pcie-adapter-15/) or Pine64's [standard adapter](https://store.pine64.org/?product=rockpro64-pci-e-x4-to-m-2ngff-nvme-ssd-interface-card)
+  * 1 TB SSD (we had good experience with Cruzial P1)
   * [Mid Profile Heatsink](https://store.pine64.org/?product=rockpro64-20mm-mid-profile-heatsink)
   * [CPU Fan](https://store.pine64.org/?product=fan-for-rockpro64-20mm-mid-profile-heatsink)
+
 * Case option B (external storage)
   * [Pine64 Aluminium Casing](https://store.pine64.org/?product=rockpro64-premium-aluminum-casing)
   * external USB3 drive (SSD or HDD)
 
-### Build Base image
+### Base image
 
-The automated build process compiles the custom Armbian operating system, installs and configures all applications and prepares the image for Mender OTA updates (optional).
+You can grab the latest Base image from our releases page.
+See the ["Releases" section](releases.html) how to download, verify and write the release to eMMC storage.
+
+But you can also build and customize the disk image yourself.
+The automated build process will compile the custom Armbian operating system, install and configure all applications and prepare the image for Mender OTA updates (optional).
 
 **Prerequisites**
 
@@ -70,6 +77,9 @@ The result is a disk image with multiple partition that contain the mender confi
   ```bash
   sudo make mender-artefacts
   ```
+
+*Note*: this method works only using eMMC storage.
+Although the RockPro64 board can also use microSD cards, it won't boot from an image that has been postprocessed by Mender.
 
 ### Assembly
 

--- a/docs/overview/releases.md
+++ b/docs/overview/releases.md
@@ -56,3 +56,24 @@ BitBoxBase-v0.X.X-RockPro64.base: OK
 BitBoxBase-v0.X.X-RockPro64.tar.gz: OK
 sha256sum: WARNING: 19 lines are improperly formatted
 ```
+
+### Write to eMMC
+
+To use the full disk image with your RockPro64, you need to write it to the eMMC chip with a USB adapter (see the ["Do it yourself!" section](diy.html)).
+
+First, extract the `tar.gz` archive with the tool of your choice, e.g. [7-Zip](https://www.7-zip.org) on Windows or simply `tar` on Linux.
+
+To write it to eMMC, you can use
+* a program like [Etcher](https://www.balena.io/etcher/)
+* or do it directly from the Linux command line.
+
+On the Linux command line use `dd`: once the eMMC chip is connected to your computer using the USB adapter, get the device name (e.g. `/dev/sdb`).
+Check it carefully, all data on this device will be lost!
+
+```bash
+lsblk
+sudo dd if=BitBoxBase-v0.1.0-RockPro64.img of=/dev/sdb bs=64K conv=sync status=progress
+sync
+```
+
+With the eMMC chip connected on the RockPro64 board, the BitBoxBase will boot right up.


### PR DESCRIPTION
related: https://github.com/digitalbitbox/bitbox-base/issues/290

Because:
* It was not mentioned that only eMMC is supported and booting from a
  Mender MicroSD card does not work

This commit:
* adds this note about only supporting eMMC
* generally improves DIY and Releases docs