### PR TITLE
bbb-cmd: restart bbbmiddleware after auth reset

### DIFF
--- a/armbian/base/scripts/bbb-cmd.sh
+++ b/armbian/base/scripts/bbb-cmd.sh
@@ -493,7 +493,11 @@ case "${MODULE}" in
             AUTH)
                 redis_set "base:setup" 0
                 redis_set "middleware:passwordSetup" 0
-
+                if ! systemctl restart bbbmiddleware.service; then
+                    echo "ERR: could not restart bbbmiddleware.service"
+                    errorExit SYSTEMD_SERVICESTART_FAILED
+                fi
+                echo "INFO: bbbmiddleware.service restarted"
                 echo "OK: middleware authentication reset, setup wizard can be run again."
                 ;;
 


### PR DESCRIPTION
fixes https://github.com/shiftdevices/bitbox-base-internal/issues/354

When resetting the authentication Redis keys, the Middleware needs to be restarted to update its internal state

This commit:
* restarts the bbbmiddleware.service incl. error handling