### PR TITLE
HSM: add firmware to Base image

### DIFF
--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -37,6 +37,8 @@ LIGHTNING_VERSION="0.7.3"
 ELECTRS_VERSION="0.7.0"
 BIN_DEPS_TAG='0.0.5'
 
+HSM_VERSION='4.3.0'
+
 PROMETHEUS_VERSION="2.11.1"
 PROMETHEUS_CHKSUM="33b4763032e7934870721ca3155a8ae0be6ed590af5e91bf4d2d4133a79e4548"
 NODE_EXPORTER_VERSION="0.18.1"
@@ -475,6 +477,12 @@ ln -sf /opt/shift/scripts/bbb-cmd.sh       /usr/local/sbin/bbb-cmd.sh
 ln -sf /opt/shift/scripts/bbb-systemctl.sh /usr/local/sbin/bbb-systemctl.sh
 
 
+# HSM FIRMWARE -----------------------------------------------------------------
+mkdir -p /opt/shift/hsm
+curl --retry 5 -SLo "/opt/shift/hsm/firmware-bitboxbase.signed.bin" \
+  "https://github.com/digitalbitbox/bitbox02-firmware/releases/download/firmware-bitboxbase%2Fv${HSM_VERSION}/firmware-bitboxbase.v${HSM_VERSION}.signed.bin"
+
+
 # TOR --------------------------------------------------------------------------
 curl --retry 5 https://deb.torproject.org/torproject.org/A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89.asc | gpg --import
 gpg --export A3C4F0F979CAA22CDBA8F512EE8CBC9E886DDD89 | apt-key add -
@@ -488,7 +496,6 @@ generateConfig "torrc.template" # --> /etc/tor/torrc
 
 ## allow user 'bitcoin' to access Tor proxy socket
 usermod -a -G debian-tor bitcoin
-
 
 
 # BITCOIN ----------------------------------------------------------------------


### PR DESCRIPTION
fixes https://github.com/shiftdevices/bitbox-base-internal/issues/369

Currently, we update the HSM firmware together with the Base image. For the Middleware to update the HSM, the specific version of the HSM firmware needs to be included in the disk image.

This issue extends the build script to provide a specific release version in the disk image. The version is specified like `HSM_VERSION='4.3.0'`, that is then used to create the valid download URI like this:
```
https://github.com/digitalbitbox/bitbox02-firmware/releases/download/firmware-bitboxbase%2Fv4.3.0/firmware-bitboxbase.v4.3.0.signed.bin
```

It is important, that the `tag` of the release always follows this syntax: `firmware-bitboxbase/v4.3.0`
and the file is named like `firmware-bitboxbase.v4.3.0.signed.bin`.

The release binary file is then stored in the disk image:
```
/opt/shift/hsm/firmware-bitboxbase.signed.bin
```

The version is deliberately omited in the filename, as the Middleware reads the internal version number (of the monotonic counter) directly out of the file, and compares it with the currently installed firmware on the HSM.