### PR TITLE
build: switch to build production image

### DIFF
--- a/armbian/base/build.conf
+++ b/armbian/base/build.conf
@@ -1,11 +1,24 @@
 # Configure Armbian image building process
-# --------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # uncomment lines for options you want to change
 # options are set to default
-# --------------------------------------------------------------
+# ------------------------------------------------------------------------------
 # Copy this file to `build-local.conf` for local configuration.
 # It is added in .gitignore, so it will not be committed.
-# --------------------------------------------------------------
+# ------------------------------------------------------------------------------
+
+
+# --- PRODUCTION MODE ---------------------------------------------------------
+# Build production image: <true|false>
+#
+# Set to "true" by default, applies production-safe default values.
+# To change and apply any options below, it must be set to "false".
+
+#BASE_PRODUCTION_IMAGE="true"
+
+
+# --- DEVELOPMENT OPTIONS ------------------------------------------------------
+# These options are only applied if BASE_PRODUCTION_IMAGE is set to "false"
 
 # Hostname
 #BASE_HOSTNAME="bitbox-base"
@@ -21,34 +34,29 @@
 #BASE_ENABLE_BITCOIN_SERVICES="false"
 
 # Include SSH keys for secure remote login: <true|false>
-# Add your keys to file `./config/authorized_keys` (excluded from Git versioning)
+# Add keys to file `./config/authorized_keys` (excluded from Git versioning)
 # additional information: <https://www.atlassian.com/git/tutorials/git-ssh>
 #BASE_ADD_SSH_KEYS="false"
 
 # Manual root password, 8 characters min, with numbers
-# WARNING: very unsafe, for DEVELOPMENT ONLY!
 #BASE_LOGINPW="your-development-password"
 
 # Enable password login for SSH: <true|false>
-# WARNING: for DEVELOPMENT ONLY!
 #BASE_SSH_PASSWORD_LOGIN="false"
 
-# Wifi settings (optional)
-#BASE_WIFI_SSID=""
-#BASE_WIFI_PW=""
-
-# Build with HDMI dashboard capability (installs x-server & chromium browser, experimental)
+# Build with HDMI dashboard capability
+# (installs x-server & chromium browser, experimental)
 #BASE_HDMI_BUILD="false"
 
 # Enable HDMI dashboard (needs BASE_HDMI_BUILD="true")
 #BASE_DASHBOARD_HDMI_ENABLED="false"
 
-# Enable web dashboard output
-#BASE_DASHBOARD_WEB_ENABLED="false"
+# Enable web dashboard output (will be disabled after Beta testing)
+#BASE_DASHBOARD_WEB_ENABLED="true"
 
 # Remove unnecessary packages (takes a while, but reduces image size by 50%)
 #BASE_MINIMAL="true"
 
 # Make root filesystem read-only and overlay it with a temporary filesystem.
-# All changes are lost on reboot, guaranteeing a safe state (experimental)
-#BASE_OVERLAYROOT="false"
+# All changes are lost on reboot, guaranteeing a safe state.
+#BASE_OVERLAYROOT="true"

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -26,6 +26,8 @@
 # Grafana, NGINX and an mDNS responder to broadcast to the local subnet.
 # ------------------------------------------------------------------------------
 
+# shellcheck disable=SC1091
+
 set -e
 
 # ------------------------------------------------------------------------------
@@ -50,6 +52,10 @@ echoArguments() {
 ================================================================================
 ==> $1
 ================================================================================
+
+PRODUCTION IMAGE:       ${BASE_PRODUCTION_IMAGE}
+
+================================================================================
 VERSIONS:
     BASE IMAGE          ${BASE_VERSION}
     BINARY DEPS         ${BIN_DEPS_TAG}
@@ -64,10 +70,8 @@ CONFIGURATION:
     USER / PASSWORD:    base / ${BASE_LOGINPW}
     HOSTNAME:           ${BASE_HOSTNAME}
     BITCOIN NETWORK:    ${BASE_BITCOIN_NETWORK}
-    WIFI SSID / PWD:    ${BASE_WIFI_SSID} ${BASE_WIFI_PW}
     WEB DASHBOARD:      ${BASE_DASHBOARD_WEB_ENABLED}
     HDMI DASHBOARD:     ${BASE_DASHBOARD_HDMI_ENABLED}
-    SSH ROOT LOGIN:     ${BASE_SSH_ROOT_LOGIN}
     SSH PASSWORD LOGIN: ${BASE_SSH_PASSWORD_LOGIN}
     AUTOSETUP SSD:      ${BASE_AUTOSETUP_SSD}
     BITCOIN SERVICES ENABLED:
@@ -80,6 +84,7 @@ BUILD OPTIONS:
     MINIMAL IMAGE:      ${BASE_MINIMAL}
     OVERLAYROOT:        ${BASE_OVERLAYROOT}
     HDMI OUTPUT:        ${BASE_HDMI_BUILD}
+
 ================================================================================
 "
 }
