### PR TITLE
update: reset 'sshpwlogin' on success

### DIFF
--- a/armbian/base/scripts/systemd-update-checks.sh
+++ b/armbian/base/scripts/systemd-update-checks.sh
@@ -135,6 +135,10 @@ else
         echo "OK: updated to BitBoxBase version $(redis_get 'base:version')"
         redis_set "base:updating" 0
 
+        # SSH login and system password are reset and need to be enabled via BitBoxApp again
+        redis_set "base:sshd:passwordlogin" 0
+        redis_set "base:sshd:rootlogin" no
+
         # send update notification to Middleware (best effort)
         timeout 5 echo '{"version": 1, "topic": "mender-update", "payload": {"success": true}}' >> /tmp/middleware-notification.pipe || true
     fi


### PR DESCRIPTION
fixes https://github.com/shiftdevices/bitbox-base-internal/issues/375

The user-set system password is not persisted on update. Even if SSH password login is enabled, the user is not able to log in without setting the password through the BitBoxApp again.

As this is a rather unsafe setting, it is not persisted on update. The goal is to use SSH keys, which can safely be persisted and don't need the `sshpwlogign` option to be enabled at all.

As of now, the Redis key `base:sshd:passwordlogin` is not set back to `0`, so the App still shows the setting as enabled, although it is not.

This commit:
* sets the Redis key `base:sshd:passwordlogin` back to `0` and `base:sshd:rootlogin` to `no` to reflect the real configuration.