### PR TITLE
fix: set a default for the SUDO_USER variable

### DIFF
--- a/armbian/armbian-build.sh
+++ b/armbian/armbian-build.sh
@@ -68,7 +68,7 @@ case ${ACTION} in
 			mv -v armbian-build/output/images/Armbian_*.img ../bin/img-armbian/BitBoxBase_Armbian_RockPro64.img
 
 			# set owner to regular user calling script with sudo (instead of root)
-			if [ "${SUDO_USER}" ]; then
+			if [ "${SUDO_USER:-}" ]; then
 				chown "${SUDO_USER}" ../bin/img-armbian/BitBoxBase_Armbian_RockPro64.img
 			fi
 

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -420,7 +420,8 @@ fi
 if [[ "$BASE_OVERLAYROOT" == "true" ]]; then
   # allow missing files if build-ondevice (e.g. not Armbian distro)
   if [[ -f /etc/default/armbian-ramlog ]] || [[ "${BASE_BUILDMODE}" != "ondevice" ]]; then
-    sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-ramlog
+    -f /etc/default/armbian-ramlog && \
+      sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-ramlog
     sed -i 's/log.hdd/log/g' /etc/logrotate.conf
     importFile /etc/logrotate.d/rsyslog
   fi
@@ -448,7 +449,8 @@ generateConfig mender.conf.template # -->  /etc/mender/mender.conf
 
 ## configure swap file (disable Armbian zram, configure custom swapfile on ssd)
 if [[ -f /etc/default/armbian-zram-config ]] || [[ "${BASE_BUILDMODE}" != "ondevice" ]]; then
-  sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-zram-config
+  -f /etc/default/armbian-zram-config && \
+    sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-zram-config
 fi
 sed -i '/vm.swappiness=/Ic\vm.swappiness=10' /etc/sysctl.conf
 

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -420,8 +420,7 @@ fi
 if [[ "$BASE_OVERLAYROOT" == "true" ]]; then
   # allow missing files if build-ondevice (e.g. not Armbian distro)
   if [[ -f /etc/default/armbian-ramlog ]] || [[ "${BASE_BUILDMODE}" != "ondevice" ]]; then
-    -f /etc/default/armbian-ramlog && \
-      sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-ramlog
+    sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-ramlog
     sed -i 's/log.hdd/log/g' /etc/logrotate.conf
     importFile /etc/logrotate.d/rsyslog
   fi
@@ -449,8 +448,7 @@ generateConfig mender.conf.template # -->  /etc/mender/mender.conf
 
 ## configure swap file (disable Armbian zram, configure custom swapfile on ssd)
 if [[ -f /etc/default/armbian-zram-config ]] || [[ "${BASE_BUILDMODE}" != "ondevice" ]]; then
-  -f /etc/default/armbian-zram-config && \
-    sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-zram-config
+  sed -i '/ENABLED=/Ic\ENABLED=false' /etc/default/armbian-zram-config
 fi
 sed -i '/vm.swappiness=/Ic\vm.swappiness=10' /etc/sysctl.conf
 

--- a/armbian/mender-convert.sh
+++ b/armbian/mender-convert.sh
@@ -81,7 +81,7 @@ case ${ACTION} in
 		cd ..
 
 		# set owner to regular user calling script with sudo (instead of root)
-		if [ "${SUDO_USER}" ]; then
+		if [ "${SUDO_USER:-}" ]; then
 			chown "${SUDO_USER}" "../../bin/img-mender/${VERSION}/"*
 		fi
 


### PR DESCRIPTION
If SUDO_USER is not set during a build, an error "unbound variable" is shown.