### PR TITLE
bbb-cmd: fix 'umount' typo instead of 'unmount'

### DIFF
--- a/armbian/base/scripts/bbb-cmd.sh
+++ b/armbian/base/scripts/bbb-cmd.sh
@@ -13,7 +13,7 @@ usage: bbb-cmd.sh [--version] [--help] <command>
 possible commands:
   setup         <datadir>
   bitcoind      <reindex|resync|refresh_rpcauth>
-  flashdrive    <check|mount|umount>
+  flashdrive    <check|mount|unmount>
   backup        <sysconfig|hsm_secret>
   restore       <sysconfig|hsm_secret>
   reset         <auth|config|image|ssd>

--- a/docs/customapps/bbb-cmd.md
+++ b/docs/customapps/bbb-cmd.md
@@ -16,7 +16,7 @@ usage: bbb-cmd.sh [--version] [--help] <command>
 possible commands:
   setup         <datadir>
   bitcoind      <reindex|resync|refresh_rpcauth>
-  flashdrive    <check|mount|umount>
+  flashdrive    <check|mount|unmount>
   backup        <sysconfig|hsm_secret>
   restore       <sysconfig|hsm_secret>
   mender-update <install|commit>

--- a/docs/os/configuration.md
+++ b/docs/os/configuration.md
@@ -51,7 +51,7 @@ usage: bbb-cmd.sh [--version] [--help] <command>
 possible commands:
   setup         <datadir>
   bitcoind      <reindex|resync|refresh_rpcauth>
-  flashdrive    <check|mount|umount>
+  flashdrive    <check|mount|unmount>
   backup        <sysconfig|hsm_secret>
   restore       <sysconfig|hsm_secret>
   reset         <auth|config|image|ssd>


### PR DESCRIPTION
The command `bbb-cmd.sh flashdrive unmount` is in some instances (e.g. help text and documentation) mistyped as `umount`.

This commit
* fixes all `umount` typos