### PR TITLE
middleware: Add unauthenticated endpoint for service status

### DIFF
--- a/middleware/src/handlers/handlers.go
+++ b/middleware/src/handlers/handlers.go
@@ -34,6 +34,7 @@ type Middleware interface {
 	GetBaseInfo() rpcmessages.GetBaseInfoResponse
 	GetBaseUpdateProgress() rpcmessages.GetBaseUpdateProgressResponse
 	GetServiceInfo() rpcmessages.GetServiceInfoResponse
+	GetServiceStatus() rpcmessages.GetServiceStatusResponse
 	IsBaseUpdateAvailable() rpcmessages.IsBaseUpdateAvailableResponse
 	RebootBase() rpcmessages.ErrorResponse
 	ReindexBitcoin() rpcmessages.ErrorResponse

--- a/middleware/src/rpcmessages/rpcmessages.go
+++ b/middleware/src/rpcmessages/rpcmessages.go
@@ -130,13 +130,9 @@ type GetBaseUpdateProgressResponse struct {
 // GetBaseInfoResponse is the struct that gets sent by the RPC server during a GetBaseInfo RPC call
 type GetBaseInfoResponse struct {
 	ErrorResponse             *ErrorResponse
-	Status                    string `json:"status"`
-	Hostname                  string `json:"hostname"`
 	MiddlewareLocalIP         string `json:"middlewareLocalIP"`
 	MiddlewarePort            string `json:"middlewarePort"`
 	MiddlewareTorOnion        string `json:"middlewareTorOnion"`
-	IsTorEnabled              bool   `json:"isTorEnabled"`
-	IsBitcoindListening       bool   `json:"isBitcoindListening"`
 	IsSSHPasswordLoginEnabled bool   `json:"isSSHPasswordLoginEnabled"`
 	FreeDiskspace             int64  `json:"freeDiskspace"`  // in Byte
 	TotalDiskspace            int64  `json:"totalDiskspace"` // in Byte
@@ -157,6 +153,17 @@ type GetServiceInfoResponse struct {
 	LightningdBlocks             int64          `json:"lightningdBlocks"`
 	LightningActiveChannels      int64          `json:"lightningActiveChannels"`
 	ElectrsBlocks                int64          `json:"electrsBlocks"`
+}
+
+// GetServiceStatusResponse is the struct that gets sent by the RPC server during a GetServiceStatus RPC call
+type GetServiceStatusResponse struct {
+	ErrorResponse    *ErrorResponse `json:"errorResponse"`
+	Hostname         string         `json:"hostname"`
+	Status           string         `json:"status"`
+	IsTorEnabled     bool           `json:"isTorEnabled"`
+	BitcoindStatus   bool           `json:"isBitcoindListening"`
+	LightningdStatus bool           `json:"lightningdStatus"`
+	ElectrsStatus    bool           `json:"electrsStatus"`
 }
 
 // ErrorResponse is a generic RPC response indicating if a RPC call was successful or not.

--- a/middleware/src/rpcserver/mocks/Middleware.go
+++ b/middleware/src/rpcserver/mocks/Middleware.go
@@ -194,6 +194,20 @@ func (_m *Middleware) GetServiceInfo() rpcmessages.GetServiceInfoResponse {
 	return r0
 }
 
+// GetServiceStatus provides a mock function with given fields:
+func (_m *Middleware) GetServiceStatus() rpcmessages.GetServiceStatusResponse {
+	ret := _m.Called()
+
+	var r0 rpcmessages.GetServiceStatusResponse
+	if rf, ok := ret.Get(0).(func() rpcmessages.GetServiceStatusResponse); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(rpcmessages.GetServiceStatusResponse)
+	}
+
+	return r0
+}
+
 // IsBaseUpdateAvailable provides a mock function with given fields:
 func (_m *Middleware) IsBaseUpdateAvailable() rpcmessages.IsBaseUpdateAvailableResponse {
 	ret := _m.Called()

--- a/middleware/src/rpcserver/rpcserver.go
+++ b/middleware/src/rpcserver/rpcserver.go
@@ -66,6 +66,7 @@ type Middleware interface {
 	GetBaseInfo() rpcmessages.GetBaseInfoResponse
 	GetBaseUpdateProgress() rpcmessages.GetBaseUpdateProgressResponse
 	GetServiceInfo() rpcmessages.GetServiceInfoResponse
+	GetServiceStatus() rpcmessages.GetServiceStatusResponse
 	IsBaseUpdateAvailable() rpcmessages.IsBaseUpdateAvailableResponse
 	RebootBase() rpcmessages.ErrorResponse
 	ReindexBitcoin() rpcmessages.ErrorResponse
@@ -441,6 +442,14 @@ func (server *RPCServer) GetServiceInfo(args rpcmessages.AuthGenericRequest, rep
 
 	*reply = server.middleware.GetServiceInfo()
 	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "GetServiceInfo", reply)
+	return nil
+}
+
+// GetServiceStatus sends the middleware's GetServiceStatusResponse over rpc.
+// Warning: This endpoint is not authenticated.
+func (server *RPCServer) GetServiceStatus(dummyArg bool, reply *rpcmessages.GetServiceStatusResponse) error {
+	*reply = server.middleware.GetServiceStatus()
+	log.Printf("RPCServer sent reply for the %q RPC: %+v\n", "GetServiceStatus", reply)
 	return nil
 }
 

--- a/middleware/src/util.go
+++ b/middleware/src/util.go
@@ -108,6 +108,11 @@ func (middleware *Middleware) runBBBSystemctlScript(args []string) (outputLines 
 	return
 }
 
+func (middleware *Middleware) checkSystemdServiceStatus(serviceName string) (bool, error) {
+	active, err := runCommand("systemctl", []string{"is-active", serviceName})
+	return active[0] == "active", err
+}
+
 // runBBBCmdScript runs the bbb-cmd.sh script.
 // The script executes commands like for example mounting a USB drive, doing a backup and copying files.
 func (middleware *Middleware) runBBBCmdScript(args []string) (outputLines []string, err error) {


### PR DESCRIPTION
This pr addresses https://github.com/shiftdevices/bitbox-base-internal/issues/395 by adding a GetServiceStatus method to the rpc server as specified in the issue. It also adds a utility function to check whether the services are active in systemd.