### PR TITLE
Minor improvements

### DIFF
--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -284,9 +284,9 @@ fi
 # SOFTWARE PACKAGE MGMT --------------------------------------------------------
 ## update system, force non-interactive commands
 
-apt -y update
-apt -y -q -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold" upgrade
-apt -y --fix-broken install
+apt-get -y update
+apt-get -y -q -o "Dpkg::Options::=--force-confdef" -o "Dpkg::Options::=--force-confold" upgrade
+apt-get -y --fix-broken install
 
 ## remove unnecessary packages (only when building image, not ondevice)
 if [[ "${BASE_BUILDMODE}" != "ondevice" ]] && [[ "${BASE_MINIMAL}" == "true" ]]; then
@@ -302,30 +302,30 @@ if [[ "${BASE_BUILDMODE}" != "ondevice" ]] && [[ "${BASE_MINIMAL}" == "true" ]];
 
   for pkg in $pkgToRemove
   do
-    apt -y remove "$pkg" || true
+    apt-get -y remove "$pkg" || true
   done
 
-  apt -y --fix-broken install
+  apt-get -y --fix-broken install
 fi
 
 ## install required software packages
-apt install -y --no-install-recommends \
+apt-get install -y --no-install-recommends \
   git openssl network-manager net-tools fio libnss-mdns avahi-daemon avahi-utils fail2ban acl rsync smartmontools curl libfontconfig jq
-apt install -y --no-install-recommends ifmetric
-apt install -y iptables-persistent
+apt-get install -y --no-install-recommends ifmetric
+apt-get install -y iptables-persistent
 
 ## install python dependencies
-apt install -y python3-pip python3-setuptools
+apt-get install -y python3-pip python3-setuptools
 pip3 install wheel
 pip3 install prometheus_client
 pip3 install redis
 pip3 install pylightning
 
 # debug
-apt install -y --no-install-recommends tmux unzip bash-completion
+apt-get install -y --no-install-recommends tmux unzip bash-completion
 
 if [[ "${BASE_DISTRIBUTION}" == "bionic" ]]; then
-    apt install -y --no-install-recommends overlayroot
+    apt-get install -y --no-install-recommends overlayroot
 fi
 
 # binariy Go dependencies, if not already present
@@ -349,7 +349,7 @@ ln -sfn /data_source /data
 touch /data/.datadir_set_up
 
 ## install Redis
-apt install -y --no-install-recommends redis
+apt-get install -y --no-install-recommends redis
 mkdir -p /data/redis/
 chown -R redis:redis /data/redis/
 
@@ -507,8 +507,8 @@ if ! grep -q "deb.torproject.org" /etc/apt/sources.list; then
   echo "deb https://deb.torproject.org/torproject.org ${BASE_DISTRIBUTION} main" >> /etc/apt/sources.list
 fi
 
-apt update
-apt -y install tor --no-install-recommends
+apt-get update
+apt-get -y install tor --no-install-recommends
 generateConfig "torrc.template" # --> /etc/tor/torrc
 
 ## allow user 'bitcoin' to access Tor proxy socket
@@ -538,7 +538,7 @@ redis-cli SET bitcoind:version "${BITCOIN_VERSION}"
 
 
 # LIGHTNING --------------------------------------------------------------------
-apt install -y  libsodium-dev autoconf automake build-essential git libtool libgmp-dev \
+apt-get install -y  libsodium-dev autoconf automake build-essential git libtool libgmp-dev \
                 libsqlite3-dev python python3 python3-mako net-tools \
                 zlib1g-dev asciidoc-base gettext
 
@@ -665,7 +665,7 @@ systemctl enable grafana-server.service
 
 
 # NGINX ------------------------------------------------------------------------
-apt install -y nginx
+apt-get install -y nginx
 rm -f /etc/nginx/sites-enabled/default
 
 importFile "/etc/nginx/nginx.conf"
@@ -720,7 +720,7 @@ importFile "/etc/systemd/system/iptables-restore.service"
 
 if [[ "${BASE_BUILDMODE}" != "ondevice" ]]; then
   ## Remove build-only packages
