### PR TITLE
Minor fixes

### DIFF
--- a/armbian/armbian-build.sh
+++ b/armbian/armbian-build.sh
@@ -66,6 +66,12 @@ case ${ACTION} in
 
 		if [[ ${IMG_COUNT} -eq 1 ]]; then
 			mv -v armbian-build/output/images/Armbian_*.img ../bin/img-armbian/BitBoxBase_Armbian_RockPro64.img
+
+			# set owner to regular user calling script with sudo (instead of root)
+			if [ "${SUDO_USER}" ]; then
+				chown "${SUDO_USER}" ../bin/img-armbian/BitBoxBase_Armbian_RockPro64.img
+			fi
+
 		else
 			echo "ERR: one image file expected in armbian-build/output/images/, ${IMG_COUNT} files found."
 			find armbian-build/output/images/Armbian_*.img

--- a/armbian/base/rootfs/etc/systemd/system/prometheus.service
+++ b/armbian/base/rootfs/etc/systemd/system/prometheus.service
@@ -11,7 +11,7 @@ ExecStart=/usr/local/bin/prometheus \
     --web.listen-address="127.0.0.1:9090" \
     --config.file /etc/prometheus/prometheus.yml \
     --storage.tsdb.path=/mnt/ssd/prometheus \
-    --storage.tsdb.retention.time=720d
+    --storage.tsdb.retention.time=720d \
     --web.console.templates=/etc/prometheus/consoles \
     --web.console.libraries=/etc/prometheus/console_libraries
 

--- a/armbian/base/scripts/systemd-lightningd-startpost.sh
+++ b/armbian/base/scripts/systemd-lightningd-startpost.sh
@@ -17,12 +17,12 @@ source /opt/shift/scripts/include/redis.sh.inc
 BITCOIN_NETWORK=$(redis_get "bitcoind:network")
 
 # wait for c-lightning to warm up
-sleep 10
+sleep 5
 
 # make available lightningd socket to group "bitcoin"
-if [[ "${BITCOIN_NETWORK}" == "mainnet" ]] && [ -f /mnt/ssd/bitcoin/.lightning/lightning-rpc ]; then
+if [[ "${BITCOIN_NETWORK}" == "mainnet" ]] && [ -S /mnt/ssd/bitcoin/.lightning/lightning-rpc ]; then
     chmod g+rwx /mnt/ssd/bitcoin/.lightning/lightning-rpc
-elif [ -f /mnt/ssd/bitcoin/.lightning-testnet/lightning-rpc ]; then
+elif [ -S /mnt/ssd/bitcoin/.lightning-testnet/lightning-rpc ]; then
     chmod g+rwx /mnt/ssd/bitcoin/.lightning-testnet/lightning-rpc
 else
     echo "Failed to set permissions to lightning-rpc socket."

--- a/armbian/mender-convert.sh
+++ b/armbian/mender-convert.sh
@@ -80,6 +80,11 @@ case ${ACTION} in
 		mv "${TARGET_NAME}"* "../../../bin/img-mender/${VERSION}/"
 		cd ..
 
+		# set owner to regular user calling script with sudo (instead of root)
+		if [ "${SUDO_USER}" ]; then
+			chown "${SUDO_USER}" "../../bin/img-mender/${VERSION}/"*
+		fi
+
 		echo "Mender files ready for provisioning:"
 		ls -lh "../../bin/img-mender/${VERSION}/${TARGET_NAME}"*
 		echo

--- a/docs/tinkering/ssh.md
+++ b/docs/tinkering/ssh.md
@@ -10,6 +10,8 @@ SSH access is disabled by default.
 Once enabled, you should always log in with the user `base` that has sudo privileges.
 The user password corresponds to the one set in the BitBoxApp setup wizard.
 
+### Enabling SSH
+
 There are multiple ways to gain access, some usable for production, others only suitable to be used for development:
 
 * **SSH keys**: if SSH keys are present in `/home/base/.ssh/authorized_keys`, SSH login is possible over regular IP address, the mDNS domain (e.g. `ssh base@bitbox-base.local`) or even a Tor hidden service (if enabled).
@@ -28,3 +30,24 @@ There are multiple ways to gain access, some usable for production, others only 
   On the BitBoxBase, logged in with user `base`, run `sudo bbb-config.sh enable rootlogin`.
 
 If you build the BitBoxBase image yourself, you can configure the options `BASE_LOGINPW` (initial login password, overwritten by the Setup Wizard) and `BASE_SSH_PASSWORD_LOGIN` in [build.conf](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/build.conf).
+
+### Working on the command line
+
+If logging in as user `base`, you might find the following `alias` helpful that are defined in `.bashrc-custom` and maintained as a [template](https://github.com/digitalbitbox/bitbox-base/blob/master/armbian/base/config/templates/bashrc-custom.template):
+
+#### Bitcoin Core
+
+* `bcli`: shortcut for `bitcoin-cli` with the necessary credentials and arguments
+* `blog`: follow the Bitcoin Core log output in the system journal
+
+#### c-lightning
+
+* `lcli`: shortcut for `lightning-cli` with the necessary credentials and arguments
+* `llog`: follow the c-lightning log output in the system journal
+
+#### Various logs
+
+* `j`: follow the system journal
+* `elog`: follow the Electrs log
+* `slog`: follow the Supervisor log
+* `mlog`: follow the Middleware log


### PR DESCRIPTION
This pull request adds some minor fixes:
* systemd: fix missing `\` in prometheus.service 
* lightingd-startpost: check of Socket, not file 
* build: set regular user calling `make` as disk image owner instead of root

See individual commits for additional information.