### PR TITLE
Middleware: Fix and mitigate switched parameters in Configuration factory function 

### DIFF
--- a/middleware/cmd/middleware/main.go
+++ b/middleware/cmd/middleware/main.go
@@ -43,7 +43,7 @@ func main() {
 
 	config := configuration.NewConfiguration(
 		*bbbCmdScript, *bbbConfigScript, *bbbSystemctlScript, *electrsRPCPort,
-		*middlewarePort, *imageUpdateInfoURL, version, *network,
+		*imageUpdateInfoURL, *middlewarePort, version, *network,
 		*notificationNamedPipePath, *prometheusURL, *redisMock, *redisPort,
 	)
 

--- a/middleware/cmd/middleware/main.go
+++ b/middleware/cmd/middleware/main.go
@@ -42,9 +42,20 @@ func main() {
 	}
 
 	config := configuration.NewConfiguration(
-		*bbbCmdScript, *bbbConfigScript, *bbbSystemctlScript, *electrsRPCPort,
-		*imageUpdateInfoURL, *middlewarePort, version, *network,
-		*notificationNamedPipePath, *prometheusURL, *redisMock, *redisPort,
+		configuration.Args{
+			BBBCmdScript:              *bbbCmdScript,
+			BBBConfigScript:           *bbbConfigScript,
+			BBBSystemctlScript:        *bbbSystemctlScript,
+			ElectrsRPCPort:            *electrsRPCPort,
+			ImageUpdateInfoURL:        *imageUpdateInfoURL,
+			MiddlewarePort:            *middlewarePort,
+			MiddlewareVersion:         version,
+			Network:                   *network,
+			NotificationNamedPipePath: *notificationNamedPipePath,
+			PrometheusURL:             *prometheusURL,
+			RedisMock:                 *redisMock,
+			RedisPort:                 *redisPort,
+		},
 	)
 
 	logBeforeExit := func() {

--- a/middleware/src/configuration/configuration.go
+++ b/middleware/src/configuration/configuration.go
@@ -2,7 +2,37 @@
 // values to the Middleware.
 package configuration
 
+// Args has the same fields as the `Configuration` struct, but the fields in
+// `Args` are public. The struct is used as parameter to the `NewConfiguration()`
+// factory function. The struct needs public fields to be settable the `main`
+// package. However the `Configuration` can't have public fields, because the
+// fields should be **READ ONLY** while the Middleware is running. Fields should
+// only be accessible via defined Getter functions.
+//
+// Note: Go does not support named arguments for functions. While passing the
+// arguments to a function would work, it would be rather easy to mistakenly
+// switch e.g. two string parameters ending up with an invalid middleware
+// configuration. Using the `Args` helps, because a Go struct can be initialized
+// with named fields.
+type Args struct {
+	BBBCmdScript              string
+	BBBConfigScript           string
+	BBBSystemctlScript        string
+	ElectrsRPCPort            string
+	ImageUpdateInfoURL        string
+	MiddlewarePort            string
+	MiddlewareVersion         string
+	Network                   string
+	NotificationNamedPipePath string
+	PrometheusURL             string
+	RedisMock                 bool
+	RedisPort                 string
+}
+
 // Configuration holds the configuration options for the Middleware.
+//
+// Note: adding / removing a field in this struct requires an update to the
+// `Args` struct as well.
 type Configuration struct {
 	bbbCmdScript              string
 	bbbConfigScript           string
@@ -19,25 +49,23 @@ type Configuration struct {
 }
 
 // NewConfiguration returns a new Configuration instance.
-func NewConfiguration(
-	bbbCmdScript string, bbbConfigScript string, bbbSystemctlScript string,
-	electrsRPCPort string, imageUpdateInfoURL string, middlewarePort string,
-	middlewareVersion string, network string, notificationNamedPipePath string,
-	prometheusURL string, redisMock bool, redisPort string,
-) Configuration {
+//
+// Note: The `Args` struct supports named fields. Go functions don't support
+// named parameters. The struct helps avoiding switched parameters.
+func NewConfiguration(args Args) Configuration {
 	config := Configuration{
-		bbbCmdScript:              bbbCmdScript,
-		bbbConfigScript:           bbbConfigScript,
-		bbbSystemctlScript:        bbbSystemctlScript,
-		electrsRPCPort:            electrsRPCPort,
-		imageUpdateInfoURL:        imageUpdateInfoURL,
-		middlewarePort:            middlewarePort,
-		middlewareVersion:         middlewareVersion,
-		network:                   network,
-		notificationNamedPipePath: notificationNamedPipePath,
-		prometheusURL:             prometheusURL,
-		redisMock:                 redisMock,
-		redisPort:                 redisPort,
+		bbbCmdScript:              args.BBBCmdScript,
+		bbbConfigScript:           args.BBBConfigScript,
+		bbbSystemctlScript:        args.BBBSystemctlScript,
+		electrsRPCPort:            args.ElectrsRPCPort,
+		imageUpdateInfoURL:        args.ImageUpdateInfoURL,
+		middlewarePort:            args.MiddlewarePort,
+		middlewareVersion:         args.MiddlewareVersion,
+		network:                   args.Network,
+		notificationNamedPipePath: args.NotificationNamedPipePath,
+		prometheusURL:             args.PrometheusURL,
+		redisMock:                 args.RedisMock,
+		redisPort:                 args.RedisPort,
 	}
 	return config
 }

--- a/middleware/src/configuration/configuration_test.go
+++ b/middleware/src/configuration/configuration_test.go
@@ -26,9 +26,20 @@ func TestConfiguration(t *testing.T) {
 	)
 
 	config := configuration.NewConfiguration(
-		bbbCmdScript, bbbConfigScript, bbbSystemctlScript, electrsRPCPort,
-		imageUpdateInfoURL, middlewarePort, middlewareVersion, network,
-		notificationNamedPipePath, prometheusURL, redisMock, redisPort,
+		configuration.Args{
+			BBBCmdScript:              bbbCmdScript,
+			BBBConfigScript:           bbbConfigScript,
+			BBBSystemctlScript:        bbbSystemctlScript,
+			ElectrsRPCPort:            electrsRPCPort,
+			ImageUpdateInfoURL:        imageUpdateInfoURL,
+			MiddlewarePort:            middlewarePort,
+			MiddlewareVersion:         middlewareVersion,
+			Network:                   network,
+			NotificationNamedPipePath: notificationNamedPipePath,
+			PrometheusURL:             prometheusURL,
+			RedisMock:                 redisMock,
+			RedisPort:                 redisPort,
+		},
 	)
 
 	require.Equal(t, bbbCmdScript, config.GetBBBCmdScript())

--- a/middleware/src/handlers/handlers_test.go
+++ b/middleware/src/handlers/handlers_test.go
@@ -42,15 +42,25 @@ func setupTestMiddleware(t *testing.T) *middleware.Middleware {
 		network                   string = "testnet"
 		notificationNamedPipePath string = "/tmp/middleware-notification.pipe"
 		prometheusURL             string = "http://localhost:9090"
-		// Important: mock redis in the unit tests
-		redisMock bool   = true
-		redisPort string = "6379"
+		redisMock                 bool   = true // Important: mock redis in the unit tests
+		redisPort                 string = "6379"
 	)
 
 	config := configuration.NewConfiguration(
-		bbbCmdScript, bbbConfigScript, bbbSystemctlScript, electrsRPCPort,
-		imageUpdateInfoURL, middlewarePort, middlewareVersion, network,
-		notificationNamedPipePath, prometheusURL, redisMock, redisPort,
+		configuration.Args{
+			BBBCmdScript:              bbbCmdScript,
+			BBBConfigScript:           bbbConfigScript,
+			BBBSystemctlScript:        bbbSystemctlScript,
+			ElectrsRPCPort:            electrsRPCPort,
+			ImageUpdateInfoURL:        imageUpdateInfoURL,
+			MiddlewarePort:            middlewarePort,
+			MiddlewareVersion:         middlewareVersion,
+			Network:                   network,
+			NotificationNamedPipePath: notificationNamedPipePath,
+			PrometheusURL:             prometheusURL,
+			RedisMock:                 redisMock,
+			RedisPort:                 redisPort,
+		},
 	)
 
 	testMiddleware, err := middleware.NewMiddleware(config, nil)

--- a/middleware/src/middleware_test.go
+++ b/middleware/src/middleware_test.go
@@ -32,15 +32,25 @@ func setupTestMiddleware(t *testing.T) *middleware.Middleware {
 		network                   string = "testnet"
 		notificationNamedPipePath string = "/tmp/middleware-notification.pipe"
 		prometheusURL             string = "http://localhost:9090"
-		// Important: mock redis in the unit tests
-		redisMock bool   = true
-		redisPort string = "6379"
+		redisMock                 bool   = true // Important: mock redis in the unit tests
+		redisPort                 string = "6379"
 	)
 
 	config := configuration.NewConfiguration(
-		bbbCmdScript, bbbConfigScript, bbbSystemctlScript, electrsRPCPort,
-		imageUpdateInfoURL, middlewarePort, middlewareVersion, network,
-		notificationNamedPipePath, prometheusURL, redisMock, redisPort,
+		configuration.Args{
+			BBBCmdScript:              bbbCmdScript,
+			BBBConfigScript:           bbbConfigScript,
+			BBBSystemctlScript:        bbbSystemctlScript,
+			ElectrsRPCPort:            electrsRPCPort,
+			ImageUpdateInfoURL:        imageUpdateInfoURL,
+			MiddlewarePort:            middlewarePort,
+			MiddlewareVersion:         middlewareVersion,
+			Network:                   network,
+			NotificationNamedPipePath: notificationNamedPipePath,
+			PrometheusURL:             prometheusURL,
+			RedisMock:                 redisMock,
+			RedisPort:                 redisPort,
+		},
 	)
 
 	testMiddleware, err := middleware.NewMiddleware(config, nil)


### PR DESCRIPTION
This PR consists of two commits. 

The first fixes two switched parameters to the `NewConfiguration()` factory function. A Middleware without the fix the tires to HTTP GET update information from the `middlewarePort` (8845) and delivered the `imageUpdateInfoURL` as Middleware port to the App. This resulted in the App not getting notified about new updates. The bug was introduced in #285.

The second commit makes the `NewConfiguration()`function more developer friendly by requiring a struct with named fields as argument rather than just a sequence of (unnamed) parameters. For this an extra `Args` struct with public fields is used, which can be filled from the `main` package. The fields of the `Configuration` struct remain private and only accessible via Getters, because they should not be changeable while the Middleware is running.

