### PR TITLE
hsm-config: set hsm config on middleware start and SetHostname

### DIFF
--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -200,6 +200,11 @@ func (middleware *Middleware) Start() <-chan handlers.Event {
 
 	go middleware.rpcLoop()
 
+	err := middleware.setHSMConfig()
+	if err != nil {
+		log.Printf("Error: could not set the HSM config: %s", err)
+	}
+
 	// before the updateCheckLoop is started the Middleware needes the Base version
 	baseVersion, err := middleware.redisClient.GetString(redis.BaseVersion)
 	if err != nil {
@@ -598,6 +603,10 @@ func (middleware *Middleware) SetHostname(args rpcmessages.SetHostnameArgs) rpcm
 				Message: strings.Join(out, "\n"),
 				Code:    errorCode,
 			}
+		}
+		err = middleware.setHSMConfig()
+		if err != nil {
+			log.Printf("Error: could not set the HSM config: %s", err)
 		}
 		return rpcmessages.ErrorResponse{Success: true}
 	}


### PR DESCRIPTION
This commit:
Adds the `setHSMConfig()` function to call the HSM API's
`BitBoxBaseSetConfig()` on middleware startup and when the Base hostname
is changed using an RPC.
The IP and hostname are fetched from redis and prometheus respectively
whenever `setHSMConfig` is called.
For `statusLedMode` and `statusScreenMode` we currently use the default
`LED_ALWAYS `and `SCREEN_ALWAYS` until we have redis config for those values.