### PR TITLE
Middleware: remove warning on RPC server Serve()

### DIFF
--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -176,7 +176,9 @@ func (handlers *Handlers) wsHandler(w http.ResponseWriter, r *http.Request) {
 	handlers.nClients++
 	handlers.mu.Unlock()
 
-	go server.Serve()
+	go func() {
+		_ = server.Serve(true /* dummy arg 1 */, nil /* dummy pointer */)
+	}()
 
 	handlers.mu.Lock()
 	for _, event := range handlers.eventQueue {

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -106,9 +106,15 @@ func NewRPCServer(middleware Middleware) *RPCServer {
 	return server
 }
 
-// Serve starts a gob rpc server
-func (server *RPCServer) Serve() {
+// Serve starts a GOB RPC Server
+//
+// Note: the `rpc` package requires a schematically like
+//  func (t *T) MethodName(argType T1, replyType *T2) error
+// or prints a confusing warning. The arguments and the returned error are only
+// dummies.
+func (server *RPCServer) Serve(dummyArg bool, dummyPointer *bool) error {
 	rpc.ServeConn(server.RPCConnection)
+	return nil
 }
 
 func (server *RPCServer) formulateJWTError(name string) rpcmessages.ErrorResponse {

--- a/middleware/src/rpcserver/rpcserver_test.go
+++ b/middleware/src/rpcserver/rpcserver_test.go
@@ -69,7 +69,9 @@ func NewTestingRPCServer() TestingRPCServer {
 	testingRPCServer.serverWriteChan = testingRPCServer.rpcServer.RPCConnection.WriteChan()
 	testingRPCServer.serverReadChan = testingRPCServer.rpcServer.RPCConnection.ReadChan()
 
-	go testingRPCServer.rpcServer.Serve()
+	go func() {
+		_ = testingRPCServer.rpcServer.Serve(true /* dummy arg 1 */, nil /* dummy pointer */)
+	}()
 
 	testingRPCServer.client = rpc.NewClient(&rpcConn{readChan: testingRPCServer.clientReadChan, writeChan: testingRPCServer.clientWriteChan})
 


### PR DESCRIPTION
The Golang [rpc package] requires a special schematic for methods. Otherwise the package prints a warning which has been confused with an error in the past (https://github.com/shiftdevices/bitbox-base-internal/issues/354). The warning was logged when the BitBoxApp connected to the Middleware.

```console
rpc.Register: method "Serve" has 1 input parameters; needs exactly three
```

This adds dummy parameters to the Serve() method to remove the warning.

[rpc package]: https://golang.org/pkg/net/rpc/


fixes https://github.com/shiftdevices/bitbox-base-internal/issues/356