-  apt -y remove git
+  apt-get -y remove git
 
   ## Delete unnecessary local files
   rm -rf /usr/share/doc/*
@@ -731,9 +731,9 @@ if [[ "${BASE_BUILDMODE}" != "ondevice" ]]; then
 fi
 
 ## Clean up
-apt install -f
-apt clean
-apt -y autoremove
+apt-get install -f
+apt-get clean
+apt-get -y autoremove
 rm -rf /usr/local/src/*
 
 ## Enable system services

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -322,7 +322,7 @@ pip3 install redis
 pip3 install pylightning
 
 # debug
-apt install -y --no-install-recommends tmux unzip
+apt install -y --no-install-recommends tmux unzip bash-completion
 
 if [[ "${BASE_DISTRIBUTION}" == "bionic" ]]; then
     apt install -y --no-install-recommends overlayroot

--- a/armbian/base/customize-armbian-rockpro64.sh
+++ b/armbian/base/customize-armbian-rockpro64.sh
@@ -302,7 +302,7 @@ if [[ "${BASE_BUILDMODE}" != "ondevice" ]] && [[ "${BASE_MINIMAL}" == "true" ]];
 
   for pkg in $pkgToRemove
   do
-    apt-get -y remove "$pkg" || true
+    apt-get -y purge "$pkg" || true
   done
 
   apt-get -y --fix-broken install
@@ -720,7 +720,7 @@ importFile "/etc/systemd/system/iptables-restore.service"
 
 if [[ "${BASE_BUILDMODE}" != "ondevice" ]]; then
   ## Remove build-only packages
-  apt-get -y remove git
+  apt-get -y purge git
 
   ## Delete unnecessary local files
   rm -rf /usr/share/doc/*

--- a/armbian/base/scripts/bbb-cmd.sh
+++ b/armbian/base/scripts/bbb-cmd.sh
@@ -102,7 +102,9 @@ case "${MODULE}" in
                             # if overlayroot enabled, create symlink to ssd within overlayroot-chroot,
                             # will only be ready after reboot
                             mkdir -p /mnt/ssd/data
-                            overlayroot-chroot /bin/bash -c "ln -sfn /mnt/ssd/data /"
+                            if ! overlayroot-chroot /bin/bash -c "ln -sfn /mnt/ssd/data /"; then
+                                echo "ERR: could not create data directory symlink in overlayrootfs"
+                            fi
 
                             # also create link in tmpfs until next reboot
                             ln -sfn /mnt/ssd/data /

--- a/armbian/base/scripts/bbb-config.sh
+++ b/armbian/base/scripts/bbb-config.sh
@@ -302,8 +302,11 @@ case "${COMMAND}" in
                     echo 'overlayroot="tmpfs:swap=1,recurse=0"' > /etc/overlayroot.local.conf
                     echo "Overlay root filesystem will be enabled on next boot."
                 else
-                    overlayroot-chroot /bin/bash -c "echo 'overlayroot=disabled' > /etc/overlayroot.local.conf"
-                    echo "Overlay root filesystem will be disabled on next boot."
+                    if ! overlayroot-chroot /bin/bash -c "echo 'overlayroot=disabled' > /etc/overlayroot.local.conf"; then
+                        echo "ERR: could not run command in overlayrootfs, is it already disabled?"
+                    else
+                        echo "Overlay root filesystem will be disabled on next boot."
+                    fi
                 fi
                 redis_set "base:overlayroot:enabled" "${ENABLE}"
                 ;;

--- a/armbian/base/scripts/include/exec_overlayroot.sh.inc
+++ b/armbian/base/scripts/include/exec_overlayroot.sh.inc
@@ -17,7 +17,9 @@ exec_overlayroot() {
 
     if [ "${OVERLAYROOT_ENABLED}" -eq 1 ]; then
         echo "executing in overlayroot-chroot: ${2}"
-        overlayroot-chroot /bin/bash -c "${2}"
+        if ! overlayroot-chroot /bin/bash -c "${2}"; then
+            echo "ERR: could not run command in overlayrootfs"
+        fi
     fi
 
     if [ "${OVERLAYROOT_ENABLED}" -ne 1 ] || [[ "${1}" == "all-layers" ]]; then

--- a/armbian/base/scripts/include/generateConfig.sh.inc
+++ b/armbian/base/scripts/include/generateConfig.sh.inc
@@ -24,7 +24,10 @@ generateConfig() {
         if [ "${OVERLAYROOT_ENABLED}" -eq 1 ]; then
             echo "generateConfig() from ${FILE}, read-only partition of overlayroot"
             /usr/local/sbin/bbbconfgen --template "${FILE}"
-            overlayroot-chroot /bin/bash -c "/usr/local/sbin/bbbconfgen --template '${FILE}'"
+            if ! overlayroot-chroot /bin/bash -c "/usr/local/sbin/bbbconfgen --template '${FILE}'"; then
+                echo "ERR: could not run command in overlayrootfs"
+            fi
+
         else
             echo "generateConfig() from ${FILE}"
             /usr/local/sbin/bbbconfgen --template "${FILE}"

--- a/docs/applications/nginx.md
+++ b/docs/applications/nginx.md
@@ -16,7 +16,7 @@ Together with the strict `iptables` firewall rules, all unknown communication pa
 NGINX is installed using the standard Armbian package and the configuration for the default web-server landing page is deleted.
 
 ```bash
-apt install -y nginx
+apt-get install -y nginx
 rm -f /etc/nginx/sites-enabled/default
 ```
 

--- a/docs/applications/redis.md
+++ b/docs/applications/redis.md
@@ -17,7 +17,7 @@ The default systemd unit is disabled in favor of a custom one optimized for this
 
 ```bash
 ## install Redis
-apt install -y --no-install-recommends redis
+apt-get install -y --no-install-recommends redis
 mkdir -p /data/redis/
 chown -R redis:redis /data/redis/
 


### PR DESCRIPTION
* add `bash-completion` package on build
* allow `overlayroot-chroot` commands to fail with error logging
* use `apt-get` instead of `apt` in scripts (https://github.com/shiftdevices/bitbox-base-internal/issues/405)
* use `apt-get purge` instead of `apt-get remove` to also remove config files (related to https://github.com/shiftdevices/bitbox-base-internal/issues/404)

See commits for additional details.