### PR TITLE
Middleware: cleanup RPCServer log messages for RPC replies

### DIFF
--- a/middleware/src/middleware.go
+++ b/middleware/src/middleware.go
@@ -1130,7 +1130,6 @@ func (middleware *Middleware) GetBaseInfo() rpcmessages.GetBaseInfoResponse {
 
 // GetServiceInfo returns the most recent information about services running on the Base such as for example bitcoind, electrs or lightningd.
 func (middleware *Middleware) GetServiceInfo() rpcmessages.GetServiceInfoResponse {
-	log.Println("Returning the lastest Service info", middleware.serviceInfo)
 	return middleware.serviceInfo
 }
 

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -179,7 +179,7 @@ type ErrorResponse struct {
 //		Message: <message>
 func (err *ErrorResponse) Error() string {
 	if err.Success {
-		return fmt.Sprintf("ErrorResponse: Success: %t \n", err.Success)
+		return fmt.Sprintf("ErrorResponse:{Success: %t}", err.Success)
 	}
-	return fmt.Sprintf("ErrorResponse:\n\tSuccess: %t \n\tCode: %s \n\tMessage: %s\n", err.Success, err.Code, err.Message)
+	return fmt.Sprintf("ErrorResponse:{\n\tSuccess: %t \n\tCode: %s \n\tMessage: %s\n}", err.Success, err.Code, err.Message)
 }

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -123,7 +123,7 @@ func (server *RPCServer) formulateJWTError(name string) rpcmessages.ErrorRespons
 // GetSetupStatus send the middleware's setup status as a SetupStatusResponse over rpc.
 func (server *RPCServer) GetSetupStatus(dummyArg bool, reply *rpcmessages.SetupStatusResponse) error {
 	*reply = server.middleware.SetupStatus()
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "GetSetupStatus", reply)
 	return nil
 }
 
@@ -139,7 +139,7 @@ func (server *RPCServer) GetSystemEnv(args rpcmessages.AuthGenericRequest, reply
 	}
 
 	*reply = server.middleware.SystemEnv()
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "GetSystemEnv", reply)
 	return nil
 }
 
@@ -152,7 +152,7 @@ func (server *RPCServer) ReindexBitcoin(args rpcmessages.AuthGenericRequest, rep
 	}
 
 	*reply = server.middleware.ReindexBitcoin()
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "ReindexBitcoin", reply)
 	return nil
 }
 
@@ -165,7 +165,7 @@ func (server *RPCServer) ResyncBitcoin(args rpcmessages.AuthGenericRequest, repl
 	}
 
 	*reply = server.middleware.ResyncBitcoin()
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "ResyncBitcoin", reply)
 	return nil
 }
 
@@ -178,7 +178,7 @@ func (server *RPCServer) BackupSysconfig(args rpcmessages.AuthGenericRequest, re
 	}
 
 	*reply = server.middleware.BackupSysconfig()
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "BackupSysconfig", reply)
 	return nil
 }
 
@@ -191,7 +191,7 @@ func (server *RPCServer) BackupHSMSecret(args rpcmessages.AuthGenericRequest, re
 	}
 
 	*reply = server.middleware.BackupHSMSecret()
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "BackupHSMSecret", reply)
 	return nil
 }
 
@@ -204,7 +204,7 @@ func (server *RPCServer) RestoreSysconfig(args rpcmessages.AuthGenericRequest, r
 	}
 
 	*reply = server.middleware.RestoreSysconfig()
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "RestoreSysconfig", reply)
 	return nil
 }
 
@@ -217,7 +217,7 @@ func (server *RPCServer) RestoreHSMSecret(args rpcmessages.AuthGenericRequest, r
 	}
 
 	*reply = server.middleware.RestoreHSMSecret()
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "RestoreHSMSecret", reply)
 	return nil
 }
 
@@ -225,7 +225,7 @@ func (server *RPCServer) RestoreHSMSecret(args rpcmessages.AuthGenericRequest, r
 // Args given specify the username and the password
 func (server *RPCServer) UserAuthenticate(args *rpcmessages.UserAuthenticateArgs, reply *rpcmessages.UserAuthenticateResponse) error {
 	*reply = server.middleware.UserAuthenticate(*args)
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "UserAuthenticate", reply)
 	return nil
 }
 
@@ -239,7 +239,7 @@ func (server *RPCServer) UserChangePassword(args *rpcmessages.UserChangePassword
 	}
 
 	*reply = server.middleware.UserChangePassword(*args)
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "UserChangePassword", reply)
 	return nil
 }
 
@@ -253,7 +253,7 @@ func (server *RPCServer) SetHostname(args *rpcmessages.SetHostnameArgs, reply *r
 	}
 
 	*reply = server.middleware.SetHostname(*args)
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "SetHostname", reply)
 	return nil
 }
 
@@ -268,7 +268,7 @@ func (server *RPCServer) EnableTor(args rpcmessages.ToggleSettingArgs, reply *rp
 	}
 
 	*reply = server.middleware.EnableTor(args)
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "EnableTor", reply)
 	return nil
 }
 
@@ -283,7 +283,7 @@ func (server *RPCServer) EnableTorMiddleware(args rpcmessages.ToggleSettingArgs,
 	}
 
 	*reply = server.middleware.EnableTorMiddleware(args)
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "EnableTorMiddleware", reply)
 	return nil
 }
 
@@ -298,7 +298,7 @@ func (server *RPCServer) EnableTorElectrs(args rpcmessages.ToggleSettingArgs, re
 	}
 
 	*reply = server.middleware.EnableTorElectrs(args)
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "EnableTorElectrs", reply)
 	return nil
 }
 