@@ -140,39 +145,45 @@ generateConfig() {
 
 # get Linux distribution and version
 # (works explicitly only on Armbian Debian Stretch, Buster and Ubuntu Bionic)
-cat /etc/os-release
-# shellcheck disable=SC1091
 source /etc/os-release
 BASE_DISTRIBUTION=${VERSION_CODENAME}
+BASE_DISTRIBUTION=${BASE_DISTRIBUTION:-"bionic"}
 
-# Load build configuration, set defaults
-# shellcheck disable=SC1091
-source /opt/shift/build.conf || true
-# shellcheck disable=SC1091
-source /opt/shift/build-local.conf || true
 BASE_VERSION=$(head -n1 /opt/shift/config/version)
 BASE_BUILDMODE=${1:-"armbian-build"}
-BASE_DISTRIBUTION=${BASE_DISTRIBUTION:-"bionic"}
-BASE_MINIMAL=${BASE_MINIMAL:-"true"}
-BASE_HOSTNAME=${BASE_HOSTNAME:-"bitbox-base"}
-BASE_BITCOIN_NETWORK=${BASE_BITCOIN_NETWORK:-"mainnet"}
-BASE_AUTOSETUP_SSD=${BASE_AUTOSETUP_SSD:-"true"}
-BASE_ENABLE_BITCOIN_SERVICES=${BASE_ENABLE_BITCOIN_SERVICES:-"false"}
-BASE_WIFI_SSID=${BASE_WIFI_SSID:-""}
-BASE_WIFI_PW=${BASE_WIFI_PW:-""}
-BASE_ADD_SSH_KEYS=${BASE_ADD_SSH_KEYS:-"false"}
-BASE_SSH_ROOT_LOGIN=${BASE_SSH_ROOT_LOGIN:-"false"}
-BASE_SSH_PASSWORD_LOGIN=${BASE_SSH_PASSWORD_LOGIN:-"false"}
-BASE_DASHBOARD_WEB_ENABLED=${BASE_DASHBOARD_WEB_ENABLED:-"false"}
-BASE_HDMI_BUILD=${BASE_HDMI_BUILD:-"false"}
-BASE_OVERLAYROOT=${BASE_OVERLAYROOT:-"false"}
+
+# Source configuration to read BASE_PRODUCTION_IMAGE
+BASE_PRODUCTION_IMAGE="true"
+source /opt/shift/build.conf || true
+source /opt/shift/build-local.conf || true
+
+# Set build option defaults
+BASE_HOSTNAME="bitbox-base"
+BASE_BITCOIN_NETWORK="mainnet"
+BASE_AUTOSETUP_SSD="true"
+BASE_ENABLE_BITCOIN_SERVICES="false"
+BASE_WIFI_SSID=""
+BASE_WIFI_PW=""
+BASE_ADD_SSH_KEYS="false"
+BASE_LOGINPW=""
+BASE_SSH_PASSWORD_LOGIN="false"
+BASE_DASHBOARD_WEB_ENABLED="true"   # TODO(Stadicus): set "false" by default after beta testing
+BASE_DASHBOARD_HDMI_ENABLED="false"
+BASE_HDMI_BUILD="false"
+BASE_MINIMAL="true"
+BASE_OVERLAYROOT="true"
+
+# Overwrite defaults if BASE_PRODUCTION_IMAGE set to "false"
+if [[ ${BASE_PRODUCTION_IMAGE} == "false" ]]; then
+  source /opt/shift/build.conf || true
+  source /opt/shift/build-local.conf || true
+fi
 
 # HDMI dashboard only enabled if image is built to support it
-if [[ "${BASE_HDMI_BUILD}" != "true" ]]; then
+if [[ "${BASE_DASHBOARD_HDMI_ENABLED}" == "true" ]] && [[ "${BASE_HDMI_BUILD}" != "true" ]]; then
   echo "WARN: HDMI dashboard is disabled. It cannot be enabled without BASE_HDMI_BUILD option set to 'true'."
   BASE_DASHBOARD_HDMI_ENABLED="false"
 fi
-BASE_DASHBOARD_HDMI_ENABLED=${BASE_DASHBOARD_HDMI_ENABLED:-"false"}
 
 if [[ ${UID} -ne 0 ]]; then
   echo "${0}: needs to be run as superuser." >&2


### PR DESCRIPTION
addresses https://github.com/digitalbitbox/bitbox-base/issues/291

The various build options make it difficult to spot if in total everyting is set correctly to build a production image. By adding the binary option `BASE_PRODUCTION_IMAGE` to build a PRODUCTION or DEV image, and setting all options to safe production defaults, configuration errors can be minimized.

This commit:
* adds the build option `BASE_PRODUCTION_IMAGE`
* sets all defaults to production values that can only be overwritten
  if `BASE_PRODUCTION_IMAGE=='false'`