### PR TITLE
docs: drop custom domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This documentation is aimed at project members, contributors and intersted peopl
 
 ## Documentation
 
-Detailed documentation is available at <https://base.shiftcrypto.ch>.
+Detailed documentation is available at <https://digitalbitbox.github.io/bitbox-base>.
 
 ## Why run a Bitcoin node
 

--- a/bin/go/README.md
+++ b/bin/go/README.md
@@ -3,4 +3,4 @@
 This directory holds the compiled binaries for custom applications of the BitBoxBase project.
 See the main documentation for more information:
 
-* <https://base.shiftcrypto.ch/customapps>
+* <https://digitalbitbox.github.io/bitbox-base/customapps>

--- a/bin/img-armbian/README.md
+++ b/bin/img-armbian/README.md
@@ -3,4 +3,4 @@
 This directory holds the compiled Armbian disk images of the BitBoxBase project.
 See the main documentation for more information:
 
-* <https://base.shiftcrypto.ch/os>
+* <https://digitalbitbox.github.io/bitbox-base/os>

--- a/bin/img-mender/README.md
+++ b/bin/img-mender/README.md
@@ -3,4 +3,4 @@
 This directory holds the Mender-enabled disk images of the BitBoxBase project.
 See the main documentation for more information:
 
-* <https://base.shiftcrypto.ch/update>
+* <https://digitalbitbox.github.io/bitbox-base/update>

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,1 +1,0 @@
-base.shiftcrypto.ch

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,5 @@
 ### BitBoxBase documentation is available at
 
-https://base.shiftcrypto.ch
+https://digitalbitbox.github.io/bitbox-base
 
 This repository contains all sources and is used for issue tracking.

--- a/tools/bbbsupervisor/README.md
+++ b/tools/bbbsupervisor/README.md
@@ -9,7 +9,7 @@ The **BitBoxBase Supervisor** `bbbsupervisor` is custom-built to monitor applica
 
 The Base Supervisor combines many small monitoring tasks. Contrary to the Middleware, its task is not about relaying application communication but to keep the running system in an operational state without user interaction.
 
-See the full documentation at <https://base.shiftcrypto.ch> for handled events.
+See the full documentation at <https://digitalbitbox.github.io/bitbox-base> for handled events.
 
 ## Installation
 


### PR DESCRIPTION
This project is inactive and unmaintained at the moment.
security@shiftcrypto.ch sometimes receive "vulnerability repots"
against base.shiftcrypto.ch. However harmless those reports have been
so far, there may be real security issues with hosting an unmaintained
website on a shiftcrypto.ch subdomain.

The commit is the first step in migrating from base.shiftcrypto.ch to
digitalbitbox.github.io/bitbox-base. Once this is submitted, next steps
are:

1. Check https://github.com/digitalbitbox/bitbox-base/settings/pages
and ensure settings are correct.
2. Change DNS replacing base.shiftcrypto CNAME with something that
points to a Shift Crypto web frontend.
3. Make the web frontend redirect base.shiftcrypto.ch/... to
digitalbitbox.github.io/bitbox-base/...
4. Update all existing links on shiftcrypto.ch, shiftcrypto.ch/blog/
and shiftcrypto.shop with the new URLs.

This will very likely cause some interruptions, including a redirect
loop because digitalbitbox.github.io/bitbox-base redirects to
base.shiftcrypto with a 301 Moved Permanently which browsers are known
to cache aggressively. But these caches should eventually clear out.