@@ -313,7 +313,7 @@ func (server *RPCServer) EnableTorSSH(args rpcmessages.ToggleSettingArgs, reply 
 	}
 
 	*reply = server.middleware.EnableTorSSH(args)
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "EnableTorSSH", reply)
 	return nil
 }
 
@@ -328,7 +328,7 @@ func (server *RPCServer) EnableClearnetIBD(args rpcmessages.ToggleSettingArgs, r
 	}
 
 	*reply = server.middleware.EnableClearnetIBD(args)
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "EnableClearnetIBD", reply)
 	return nil
 }
 
@@ -342,7 +342,7 @@ func (server *RPCServer) ShutdownBase(args rpcmessages.AuthGenericRequest, reply
 	}
 
 	*reply = server.middleware.ShutdownBase()
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "ShutdownBase", reply)
 	return nil
 }
 
@@ -356,7 +356,7 @@ func (server *RPCServer) RebootBase(args rpcmessages.AuthGenericRequest, reply *
 	}
 
 	*reply = server.middleware.RebootBase()
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "RebootBase", reply)
 	return nil
 }
 
@@ -371,7 +371,7 @@ func (server *RPCServer) EnableRootLogin(args rpcmessages.ToggleSettingArgs, rep
 	}
 
 	*reply = server.middleware.EnableRootLogin(args)
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "EnableRootLogin", reply)
 	return nil
 }
 
@@ -386,7 +386,7 @@ func (server *RPCServer) EnableSSHPasswordLogin(args rpcmessages.ToggleSettingAr
 	}
 
 	*reply = server.middleware.EnableSSHPasswordLogin(args)
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "EnableSSHPasswordLogin", reply)
 	return nil
 }
 
@@ -402,7 +402,7 @@ func (server *RPCServer) SetLoginPassword(args rpcmessages.SetLoginPasswordArgs,
 	}
 
 	*reply = server.middleware.SetLoginPassword(args)
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "SetLoginPassword", reply)
 	return nil
 }
 
@@ -417,7 +417,7 @@ func (server *RPCServer) GetBaseInfo(args rpcmessages.AuthGenericRequest, reply 
 	}
 
 	*reply = server.middleware.GetBaseInfo()
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "GetBaseInfo", reply)
 	return nil
 }
 
@@ -432,7 +432,7 @@ func (server *RPCServer) GetServiceInfo(args rpcmessages.AuthGenericRequest, rep
 	}
 
 	*reply = server.middleware.GetServiceInfo()
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "GetServiceInfo", reply)
 	return nil
 }
 
@@ -446,7 +446,7 @@ func (server *RPCServer) UpdateBase(args rpcmessages.UpdateBaseArgs, reply *rpcm
 	}
 
 	*reply = server.middleware.UpdateBase(args)
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "UpdateBase", reply)
 	return nil
 }
 
@@ -460,7 +460,7 @@ func (server *RPCServer) GetBaseUpdateProgress(args rpcmessages.AuthGenericReque
 	}
 
 	*reply = server.middleware.GetBaseUpdateProgress()
-	log.Printf("sent reply %v: ", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "GetBaseUpdateProgress", reply)
 	return nil
 }
 
@@ -474,7 +474,7 @@ func (server *RPCServer) IsBaseUpdateAvailable(args rpcmessages.AuthGenericReque
 	}
 
 	*reply = server.middleware.IsBaseUpdateAvailable()
-	log.Printf("IsBaseUpdateAvailable reply: %v\n", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "IsBaseUpdateAvailable", reply)
 	return nil
 }
 
@@ -488,7 +488,7 @@ func (server *RPCServer) FinalizeSetupWizard(args rpcmessages.AuthGenericRequest
 	}
 
 	*reply = server.middleware.FinalizeSetupWizard()
-	log.Printf("FinalizeSetupWizard reply: %v\n", reply)
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "FinalizeSetupWizard", reply)
 	return nil
 }
 

--- a/middleware/src/util.go
+++ b/middleware/src/util.go
@@ -196,7 +196,7 @@ func (middleware *Middleware) didServiceInfoChange() (changed bool) {
 	// reflect.DeepEqual() checks if the values at the pointer addresses are equal.
 	if !reflect.DeepEqual(upToDateServiceInfo, middleware.serviceInfo) {
 		middleware.serviceInfo = upToDateServiceInfo
-		log.Println("new serviceInfo", middleware.serviceInfo)
+		log.Printf("new serviceInfo is available: %+v", middleware.serviceInfo)
 		return true
 	}
 	return false


### PR DESCRIPTION
The RPCServer logged the same "sent reply" message for each RPC response. The output contained values, but no field labels for the values.

This adds the name of the RPC to the response log and prints the responses with field names. This should make the Middleware logs more accessible for debugging.

Example before:
```log
2019/12/06 17:51:04 sent reply &{ErrorResponse: Success: true\n 606941 606941 0.9999953681135885 9 false 606941 0 606942}:
```

Example after:
```log
2019/12/06 18:00:10 RPCServer sent reply for the "GetServiceInfo" RPC: &{ErrorResponse:ErrorResponse:{Success: true} BitcoindBlocks:606951 BitcoindHeaders:606951 BitcoindVerificationProgress:0.9999994641028246 BitcoindPeers:8 BitcoindIBD:false LightningdBlocks:606950 LightningActiveChannels:0 ElectrsBlocks:606951}
```

fixes https://github.com/shiftdevices/bitbox-base-internal/issues/338